### PR TITLE
Feature(135751): Melhorar Listagem de Unidades Administrativas

### DIFF
--- a/dados_comuns/admin.py
+++ b/dados_comuns/admin.py
@@ -7,11 +7,18 @@ UNIDADE_ADMINISTRATIVA_ORIGEM_AUTOCOMPLETE = "unidade_administrativa_origem"
 
 @admin.register(UnidadeAdministrativa)
 class UnidadeAdministrativaAdmin(admin.ModelAdmin):
-    search_fields = [
-        "nome",
-        "sigla",
+    list_display = (
         "codigo",
-    ]
+        "sigla",
+        "nome",
+    )
+    search_fields = (
+        "sigla",
+        "nome",
+        "codigo",
+    )
+    search_help_text = "Pesquise por sigla, nome ou código."
+    ordering = ("codigo", "sigla", "nome")
 
     def get_search_results(self, request, queryset, search_term):
         """

--- a/dados_comuns/models.py
+++ b/dados_comuns/models.py
@@ -20,7 +20,7 @@ class UnidadeAdministrativa(models.Model):
     class Meta:
         verbose_name = "unidade administrativa"
         verbose_name_plural = "unidades administrativas"
-        ordering = ["codigo", "nome", "sigla"]
+        ordering = ["codigo", "sigla", "nome"]
 
     def save(self, *args, **kwargs):
         self.updated_at = datetime.now()

--- a/dados_comuns/tests/tests_models.py
+++ b/dados_comuns/tests/tests_models.py
@@ -1,16 +1,45 @@
 from django.test import TestCase
+from django.contrib.admin.sites import AdminSite
 from dados_comuns.models import UnidadeAdministrativa
+from dados_comuns.admin import UnidadeAdministrativaAdmin
 
 
 class SetupData:
     def create_instance(self):
 
         obj = {
-            "codigo": 39684596,
-            "sigla":  "COTIC",
+            "codigo": "39684596",
+            "sigla": "COTIC",
             "nome": "Centro de tecnologia",
-        }      
+        }
         UnidadeAdministrativa.objects.create(**obj)
+
+    def create_multiple_instances(self):
+        instances = [
+            {
+                "codigo": "100",
+                "sigla": "SME",
+                "nome": "Secretaria Municipal de Educação",
+            },
+            {
+                "codigo": "050",
+                "sigla": "DRE-BT",
+                "nome": "Diretoria Regional de Educação Butantã",
+            },
+            {"codigo": "200", "sigla": "COTIC", "nome": "Centro de Tecnologia"},
+            {
+                "codigo": "050",
+                "sigla": "DRE-CS",
+                "nome": "Diretoria Regional de Educação Campo Limpo",
+            },
+            {
+                "codigo": "050",
+                "sigla": "DRE-CL",
+                "nome": "Diretoria Regional de Educação Capela do Socorro",
+            },
+        ]
+        for obj in instances:
+            UnidadeAdministrativa.objects.create(**obj)
 
 
 class UnidadeAdministrativaTestCase(TestCase):
@@ -36,3 +65,76 @@ class UnidadeAdministrativaTestCase(TestCase):
 
         self.assertFalse(instance.id)
         self.assertIsInstance(instance, self.entity)
+
+
+class UnidadeAdministrativaOrderingTestCase(TestCase):
+
+    def setUp(self):
+        setup = SetupData()
+        setup.create_multiple_instances()
+
+    def test_ordering_by_codigo_sigla_nome(self):
+        unidades = UnidadeAdministrativa.objects.all()
+
+        self.assertGreater(unidades.count(), 0)
+
+        unidades_list = list(unidades)
+
+        self.assertEqual(unidades_list[0].codigo, "050")
+        self.assertEqual(unidades_list[-1].codigo, "200")
+
+        unidades_codigo_050 = [u for u in unidades_list if u.codigo == "050"]
+        self.assertEqual(len(unidades_codigo_050), 3)
+        self.assertEqual(unidades_codigo_050[0].sigla, "DRE-BT")
+        self.assertEqual(unidades_codigo_050[1].sigla, "DRE-CL")
+        self.assertEqual(unidades_codigo_050[2].sigla, "DRE-CS")
+
+    def test_model_meta_ordering(self):
+        self.assertEqual(
+            UnidadeAdministrativa._meta.ordering, ["codigo", "sigla", "nome"]
+        )
+
+    def test_str_representation(self):
+        unidade = UnidadeAdministrativa.objects.first()
+        expected = f"{unidade.codigo} - {unidade.sigla}"
+        self.assertEqual(str(unidade), expected)
+
+
+class UnidadeAdministrativaAdminTestCase(TestCase):
+
+    def setUp(self):
+        setup = SetupData()
+        setup.create_multiple_instances()
+        self.site = AdminSite()
+        self.admin = UnidadeAdministrativaAdmin(UnidadeAdministrativa, self.site)
+
+    def test_list_display_fields(self):
+        expected_fields = ("codigo", "sigla", "nome")
+        self.assertEqual(self.admin.list_display, expected_fields)
+
+    def test_search_fields_order(self):
+        expected_fields = ("sigla", "nome", "codigo")
+        self.assertEqual(self.admin.search_fields, expected_fields)
+
+    def test_search_help_text(self):
+        expected_text = "Pesquise por sigla, nome ou código."
+        self.assertEqual(self.admin.search_help_text, expected_text)
+
+    def test_admin_ordering(self):
+        expected_ordering = ("codigo", "sigla", "nome")
+        self.assertEqual(self.admin.ordering, expected_ordering)
+
+    def test_admin_queryset_ordering(self):
+        from django.test import RequestFactory
+        from usuario.models import Usuario
+
+        factory = RequestFactory()
+        request = factory.get("/admin/dados_comuns/unidadeadministrativa/")
+        request.user = Usuario()
+
+        queryset = self.admin.get_queryset(request)
+        unidades_list = list(queryset)
+
+        self.assertGreater(len(unidades_list), 0)
+        self.assertEqual(unidades_list[0].codigo, "050")
+        self.assertEqual(unidades_list[-1].codigo, "200")


### PR DESCRIPTION
## 📋 Descrição

Melhorias na listagem de Unidades Administrativas no Django Admin: ordenação numérica crescente, colunas separadas e busca otimizada.

## ✅ Critérios de Aceite

- [x] Listagem ordenada por código (crescente), sigla e nome
- [x] Busca por código, nome e sigla com texto de ajuda
- [x] Colunas separadas: Código | Sigla | Nome

## 🔧 Alterações Técnicas

### Arquivos Modificados

**`dados_comuns/models.py`**

```python
ordering = ["codigo", "sigla", "nome"]  # Ordenação em 3 níveis
```

**`dados_comuns/admin.py`**

```python
list_display = ("codigo", "sigla", "nome")
search_fields = ("sigla", "nome", "codigo")  # Prioriza sigla e nome
search_help_text = "Pesquise por sigla, nome ou código."
ordering = ("codigo", "sigla", "nome")
```

**`dados_comuns/tests/tests_models.py`**

- ➕ 8 novos testes unitários em 2 classes:
  - `UnidadeAdministrativaOrderingTestCase`: testa ordenação e configurações do modelo
  - `UnidadeAdministrativaAdminTestCase`: valida configurações do admin

**Total:** 11 testes (3 originais + 8 novos)

## 📊 Impacto

| Antes | Depois |
|-------|--------|
| Código e sigla mesclados | 3 colunas separadas |
| Ordenação não garantida | Ordenação: código → sigla → nome |
| Sem orientação de busca | Texto de ajuda visível e Busca por todos os campos |

##   Como Testar

```bash
# Executar testes
python manage.py test dados_comuns.tests.tests_models

# Acessar admin
http://localhost:8000/admin/dados_comuns/unidadeadministrativa/
```

**Validações:**

- Listagem ordenada por código crescente
- Buscar por "DRE", "Educação" ou "050"
- Verificar 3 colunas separadas

##   Observações

- ✅ Retrocompatível (sem migrações)
- ✅ Funcionalidade de autocomplete mantida
- ✅ Segue padrão de Bens Patrimoniais
