### PR TITLE
fix: Acesso de visualizacao da unidade adm para o perador para visual…

### DIFF
--- a/usuario/utils.py
+++ b/usuario/utils.py
@@ -46,6 +46,7 @@ def setup_grupos_e_permissoes():
         "_unidadeadministrativabempatrimonial": ["view"],
         "_movimentacaobempatrimonial": ["add", "change", "view"],
         "_statusbempatrimonial": ["view"],
+        "_unidadeadministrativa": ["view"],
         # Módulo de Suporte desabilitado temporariamente
         # '_agendamentosuporte': ['add', 'change', 'delete', 'view'],
     }


### PR DESCRIPTION
### 🛠️ Descrição
Adiciona a permissão de **visualização de Unidade Administrativa** ao grupo **OPERADOR_INVENTARIO**, garantindo o funcionamento correto do campo de **autocomplete** nas movimentações de bens patrimoniais.

Sem essa permissão, usuários operadores recebiam erro **403 (PermissionDenied)** ao tentar buscar unidades administrativas no Django Admin.

---

### 🔧 Alterações realizadas
```python
operador_settings = {
    "_bempatrimonial": ["add", "change", "delete", "view"],
    "_unidadeadministrativabempatrimonial": ["view"],
    "_movimentacaobempatrimonial": ["add", "change", "view"],
    "_statusbempatrimonial": ["view"],
    "_unidadeadministrativa": ["view"],
    # Módulo de Suporte desabilitado temporariamente
    # '_agendamentosuporte': ['add', 'change', 'delete', 'view'],
}
```

Arquivo modificado:
- `usuario/utils.py`

---

### ✅ Resultado esperado
Após rodar:
```bash
python manage.py setup_grupos_e_permissoes
```

- O grupo **OPERADOR_INVENTARIO** passa a ter a permissão `view_unidadeadministrativa`.  
- O campo de **Unidade Administrativa (origem/destino)** em **Movimentação de Bem Patrimonial** volta a funcionar corretamente no Django Admin (autocomplete sem erro 403).  

---

### 🧩 Contexto
O Django exige permissão de “view” no modelo do autocomplete para liberar requisições ao endpoint `/admin/autocomplete/`.  
Sem ela, o sistema retornava **403 Forbidden**, mesmo com `search_fields` configurado corretamente.

---

**Tipo:** `fix(permissoes)`  
**Impacto:** baixo — apenas ajuste de permissão no setup de grupos.
