### PR TITLE
Fix(136179): Ajuste Readonlyfields

### DIFF
--- a/bem_patrimonial/admins/movimentacao_bem_patrimonial.py
+++ b/bem_patrimonial/admins/movimentacao_bem_patrimonial.py
@@ -313,7 +313,7 @@ class MovimentacaoBemPatrimonialAdmin(admin.ModelAdmin):
     list_display = (
         "id",
         "status",
-        "numero_cimbpm",
+        # "numero_cimbpm",
         "unidade_administrativa_origem",
         "unidade_administrativa_destino",
         "solicitado_por",
@@ -331,7 +331,7 @@ class MovimentacaoBemPatrimonialAdmin(admin.ModelAdmin):
         "rejeitado_por",
         "cancelado_por",
         "status",
-        "numero_cimbpm",
+        # "numero_cimbpm",
         "get_documento_cimbpm_link",
     )
 


### PR DESCRIPTION
Este pull request faz um pequeno ajuste na configuração do Django Admin para `MovimentacaoBemPatrimonialAdmin`, comentando o campo `numero_cimbpm` nos atributos `list_display` e `readonly_fields`. Isso oculta o campo `numero_cimbpm` tanto na lista quanto na visualização detalhada no admin.

* O campo `numero_cimbpm` foi comentado em `list_display` e `readonly_fields` dentro da classe `MovimentacaoBemPatrimonialAdmin`, removendo sua exibição na interface administrativa.
