### PR TITLE
fix: Restaura o campo 'numero_cimbpm' na lista de exibição

### DIFF
--- a/bem_patrimonial/admins/movimentacao_bem_patrimonial.py
+++ b/bem_patrimonial/admins/movimentacao_bem_patrimonial.py
@@ -313,7 +313,6 @@ class MovimentacaoBemPatrimonialAdmin(admin.ModelAdmin):
     list_display = (
         "id",
         "status",
-        # "numero_cimbpm",
         "unidade_administrativa_origem",
         "unidade_administrativa_destino",
         "solicitado_por",
@@ -331,7 +330,7 @@ class MovimentacaoBemPatrimonialAdmin(admin.ModelAdmin):
         "rejeitado_por",
         "cancelado_por",
         "status",
-        # "numero_cimbpm",
+        "numero_cimbpm",
         "get_documento_cimbpm_link",
     )
 
@@ -362,7 +361,7 @@ class MovimentacaoBemPatrimonialAdmin(admin.ModelAdmin):
         if obj is not None:
             return [
                 "status",
-                # "numero_cimbpm",
+                "numero_cimbpm",
                 "get_documento_cimbpm_link",
                 "solicitado_por",
                 "aprovado_por",


### PR DESCRIPTION
Este pull request faz pequenos ajustes na configuração do Django Admin para a classe `MovimentacaoBemPatrimonialAdmin`, reabilitando a exibição e edição do campo `numero_cimbpm` na interface administrativa.

**Melhorias na interface do admin:**

* O campo `numero_cimbpm` foi reinserido em `list_display` e nos `fields` exibidos no admin, permitindo que usuários visualizem e editem esse campo diretamente.
