### PR TITLE
bug(fluxo) Ajuste no fluxo de cadastro de multiplos bens e validacoes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,3 +178,4 @@ cython_debug/
 .github
 .gitignore
 .vscode/launch.json
+docker-compose-dev.yml

--- a/bem_patrimonial/models.py
+++ b/bem_patrimonial/models.py
@@ -100,7 +100,11 @@ class BemPatrimonial(models.Model):
     AUDIT_IGNORE_FIELDS = ("id", "criado_em", "atualizado_em", "criado_por")
 
     def __str__(self):
-        return f'{self.numero_patrimonial} - {self.nome}' if self.numero_patrimonial else self.nome
+        return (
+            f"{self.numero_patrimonial} - {self.nome}"
+            if self.numero_patrimonial
+            else self.nome
+        )
 
     class Meta:
         verbose_name = "bem patrimonial"

--- a/bem_patrimonial/tests/tests_admin_list_display.py
+++ b/bem_patrimonial/tests/tests_admin_list_display.py
@@ -44,7 +44,6 @@ class BemPatrimonialAdminListDisplayTestCase(TestCase):
         request.user = self.gestor
 
         expected_fields = (
-            "thumb",
             "numero_patrimonial",
             "nome",
             "unidade_administrativa",
@@ -57,7 +56,7 @@ class BemPatrimonialAdminListDisplayTestCase(TestCase):
         request = self.factory.get("/admin/bem_patrimonial/bempatrimonial/")
         request.user = self.operador
 
-        expected_fields = ("thumb", "numero_patrimonial", "nome", "status")
+        expected_fields = ("numero_patrimonial", "nome", "status")
         actual_fields = self.admin.get_list_display(request)
         self.assertEqual(actual_fields, expected_fields)
 
@@ -138,7 +137,6 @@ class BemPatrimonialAdminListDisplayTestCase(TestCase):
         request.user = self.gestor
         actual = self.admin.get_list_display(request)
         expected = (
-            "thumb",
             "numero_patrimonial",
             "nome",
             "unidade_administrativa",
@@ -150,17 +148,17 @@ class BemPatrimonialAdminListDisplayTestCase(TestCase):
         request = self.factory.get("/admin/bem_patrimonial/bempatrimonial/")
         request.user = self.gestor
         actual = self.admin.get_list_display(request)
-        self.assertEqual(len(actual), 5)
+        self.assertEqual(len(actual), 4)
 
     def test_list_display_operador_contains_required_fields(self):
         request = self.factory.get("/admin/bem_patrimonial/bempatrimonial/")
         request.user = self.operador
         actual = self.admin.get_list_display(request)
-        expected = ("thumb", "numero_patrimonial", "nome", "status")
+        expected = ("numero_patrimonial", "nome", "status")
         self.assertEqual(actual, expected)
 
     def test_list_display_operador_has_four_fields(self):
         request = self.factory.get("/admin/bem_patrimonial/bempatrimonial/")
         request.user = self.operador
         actual = self.admin.get_list_display(request)
-        self.assertEqual(len(actual), 4)
+        self.assertEqual(len(actual), 3)

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -32,10 +32,11 @@ services:
   web:
     build:
       context: .
-      dockerfile: Dockerfile
+      dockerfile: Dockerfile.dev
     container_name: sme_bens_fisicos_web
     command: >
-      python manage.py runserver 0.0.0.0:8000
+      python -m debugpy --wait-for-client --listen 0.0.0.0:5678
+      manage.py runserver 0.0.0.0:8000
     volumes:
       - .:/code
     ports:

--- a/static/admin/bem_patrimonial.js
+++ b/static/admin/bem_patrimonial.js
@@ -377,7 +377,7 @@
     var form = qs('form');
     if (!form) return;
 
-    var anchor = qs('.form-row.field-foto');
+    var anchor = qs('.form-row.field-numero_processo');
     var wrapper = document.createElement('div');
     wrapper.innerHTML = multiHTML();
     if (anchor && anchor.parentNode){ anchor.parentNode.insertBefore(wrapper, anchor.nextSibling); }


### PR DESCRIPTION
 Ajustes de validação do **Número Patrimonial** (edição e criação) + pequenos refinamentos

**Contexto**
- Na edição, o sistema não permitia alterar o **Número Patrimonial** conforme regras desejadas.
- Precisamos garantir que, ao **editar**, se um número for informado, ele esteja **no padrão novo** `000.000000000-0`, exceto quando o **Formato antigo** estiver marcado.  
- Mesmo que **Sem numeração** esteja marcado, se o usuário **informar um número** na edição, deve validar o formato (novo ou antigo).

---

### 🔧 Alterações principais
1. **Form `BemPatrimonialAdminForm.clean()`**
   - **Edição (`instance.pk` presente)**:
     - Se **informar número**: exige **padrão novo** `000.000000000-0` **ou** marcar **Formato antigo**.
     - Se **informar número**, força `sem_numeracao=False`.
     - Se **não informar número** e **não marcar** “Sem numeração”, retorna erro.
     - Se **marcar “Sem numeração”**, zera `numero_formato_antigo`.
   - **Criação (sem `pk`)**:
     - Impede marcar **“Sem numeração”** **e** **“Formato antigo”** simultaneamente.
     - Se **não** for “Sem numeração” **e** **não** for “Formato antigo”, o número **precisa** seguir o **padrão novo**.

2. **JS (máscara do número no admin)**
   - Garante que o campo **Número Patrimonial** continue **editável** na edição.
   - Mantém a máscara apenas quando **não** estiver marcado **Formato antigo** e **não** for “Sem numeração”.
   - Realce visual de erros no modo **Múltiplos Bens** corrigido (borda/outline).

3. **Admin (modo múltiplo)**
   - Injeta o bloco do **cadastro múltiplo** em ponto estável do template (após `numero_processo`), evitando dependência do campo `foto`.
   - No POST de múltiplos, o form base é afrouxado para não exigir `localizacao` (a obrigatoriedade é por linha).

---

### ✅ Resultado esperado
- Na **edição**:
  - Usuário pode **alterar** o **Número Patrimonial** livremente.
  - Se informar número: **novo padrão** ou marcar **Formato antigo**.
  - Se não informar número: precisa marcar **Sem numeração**.
- No **cadastro múltiplo**:
  - UI estável, erros por linha com destaque visual e mensagem agregada no topo.
- Sem alteração de comportamento para criação já validada anteriormente.

---

### 🔍 Como testar
1. **Edição com número novo (padrão novo)**  
   - Edite um bem com `numero_patrimonial`: informe `123.123456789-0`, **sem** marcar “Formato antigo” → **deve salvar**.
2. **Edição com número “antigo”**  
   - Informe algo fora do padrão (ex.: `ABC-123`) e **marque** “Formato antigo” → **deve salvar**.
3. **Edição sem número e sem “Sem numeração”**  
   - Apague o número e **não marque** “Sem numeração” → **deve exibir erro**.
4. **Edição com “Sem numeração” mas preenchendo número**  
   - Marque “Sem numeração” e informe `123.123456789-0` → valida e **salva** (força `sem_numeracao=False`).
5. **Cadastro Múltiplo**  
   - Entre no modo múltiplo, adicione uma linha **sem Localização** → erro visual na linha.  
   - Adicione outra linha com **Formato antigo** e número livre → **deve salvar**.

---

### 📦 Impacto / Risco
- **Baixo**: alterações focadas no `clean()` do form e no JS do admin.  
- Sem migrações. Sem mudança de schema.

---

### ✅ Checklist
- [x] Regras de edição aplicadas (padrão novo ou marcar “Formato antigo”).  
- [x] “Sem numeração” não bloqueia edição quando número é informado.  
- [x] UI do múltiplo estável e com erros destacados por linha.  
- [x] Sem dependência do campo `foto` para injeção do bloco múltiplo.  
- [x] Sem mudanças de banco / migração.
