### PR TITLE
fix(numero) Ajuste para na geracao automeatica sempre considerar 15 c…

### DIFF
--- a/bem_patrimonial/models.py
+++ b/bem_patrimonial/models.py
@@ -150,7 +150,7 @@ class BemPatrimonial(models.Model):
             base_id = self.pk
 
             while True:
-                id_str = str(base_id).zfill(12)
+                id_str = str(base_id).zfill(9)
                 numero_formatado = f"000.{id_str}-0"
 
                 if (

--- a/bem_patrimonial/tests/tests_models.py
+++ b/bem_patrimonial/tests/tests_models.py
@@ -12,8 +12,8 @@ from bem_patrimonial.constants import (
 )
 from usuario.tests import tests_models as usuariotests_models
 
-# O model atual formata como: 000.{12 dígitos}-0
-NPAT_REGEX = r"^\d{3}\.\d{12}-\d$"
+# O model atual formata como: 000.{9 dígitos}-0
+NPAT_REGEX = r"^\d{3}\.\d{9}-\d$"
 
 
 class SetupData:
@@ -176,8 +176,7 @@ class BemPatrimonialTestCase(TestCase):
         obj.full_clean()
         obj.save()
         self.assertIsNotNone(obj.numero_patrimonial)
-        # "000." + 12 dígitos + "-0" -> total esperado = 4 + 12 + 2 = 18
-        self.assertEqual(len(obj.numero_patrimonial), 18)
+        self.assertEqual(len(obj.numero_patrimonial), 15)
         self.assertRegex(obj.numero_patrimonial, NPAT_REGEX)
 
     def test_unicidade_numero_patrimonial(self):


### PR DESCRIPTION
### 🛠️ Atualizações Realizadas

- Ajustado o formato oficial do **Número Patrimonial** para `000.000000000-0` (15 caracteres).  
- Corrigida a geração automática de número para seguir o novo padrão.  
- Mantida a validação de unicidade e incremento automático em caso de colisão.  
- Alinhado o regex e validações do backend e dos testes com o formato atualizado.  
- Revisado o comportamento do formulário para permitir edição do número patrimonial conforme as novas regras.  

✅ Todos os testes ajustados e executando com sucesso no novo formato.