### PR TITLE
Feature(135368/135369) Ajustar listagem de Bens Patrimoniais para Gestor e Operador

### DIFF
--- a/bem_patrimonial/admins/bem_patrimonial.py
+++ b/bem_patrimonial/admins/bem_patrimonial.py
@@ -86,6 +86,11 @@ class BemPatrimonialAdmin(ImportExportModelAdmin):
         "criado_em",
     )
 
+    def get_list_display(self, request):
+        if request.user.is_operador_inventario:
+            return ("numero_patrimonial", "nome", "status")
+        return ("numero_patrimonial", "nome", "unidade_administrativa", "status")
+
     fields = (
         "status",
         "nome",

--- a/bem_patrimonial/admins/bem_patrimonial.py
+++ b/bem_patrimonial/admins/bem_patrimonial.py
@@ -62,11 +62,10 @@ class BemPatrimonialResource(resources.ModelResource):
 class BemPatrimonialAdmin(ImportExportModelAdmin):
     model = BemPatrimonial
     list_display = (
-        "id",
+        "numero_patrimonial",
+        "nome",
+        "unidade_administrativa",
         "status",
-        "descricao",
-        "criado_por",
-        "criado_em",
     )
     search_fields = (
         "nome",

--- a/bem_patrimonial/tests/tests_admin_list_display.py
+++ b/bem_patrimonial/tests/tests_admin_list_display.py
@@ -1,0 +1,35 @@
+from django.test import TestCase
+from django.contrib.admin.sites import AdminSite
+from bem_patrimonial.admins.bem_patrimonial import BemPatrimonialAdmin
+from bem_patrimonial.models import BemPatrimonial
+
+
+class BemPatrimonialAdminListDisplayTestCase(TestCase):
+
+    def setUp(self):
+        self.site = AdminSite()
+        self.admin = BemPatrimonialAdmin(BemPatrimonial, self.site)
+
+    def test_list_display_contains_required_fields(self):
+        expected_fields = (
+            "numero_patrimonial",
+            "nome",
+            "unidade_administrativa",
+            "status",
+        )
+        self.assertEqual(self.admin.list_display, expected_fields)
+
+    def test_list_display_does_not_contain_old_fields(self):
+        old_fields = ["id", "descricao", "criado_por", "criado_em"]
+        for field in old_fields:
+            self.assertNotIn(field, self.admin.list_display)
+
+    def test_list_display_fields_are_valid(self):
+        model_fields = [f.name for f in BemPatrimonial._meta.get_fields()]
+
+        for field in self.admin.list_display:
+            self.assertIn(
+                field,
+                model_fields,
+                f"O campo '{field}' não existe no modelo BemPatrimonial",
+            )

--- a/bem_patrimonial/tests/tests_admin_list_display.py
+++ b/bem_patrimonial/tests/tests_admin_list_display.py
@@ -1,7 +1,10 @@
-from django.test import TestCase
+from django.test import TestCase, RequestFactory
 from django.contrib.admin.sites import AdminSite
 from bem_patrimonial.admins.bem_patrimonial import BemPatrimonialAdmin
 from bem_patrimonial.models import BemPatrimonial
+from dados_comuns.models import UnidadeAdministrativa
+from usuario.models import Usuario
+from usuario.constants import GRUPO_GESTOR_PATRIMONIO, GRUPO_OPERADOR_INVENTARIO
 
 
 class BemPatrimonialAdminListDisplayTestCase(TestCase):
@@ -9,27 +12,119 @@ class BemPatrimonialAdminListDisplayTestCase(TestCase):
     def setUp(self):
         self.site = AdminSite()
         self.admin = BemPatrimonialAdmin(BemPatrimonial, self.site)
+        self.factory = RequestFactory()
 
-    def test_list_display_contains_required_fields(self):
+        self.unidade = UnidadeAdministrativa.objects.create(
+            codigo="UA001", nome="Unidade Teste", sigla="DRE"
+        )
+
+        self.gestor = Usuario.objects.create_user(
+            username="gestor",
+            email="gestor@teste.com",
+            password="senha123",
+            unidade_administrativa=self.unidade,
+        )
+        from django.contrib.auth.models import Group
+
+        grupo_gestor, _ = Group.objects.get_or_create(name=GRUPO_GESTOR_PATRIMONIO)
+        self.gestor.groups.add(grupo_gestor)
+
+        self.operador = Usuario.objects.create_user(
+            username="operador",
+            email="operador@teste.com",
+            password="senha123",
+            unidade_administrativa=self.unidade,
+        )
+        grupo_operador, _ = Group.objects.get_or_create(name=GRUPO_OPERADOR_INVENTARIO)
+        self.operador.groups.add(grupo_operador)
+
+    def test_list_display_gestor_contains_required_fields(self):
+        request = self.factory.get("/admin/bem_patrimonial/bempatrimonial/")
+        request.user = self.gestor
+
         expected_fields = (
             "numero_patrimonial",
             "nome",
             "unidade_administrativa",
             "status",
         )
-        self.assertEqual(self.admin.list_display, expected_fields)
+        actual_fields = self.admin.get_list_display(request)
+        self.assertEqual(actual_fields, expected_fields)
+
+    def test_list_display_operador_contains_required_fields(self):
+        request = self.factory.get("/admin/bem_patrimonial/bempatrimonial/")
+        request.user = self.operador
+
+        expected_fields = ("numero_patrimonial", "nome", "status")
+        actual_fields = self.admin.get_list_display(request)
+        self.assertEqual(actual_fields, expected_fields)
+
+    def test_list_display_operador_does_not_show_unidade_administrativa(self):
+        request = self.factory.get("/admin/bem_patrimonial/bempatrimonial/")
+        request.user = self.operador
+
+        actual_fields = self.admin.get_list_display(request)
+        self.assertNotIn("unidade_administrativa", actual_fields)
+
+    def test_list_display_gestor_shows_unidade_administrativa(self):
+        request = self.factory.get("/admin/bem_patrimonial/bempatrimonial/")
+        request.user = self.gestor
+
+        actual_fields = self.admin.get_list_display(request)
+        self.assertIn("unidade_administrativa", actual_fields)
 
     def test_list_display_does_not_contain_old_fields(self):
         old_fields = ["id", "descricao", "criado_por", "criado_em"]
+
+        request_gestor = self.factory.get("/admin/bem_patrimonial/bempatrimonial/")
+        request_gestor.user = self.gestor
+        gestor_fields = self.admin.get_list_display(request_gestor)
+
         for field in old_fields:
-            self.assertNotIn(field, self.admin.list_display)
+            self.assertNotIn(field, gestor_fields)
+
+        request_operador = self.factory.get("/admin/bem_patrimonial/bempatrimonial/")
+        request_operador.user = self.operador
+        operador_fields = self.admin.get_list_display(request_operador)
+
+        for field in old_fields:
+            self.assertNotIn(field, operador_fields)
 
     def test_list_display_fields_are_valid(self):
         model_fields = [f.name for f in BemPatrimonial._meta.get_fields()]
 
-        for field in self.admin.list_display:
+        request_gestor = self.factory.get("/admin/bem_patrimonial/bempatrimonial/")
+        request_gestor.user = self.gestor
+        gestor_fields = self.admin.get_list_display(request_gestor)
+
+        for field in gestor_fields:
             self.assertIn(
                 field,
                 model_fields,
                 f"O campo '{field}' não existe no modelo BemPatrimonial",
             )
+
+        request_operador = self.factory.get("/admin/bem_patrimonial/bempatrimonial/")
+        request_operador.user = self.operador
+        operador_fields = self.admin.get_list_display(request_operador)
+
+        for field in operador_fields:
+            self.assertIn(
+                field,
+                model_fields,
+                f"O campo '{field}' não existe no modelo BemPatrimonial",
+            )
+
+    def test_list_display_operador_has_three_fields(self):
+        request = self.factory.get("/admin/bem_patrimonial/bempatrimonial/")
+        request.user = self.operador
+
+        actual_fields = self.admin.get_list_display(request)
+        self.assertEqual(len(actual_fields), 3)
+
+    def test_list_display_gestor_has_four_fields(self):
+        request = self.factory.get("/admin/bem_patrimonial/bempatrimonial/")
+        request.user = self.gestor
+
+        actual_fields = self.admin.get_list_display(request)
+        self.assertEqual(len(actual_fields), 4)


### PR DESCRIPTION
## 📋 Resumo

Ajuste na visualização da listagem de Bens Patrimoniais no Django Admin para priorizar informações mais relevantes tanto para o Gestor de Patrimônio quanto para o Operador de Inventário, exibindo colunas personalizadas por tipo de usuário.

## 🎯 Objetivo

Melhorar a usabilidade da interface administrativa, exibindo colunas diferenciadas que facilitam a identificação e gestão rápida dos bens patrimoniais de acordo com o papel do usuário no sistema.

## 🔧 Alterações Realizadas

### 1. Atualização do `BemPatrimonialAdmin`

**Arquivo:** `bem_patrimonial/admins/bem_patrimonial.py`

Implementação do método `get_list_display()` para exibir colunas personalizadas por tipo de usuário:

#### Gestor de Patrimônio

| Ordem | Campo | Descrição |
|-------|-------|-----------|
| 1 | `numero_patrimonial` | Número Patrimonial do bem |
| 2 | `nome` | Nome do bem |
| 3 | `unidade_administrativa` | Unidade administrativa responsável |
| 4 | `status` | Status atual do bem |

#### Operador de Inventário

| Ordem | Campo | Descrição |
|-------|-------|-----------|
| 1 | `numero_patrimonial` | Número Patrimonial do bem |
| 2 | `nome` | Nome do bem |
| 3 | `status` | Status atual do bem |

**Antes:**

```python
list_display = (
    "id",
    "status",
    "descricao",
    "criado_por",
    "criado_em",
)
```

**Depois:**

```python
def get_list_display(self, request):
    if request.user.is_operador_inventario:
        return ("numero_patrimonial", "nome", "status")
    return ("numero_patrimonial", "nome", "unidade_administrativa", "status")
```

### 2. Testes Unitários

**Arquivo:** `bem_patrimonial/tests/tests_admin_list_display.py`

Criação de testes abrangentes para validar a configuração:

- ✅ Verifica colunas corretas para **Gestor de Patrimônio** (4 campos)
- ✅ Verifica colunas corretas para **Operador de Inventário** (3 campos)
- ✅ Confirma que Operador **não** vê a coluna `unidade_administrativa`
- ✅ Confirma que Gestor **vê** a coluna `unidade_administrativa`
- ✅ Valida remoção de campos antigos (id, descricao, criado_por, criado_em) para ambos
- ✅ Valida que todos os campos existem no modelo `BemPatrimonial` para ambos os perfis

## 💡 Justificativa

A alteração personaliza a visualização de acordo com o contexto de uso de cada perfil:

### Para o Gestor de Patrimônio

Exibe informações essenciais para gestão ampla:

- **Número Patrimonial**: Identificador único e oficial do bem
- **Nome**: Descrição curta e direta do item
- **Unidade Administrativa**: Localização/responsabilidade do bem (essencial para gestão centralizada)
- **Status**: Situação atual (Aguardando Aprovação, Aprovado, etc.)

### Para o Operador de Inventário

Exibe informações focadas no contexto da unidade:

- **Número Patrimonial**: Identificador único e oficial do bem
- **Nome**: Descrição curta e direta do item
- **Status**: Situação atual do bem

**Nota**: A coluna "Unidade Administrativa" foi removida para o Operador porque ele já trabalha exclusivamente com bens de sua própria unidade (filtrado automaticamente), tornando essa informação redundante.

A remoção do campo "Descrição" da listagem principal reduz poluição visual para ambos os perfis, mantendo este campo acessível na visualização detalhada do bem.

## ✅ Validação

- [x] Testes unitários criados e funcionais para ambos os perfis
- [x] Campos validados contra o modelo `BemPatrimonial`
- [x] Visualização diferenciada por papel (Gestor vs Operador)
- [x] Filtragem de queryset por papel mantida
- [x] Funcionalidades de busca e exportação mantidas
- [x] Compatibilidade com permissões existentes

## 🔍 Checklist de Revisão

- [x] Código segue os padrões do projeto
- [x] Testes unitários incluídos
- [x] Sem quebra de funcionalidades existentes
- [x] Documentação atualizada (este PR)

## 🚀 Como Testar

### Teste Manual

#### Como Gestor de Patrimônio

1. Acesse o Django Admin como Gestor de Patrimônio
2. Navegue para `Home > Bens Patrimoniais`
3. Verifique se as colunas exibidas são: **Número Patrimonial, Nome, Unidade Administrativa e Status** (4 colunas)

#### Como Operador de Inventário

1. Acesse o Django Admin como Operador de Inventário
2. Navegue para `Home > Bens Patrimoniais`
3. Verifique se as colunas exibidas são: **Número Patrimonial, Nome e Status** (3 colunas)
4. Confirme que a coluna "Unidade Administrativa" **não** está visível

### Teste Automatizado

```bash
python manage.py test bem_patrimonial.tests.tests_admin_list_display
```
