### PR TITLE
Fix: Ajusta testes excluindo campos removidos do banco

### DIFF
--- a/bem_patrimonial/tests/tests_email_nova_movimentacao.py
+++ b/bem_patrimonial/tests/tests_email_nova_movimentacao.py
@@ -6,7 +6,6 @@ import datetime
 from bem_patrimonial.models import (
     BemPatrimonial,
     MovimentacaoBemPatrimonial,
-    UnidadeAdministrativaBemPatrimonial,
 )
 from bem_patrimonial.constants import APROVADO
 from dados_comuns.models import UnidadeAdministrativa
@@ -58,22 +57,14 @@ class EmailNovaMovimentacaoTestCase(TestCase):
         self.bem = BemPatrimonial.objects.create(
             nome="POLTRONA GIRATÓRIA",
             numero_patrimonial="001.053719507-5",
-            data_compra_entrega=datetime.date.today(),
-            origem="aquisicao_direta",
             marca="Marca Teste",
             modelo="Modelo Teste",
-            quantidade=10,
             descricao="Descrição teste",
             valor_unitario=1500.00,
-            numero_processo=123456,
+            numero_processo="123456",
             criado_por=self.operador_origem,
             status=APROVADO,
-        )
-
-        UnidadeAdministrativaBemPatrimonial.objects.create(
-            bem_patrimonial=self.bem,
             unidade_administrativa=self.ua_origem,
-            quantidade=10,
         )
 
     @patch("bem_patrimonial.emails.email_utils.send_email_ctrl")
@@ -82,7 +73,6 @@ class EmailNovaMovimentacaoTestCase(TestCase):
             bem_patrimonial=self.bem,
             unidade_administrativa_origem=self.ua_origem,
             unidade_administrativa_destino=self.ua_destino,
-            quantidade=5,
             solicitado_por=self.operador_origem,
         )
 
@@ -100,7 +90,6 @@ class EmailNovaMovimentacaoTestCase(TestCase):
             bem_patrimonial=self.bem,
             unidade_administrativa_origem=self.ua_origem,
             unidade_administrativa_destino=self.ua_destino,
-            quantidade=5,
             solicitado_por=self.operador_origem,
         )
 
@@ -124,7 +113,6 @@ class EmailNovaMovimentacaoTestCase(TestCase):
             bem_patrimonial=self.bem,
             unidade_administrativa_origem=self.ua_origem,
             unidade_administrativa_destino=self.ua_destino,
-            quantidade=5,
             solicitado_por=self.operador_origem,
         )
 
@@ -145,7 +133,6 @@ class EmailNovaMovimentacaoTestCase(TestCase):
             bem_patrimonial=self.bem,
             unidade_administrativa_origem=self.ua_origem,
             unidade_administrativa_destino=self.ua_destino,
-            quantidade=5,
             solicitado_por=self.operador_origem,
         )
 
@@ -165,7 +152,6 @@ class EmailNovaMovimentacaoTestCase(TestCase):
             bem_patrimonial=self.bem,
             unidade_administrativa_origem=self.ua_origem,
             unidade_administrativa_destino=self.ua_destino,
-            quantidade=5,
             solicitado_por=self.operador_origem,
         )
 
@@ -187,7 +173,6 @@ class EmailNovaMovimentacaoTestCase(TestCase):
             bem_patrimonial=self.bem,
             unidade_administrativa_origem=self.ua_origem,
             unidade_administrativa_destino=self.ua_destino,
-            quantidade=5,
             solicitado_por=self.operador_origem,
         )
 
@@ -202,7 +187,6 @@ class EmailNovaMovimentacaoTestCase(TestCase):
             bem_patrimonial=self.bem,
             unidade_administrativa_origem=self.ua_origem,
             unidade_administrativa_destino=self.ua_destino,
-            quantidade=5,
             solicitado_por=self.operador_origem,
         )
 
@@ -224,7 +208,6 @@ class EmailNovaMovimentacaoTestCase(TestCase):
             bem_patrimonial=self.bem,
             unidade_administrativa_origem=self.ua_origem,
             unidade_administrativa_destino=self.ua_destino,
-            quantidade=5,
             solicitado_por=self.operador_origem,
         )
 
@@ -236,7 +219,6 @@ class EmailNovaMovimentacaoTestCase(TestCase):
             bem_patrimonial=self.bem,
             unidade_administrativa_origem=self.ua_origem,
             unidade_administrativa_destino=self.ua_destino,
-            quantidade=5,
             solicitado_por=self.operador_origem,
         )
 

--- a/bem_patrimonial/tests/tests_unidade_administrativa_setup.py
+++ b/bem_patrimonial/tests/tests_unidade_administrativa_setup.py
@@ -64,7 +64,7 @@ class SetupUnidadeAdministrativaStatusData:
 
         return operador_1, operador_2, gestor
 
-    def create_bem_patrimonial(self, criado_por, ua_origem, quantidade=10):
+    def create_bem_patrimonial(self, criado_por, ua_origem):
         """
         quantidade é ignorado no model atual; mantido só por compatibilidade.
         """


### PR DESCRIPTION
Este pull request refatora as suítes de teste de `bem_patrimonial` removendo o uso do campo `quantidade` das configurações e casos de teste, além de eliminar dependências diretas do modelo `UnidadeAdministrativaBemPatrimonial` nos testes. As alterações simplificam a criação de dados de teste e focam em outros atributos, como `observacao`, para cenários de edição e validação.

**Simplificação do modelo e configuração de dados de teste:**

* Removidas as referências a `UnidadeAdministrativaBemPatrimonial` das importações e da criação de dados de teste, tornando a configuração mais simples e reduzindo dependências desnecessárias.
* Refatorada a criação de objetos `BemPatrimonial` nos testes para excluir campos como `quantidade`, `data_compra_entrega` e `origem`, além de garantir que `numero_processo` seja uma string, alinhando os dados de teste com os requisitos atuais do modelo.

**Atualizações nos casos de teste:**

* Removido o argumento `quantidade` de todos os casos de teste de `MovimentacaoBemPatrimonial`, focando os testes em outras lógicas de negócio em vez do tratamento de quantidade.

**Alterações na lógica de edição e validação:**

* Atualizados os testes de edição de `MovimentacaoBemPatrimonial` para usar o campo `observacao` em vez de `quantidade`, refletindo uma mudança no foco dos testes e nos requisitos de negócio.


