### PR TITLE
Hotfix(138326): [PRODUÇÃO] Corrige inconsistência de unidade administrativa em bens após migração

### DIFF
--- a/bem_patrimonial/migrations/0010_corrige_unidades_por_movimentacao.py
+++ b/bem_patrimonial/migrations/0010_corrige_unidades_por_movimentacao.py
@@ -1,0 +1,37 @@
+# Gerado manual para corrigir unidades administrativas incorretas
+# com base na última movimentação aprovada de cada bem patrimonial.
+
+from django.db import migrations
+
+SQL_CORRIGE_UNIDADE_POR_MOVIMENTACAO = r"""
+WITH ultima_movimentacao AS (
+    SELECT DISTINCT ON (bem_patrimonial_id)
+        bem_patrimonial_id,
+        unidade_administrativa_destino_id
+    FROM bem_patrimonial_movimentacaobempatrimonial
+    WHERE aprovado_por_id IS NOT NULL
+    ORDER BY bem_patrimonial_id, atualizado_em DESC NULLS LAST, id DESC
+)
+UPDATE bem_patrimonial_bempatrimonial AS b
+SET unidade_administrativa_id = m.unidade_administrativa_destino_id
+FROM ultima_movimentacao AS m
+WHERE b.id = m.bem_patrimonial_id
+  AND b.unidade_administrativa_id IS DISTINCT FROM m.unidade_administrativa_destino_id;
+"""
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        (
+            "bem_patrimonial",
+            "0009_alter_bempatrimonial_numero_processo",
+        ),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql=SQL_CORRIGE_UNIDADE_POR_MOVIMENTACAO,
+            reverse_sql=migrations.RunSQL.noop,
+        ),
+    ]


### PR DESCRIPTION
## 🧩 Contexto

Após a migração que passou a armazenar a unidade administrativa diretamente no modelo `BemPatrimonial`, foi identificado que diversos bens permaneceram vinculados à **unidade de origem**, mesmo após movimentações aprovadas que deveriam tê-los transferido para a unidade de destino.

O problema foi percebido em ambientes produtivos, quando relatórios e consultas mostraram bens localizados em unidades incorretas.

---

## 🧭 Causa

Durante a migração original, os dados da tabela legada `bem_patrimonial_unidadeadministrativabempatrimonial` foram copiados para o novo campo `unidade_administrativa_id` com base na “última” associação registrada.

Contudo, essa tabela continha dois registros quase simultâneos para cada movimentação:
- Um de **saída** (unidade de origem);
- Outro de **entrada** (unidade de destino).

Devido à diferença mínima de tempo entre as gravações, em alguns casos o registro da **origem** acabou sendo interpretado como o mais recente, fazendo com que o bem permanecesse vinculado à unidade errada.

---

## ⚠️ Impacto

- Bens movimentados antes da migração ficaram associados à unidade de origem em vez da de destino.  
- Relatórios e consultas passaram a exibir informações incorretas sobre a unidade atual dos bens.  
- Possibilidade de inconsistências em novas movimentações baseadas em dados incorretos.

---

## 🛠️ Solução Aplicada

Foi criada uma nova migração para corrigir a unidade administrativa dos bens com base na **última movimentação aprovada** registrada no sistema.

Essa correção:
- Considera apenas movimentações **aprovadas**;
- Atualiza a unidade do bem conforme o **destino** da movimentação mais recente;
- Evita alterações desnecessárias (somente atualiza bens com valor divergente);
- É **idempotente**, podendo ser executada novamente sem causar inconsistências.

---

## ✅ Resultado Esperado

- Todos os bens passam a estar vinculados corretamente à **unidade administrativa de destino** da última movimentação aprovada;  
- Bens que já estavam corretos **não sofrem alterações**;  
- O sistema volta a refletir fielmente a situação real das movimentações.

---

## 🔍 Checklist

- [x] Script validado em ambiente local e  de homologação  
- [x] Confirmada a correção da unidade de destino em bens com movimentações antigas  
- [x] Migração idempotente (segura para reexecução)  
- [x] Testado impacto em relatórios e consultas relacionadas  

---

## 🧪 Como testar

1. Identificar um bem que apresentava divergência de unidade antes da correção.  
2. Executar a migração.  
3. Verificar se o bem passou a estar vinculado à **unidade administrativa de destino** da última movimentação aprovada.  
4. Conferir relatórios e histórico de movimentações para garantir a consistência dos dados.

--- 

## 🧩 Notas Técnicas Internas

- **App afetado:** `bem_patrimonial`  
- **Tipo de mudança:** Migração de correção de dados  
- **Arquivo criado:** `bem_patrimonial/migrations/0010_corrige_unidades_por_movimentacao.py`  
- **Dependências:** Após a migração que removeu o model legado `UnidadeAdministrativaBemPatrimonial`  
- **Lógica da correção:** Atualização do campo `unidade_administrativa_id` com base na última movimentação aprovada (`unidade_administrativa_destino_id`)  
- **Execução segura:** Script pode ser rodado múltiplas vezes sem causar alterações indevidas (uso de `IS DISTINCT FROM`)

---

📌 **Resumo:**  
Esta correção garante que todos os bens patrimoniais reflitam corretamente a unidade administrativa de destino da última movimentação aprovada, resolvendo a inconsistência introduzida na migração anterior.