### PR TITLE
Feature(138311): Remover Ícones de CRUD nos Cadastros

### DIFF
--- a/bem_patrimonial/admins/bem_patrimonial.py
+++ b/bem_patrimonial/admins/bem_patrimonial.py
@@ -115,7 +115,7 @@ class BemPatrimonialAdmin(ImportExportModelAdmin):
 
     class Media:
         js = ("admin/bem_patrimonial.js",)
-        css = {"all": ("admin/bem_patrimonial.css",)}
+        css = {"all": ("admin/bem_patrimonial.css", "css/hide_crud_icons.css")}
 
     def get_actions(self, request):
         actions = super().get_actions(request)
@@ -176,17 +176,20 @@ class BemPatrimonialAdmin(ImportExportModelAdmin):
 
                     if "unidade_administrativa" in self_inner.fields:
                         fld = self_inner.fields["unidade_administrativa"]
-                        fld.required = True  
+                        fld.required = True
 
                         qs = UnidadeAdministrativa.objects.filter(
                             status=UnidadeAdministrativa.ATIVA
                         )
 
-                        if request.user.is_operador_inventario and not request.user.is_gestor_patrimonio:
+                        if (
+                            request.user.is_operador_inventario
+                            and not request.user.is_gestor_patrimonio
+                        ):
                             ua = getattr(request.user, "unidade_administrativa", None)
                             qs = qs.filter(pk=getattr(ua, "pk", None))
                             fld.initial = ua
-                            fld.disabled = True  
+                            fld.disabled = True
                         fld.queryset = qs
 
                 def clean(self_inner):
@@ -198,13 +201,15 @@ class BemPatrimonialAdmin(ImportExportModelAdmin):
                     ):
                         if not cleaned_data.get("unidade_administrativa") and ua_user:
                             cleaned_data["unidade_administrativa"] = ua_user
-                    
+
                     ua_form = cleaned_data.get("unidade_administrativa")
                     if not ua_form:
                         raise ValidationError(
-                            {"unidade_administrativa": "Selecione a Unidade Administrativa."}
+                            {
+                                "unidade_administrativa": "Selecione a Unidade Administrativa."
+                            }
                         )
-                        
+
                     if ua_user and not ua_user.is_ativa:
                         raise ValidationError(
                             f"Não é possível criar bens patrimoniais. Sua unidade administrativa "
@@ -581,7 +586,7 @@ class BemPatrimonialAdmin(ImportExportModelAdmin):
         except Exception:
             pass
         return "—"
-    
+
     def get_search_results(self, request, queryset, search_term):
         qs, use_distinct = super().get_search_results(request, queryset, search_term)
 
@@ -603,11 +608,7 @@ class BemPatrimonialAdmin(ImportExportModelAdmin):
 
                 exclude_bens = request.GET.get("exclude_bens")
                 if exclude_bens:
-                    ids = [
-                        int(pk)
-                        for pk in exclude_bens.split(",")
-                        if pk.isdigit()
-                    ]
+                    ids = [int(pk) for pk in exclude_bens.split(",") if pk.isdigit()]
                     if ids:
                         qs = qs.exclude(pk__in=ids)
 

--- a/bem_patrimonial/admins/movimentacao_bem_patrimonial.py
+++ b/bem_patrimonial/admins/movimentacao_bem_patrimonial.py
@@ -352,7 +352,13 @@ class MovimentacaoBemPatrimonialAdmin(admin.ModelAdmin):
             "js/bem_patrimonial/prevenir_duplo_submit.js",
             "admin/movimentacao_filtra_bens_por_ua.js",
         )
-        css = {"all": ("css/prevenir_duplo_submit.css", "css/custom_inline.css")}
+        css = {
+            "all": (
+                "css/prevenir_duplo_submit.css",
+                "css/custom_inline.css",
+                "css/hide_crud_icons.css",
+            )
+        }
 
     def get_fields(self, request, obj=None):
         base_fields = [

--- a/static/css/hide_crud_icons.css
+++ b/static/css/hide_crud_icons.css
@@ -1,0 +1,11 @@
+/**
+ * CSS para ocultar ícones de CRUD (editar, adicionar, excluir, visualizar)
+ * nas telas de detalhe do Django Admin
+ */
+ 
+.related-widget-wrapper .add-related,
+.related-widget-wrapper .change-related,
+.related-widget-wrapper .delete-related,
+.related-widget-wrapper .view-related {
+    display: none !important;
+}

--- a/usuario/admin.py
+++ b/usuario/admin.py
@@ -77,6 +77,9 @@ class CustomUserModelAdmin(UserAdmin):
         ("Datas importantes", {"fields": ("last_login", "date_joined")}),
     )
 
+    class Media:
+        css = {"all": ("css/hide_crud_icons.css",)}
+
     def get_readonly_fields(self, request, obj=None):
         if obj:
             return self.readonly_fields + ("username",)


### PR DESCRIPTION
## 🎯 Objetivo

Ocultar ícones de CRUD (lápis, +, X, olho) nas telas de detalhe de Bem Patrimonial, Movimentação e Usuário para melhorar a usabilidade.

## 📝 Implementação

### Arquivo Criado

**`static/css/hide_crud_icons.css`**

```css
.related-widget-wrapper .add-related,
.related-widget-wrapper .change-related,
.related-widget-wrapper .delete-related,
.related-widget-wrapper .view-related {
    display: none !important;
}
```

### Arquivos Modificados

Adicionado `"css/hide_crud_icons.css"` na classe `Media` dos seguintes admins:

- `bem_patrimonial/admins/bem_patrimonial.py` (BemPatrimonialAdmin)
- `bem_patrimonial/admins/movimentacao_bem_patrimonial.py` (MovimentacaoBemPatrimonialAdmin)
- `usuario/admin.py` (CustomUserModelAdmin)

## 🚀 Deploy

```bash
python manage.py collectstatic --noinput
```

## ✅ Critérios de Aceite

- [x] Ícones ocultados em Bem Patrimonial
- [x] Ícones ocultados em Movimentação de Bem Patrimonial
- [x] Ícones ocultados em Usuário
- [x] Layout não quebrado
- [x] Compatível com CSS existente (`custom_inline.css`)

## 🧪 Testes

Esta funcionalidade não requer testes unitários, pois trata-se de uma mudança puramente visual (CSS). 

**Testes manuais verificados:**
1. Acessar tela de detalhe de Bem Patrimonial e verificar se ícones de CRUD estão ocultados
2. Acessar tela de detalhe de Movimentação e verificar se ícones de CRUD estão ocultados
3. Acessar tela de detalhe de Usuário e verificar se ícones de CRUD estão ocultados
4. Verificar se o layout geral não foi quebrado

## ⚠️ Observações

- Mudança apenas visual (CSS), sem impacto em lógica de negócio
- Usa `!important` para sobrescrever estilos padrão do Django Admin
- Testes manuais (não requer testes unitários)
