### PR TITLE
Feature(136170) Facilitar visualização da listagem de Unidades Administrativas no Cadastro de Movimentação

### DIFF
--- a/dados_comuns/admin.py
+++ b/dados_comuns/admin.py
@@ -1,4 +1,26 @@
 from django.contrib import admin
+from dados_comuns.libs.unidade_administrativa import uas_do_usuario
 from dados_comuns.models import UnidadeAdministrativa
 
-admin.site.register(UnidadeAdministrativa)
+UNIDADE_ADMINISTRATIVA_ORIGEM_AUTOCOMPLETE = "unidade_administrativa_origem"
+
+@admin.register(UnidadeAdministrativa)
+class UnidadeAdministrativaAdmin(admin.ModelAdmin):
+    search_fields = [
+        "nome",
+        "sigla",
+        "descricao",
+        "codigo",
+    ]
+    def get_search_results(self, request, queryset, search_term):
+        """
+        Filtra o autocomplete para exibir apenas as UAs associadas ao usuário Operador.
+        """
+        queryset, use_distinct = super().get_search_results(request, queryset, search_term)
+
+        field_name = request.GET.get("field_name")
+        if field_name == UNIDADE_ADMINISTRATIVA_ORIGEM_AUTOCOMPLETE and request.user.is_operador_inventario:
+            uas_user = uas_do_usuario(request.user)
+            queryset = queryset.filter(id__in=uas_user.values_list("id", flat=True))
+
+        return queryset, use_distinct

--- a/dados_comuns/libs/unidade_administrativa.py
+++ b/dados_comuns/libs/unidade_administrativa.py
@@ -1,0 +1,7 @@
+from dados_comuns.models import UnidadeAdministrativa
+
+
+def uas_do_usuario(user):
+    if hasattr(user, "unidade_administrativa_id") and user.unidade_administrativa_id:
+        return UnidadeAdministrativa.objects.filter(id=user.unidade_administrativa_id)
+    return UnidadeAdministrativa.objects.none()

--- a/dados_comuns/models.py
+++ b/dados_comuns/models.py
@@ -17,6 +17,7 @@ class UnidadeAdministrativa(models.Model):
     class Meta:
         verbose_name = 'unidade administrativa'
         verbose_name_plural = 'unidades administrativas'
+        ordering = ['codigo', 'nome', 'sigla']
 
     def save(self, *args, **kwargs):
         self.updated_at = datetime.now()

--- a/usuario/models.py
+++ b/usuario/models.py
@@ -18,7 +18,7 @@ class Usuario(AbstractUser):
         ],
     )
     unidade_administrativa = models.ForeignKey(
-        UnidadeAdministrativa, on_delete=models.SET_NULL, null=True, blank=True
+        UnidadeAdministrativa, related_name="%(class)s_unidade_administrativa", on_delete=models.SET_NULL, null=True, blank=True
     )
 
     @property


### PR DESCRIPTION
implementa melhoria na visualização e filtragem das unidades administrativas no cadastro de movimentação

- adiciona filtro dinâmico no campo "Unidade Administrativa de Origem" conforme as UAs vinculadas ao usuário
- mantém a listagem completa para o campo de destino
- aplica seleção automática quando o usuário possui apenas uma unidade administrativa de origem
- garante ordenação das UAs por código para facilitar a busca

Referência azure:
136170