### PR TITLE
Feature(138309): Accordion para Histórico Geral do Bem Patrimonial

### DIFF
--- a/bem_patrimonial/admins/bem_patrimonial.py
+++ b/bem_patrimonial/admins/bem_patrimonial.py
@@ -48,9 +48,13 @@ class HistoricoGeralInline(GenericTabularInline):
     )
     fields = ("campo", "valor_antigo", "valor_novo", "alterado_por", "alterado_em")
     ordering = ("-alterado_em",)
+    template = "admin/bem_patrimonial/edit_inline/tabular-historico.html"
 
     def has_view_or_change_permission(self, request, obj=None):
         return True
+
+    def has_add_permission(self, request, obj=None):
+        return False
 
 
 class BemPatrimonialResource(resources.ModelResource):
@@ -176,17 +180,20 @@ class BemPatrimonialAdmin(ImportExportModelAdmin):
 
                     if "unidade_administrativa" in self_inner.fields:
                         fld = self_inner.fields["unidade_administrativa"]
-                        fld.required = True  
+                        fld.required = True
 
                         qs = UnidadeAdministrativa.objects.filter(
                             status=UnidadeAdministrativa.ATIVA
                         )
 
-                        if request.user.is_operador_inventario and not request.user.is_gestor_patrimonio:
+                        if (
+                            request.user.is_operador_inventario
+                            and not request.user.is_gestor_patrimonio
+                        ):
                             ua = getattr(request.user, "unidade_administrativa", None)
                             qs = qs.filter(pk=getattr(ua, "pk", None))
                             fld.initial = ua
-                            fld.disabled = True  
+                            fld.disabled = True
                         fld.queryset = qs
 
                 def clean(self_inner):
@@ -198,13 +205,15 @@ class BemPatrimonialAdmin(ImportExportModelAdmin):
                     ):
                         if not cleaned_data.get("unidade_administrativa") and ua_user:
                             cleaned_data["unidade_administrativa"] = ua_user
-                    
+
                     ua_form = cleaned_data.get("unidade_administrativa")
                     if not ua_form:
                         raise ValidationError(
-                            {"unidade_administrativa": "Selecione a Unidade Administrativa."}
+                            {
+                                "unidade_administrativa": "Selecione a Unidade Administrativa."
+                            }
                         )
-                        
+
                     if ua_user and not ua_user.is_ativa:
                         raise ValidationError(
                             f"Não é possível criar bens patrimoniais. Sua unidade administrativa "
@@ -581,7 +590,7 @@ class BemPatrimonialAdmin(ImportExportModelAdmin):
         except Exception:
             pass
         return "—"
-    
+
     def get_search_results(self, request, queryset, search_term):
         qs, use_distinct = super().get_search_results(request, queryset, search_term)
 
@@ -603,11 +612,7 @@ class BemPatrimonialAdmin(ImportExportModelAdmin):
 
                 exclude_bens = request.GET.get("exclude_bens")
                 if exclude_bens:
-                    ids = [
-                        int(pk)
-                        for pk in exclude_bens.split(",")
-                        if pk.isdigit()
-                    ]
+                    ids = [int(pk) for pk in exclude_bens.split(",") if pk.isdigit()]
                     if ids:
                         qs = qs.exclude(pk__in=ids)
 

--- a/config/templates/admin/bem_patrimonial/edit_inline/tabular-historico.html
+++ b/config/templates/admin/bem_patrimonial/edit_inline/tabular-historico.html
@@ -1,0 +1,50 @@
+{% load static %}
+<div class="inline-group" id="{{ inline_admin_formset.formset.prefix }}-group">
+  <div class="tabular inline-related">
+    <fieldset class="module">
+      <h2 style="cursor: pointer; user-select: none;" onclick="var c = this.nextElementSibling, i = this.querySelector('.toggle-icon'); if (c.style.display === 'none') { c.style.display = 'block'; i.textContent = '▼'; } else { c.style.display = 'none'; i.textContent = '▶'; }">
+        <span class="toggle-icon">▶</span>
+        {{ inline_admin_formset.opts.verbose_name_plural|capfirst }}
+        ({{ inline_admin_formset.formset.total_form_count }})
+      </h2>
+      
+      <div style="display: none;">
+        {% if inline_admin_formset.formset.non_form_errors %}
+          {{ inline_admin_formset.formset.non_form_errors }}
+        {% endif %}
+        {{ inline_admin_formset.formset.management_form }}
+
+        <table>
+          <thead>
+            <tr>
+              {% for field in inline_admin_formset.fields %}
+                {% if not field.widget.is_hidden %}
+                  <th{% if field.required %} class="required"{% endif %}>{{ field.label|capfirst }}</th>
+                {% endif %}
+              {% endfor %}
+            </tr>
+          </thead>
+          <tbody>
+            {% for inline_admin_form in inline_admin_formset %}
+              <tr class="{% cycle "row1" "row2" %}">
+                {% for fieldset in inline_admin_form %}
+                  {% for line in fieldset %}
+                    {% for field in line %}
+                      <td{% if field.field.name %} class="field-{{ field.field.name }}"{% endif %}>
+                        {% if field.is_readonly %}
+                          <p>{{ field.contents }}</p>
+                        {% else %}
+                          {{ field.field }}
+                        {% endif %}
+                      </td>
+                    {% endfor %}
+                  {% endfor %}
+                {% endfor %}
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </fieldset>
+  </div>
+</div>


### PR DESCRIPTION
## 📝 Descrição

Implementa accordion recolhível para o inline "Histórico Geral" na tela de edição de Bem Patrimonial, mantendo a interface mais limpa e organizada.

## 🔧 Alterações

**Arquivo criado:**

- `config/templates/admin/bem_patrimonial/edit_inline/tabular-historico.html` - Template customizado com accordion e JavaScript inline

**Arquivo modificado:**

- `bem_patrimonial/admins/bem_patrimonial.py` - Adicionado `template` customizado e método `has_add_permission()` no `HistoricoGeralInline`

## ✨ Funcionalidades

- ✅ Accordion recolhido por padrão (ícone ▶)
- ✅ Clique no título para expandir/recolher (ícone ▼)
- ✅ Contador de registros sempre visível
- ✅ Desabilita adição manual de histórico (protege integridade da auditoria)
- ✅ Mantém layout e cores padrão do Django Admin
- ✅ JavaScript inline minimalista (sem dependências)

## 🧪 Como Testar

1. Acesse um bem patrimonial no Django Admin
2. Verifique que o "Histórico gerais (N)" está recolhido com ícone ▶
3. Clique no título para expandir e visualizar a tabela (ícone muda para ▼)
4. Clique novamente para recolher
5. Confirme que **não há botão** "Adicionar outro Histórico geral"
6. Teste com perfis: Gestor de Patrimônio e Operador de Inventário

## 📌 Observações

- Não altera regras de negócio ou permissões existentes
- Apenas melhoria de UX (experiência do usuário)
