### PR TITLE
Feature(126819) Ajustes exibicao perfil e remocao de adicao na edição da movimentacao

### DIFF
--- a/bem_patrimonial/admins/forms/movimentacao_bem_patrimonial_form.py
+++ b/bem_patrimonial/admins/forms/movimentacao_bem_patrimonial_form.py
@@ -8,33 +8,28 @@ from dados_comuns.models import UnidadeAdministrativa
 class MovimentacaoBemPatrimonialForm(forms.ModelForm):
     class Meta:
         model = MovimentacaoBemPatrimonial
-        # Esconde campos de controle e campo legado bem_patrimonial + bens (M2M)
+
         exclude = (
             "solicitado_por",
             "aprovado_por",
             "rejeitado_por",
             "cancelado_por",
             "status",
-            "bem_patrimonial",  # legado
-            "bens",             # M2M gerenciado via inline
+            "bem_patrimonial",
+            "bens",
         )
 
     def __init__(self, *args, **kwargs):
         super(MovimentacaoBemPatrimonialForm, self).__init__(*args, **kwargs)
 
-        # Filtrar apenas unidades administrativas ativas
         if "unidade_administrativa_origem" in self.fields:
             self.fields["unidade_administrativa_origem"].queryset = (
-                UnidadeAdministrativa.objects.filter(
-                    status=UnidadeAdministrativa.ATIVA
-                )
+                UnidadeAdministrativa.objects.filter(status=UnidadeAdministrativa.ATIVA)
             )
 
         if "unidade_administrativa_destino" in self.fields:
             self.fields["unidade_administrativa_destino"].queryset = (
-                UnidadeAdministrativa.objects.filter(
-                    status=UnidadeAdministrativa.ATIVA
-                )
+                UnidadeAdministrativa.objects.filter(status=UnidadeAdministrativa.ATIVA)
             )
 
     def clean(self):
@@ -47,7 +42,6 @@ class MovimentacaoBemPatrimonialForm(forms.ModelForm):
 
         is_editing = self.instance.pk is not None
 
-        # Validação de unidades administrativas
         if not ua_origem:
             raise ValidationError("Unidade administrativa de origem é obrigatória.")
 
@@ -67,9 +61,10 @@ class MovimentacaoBemPatrimonialForm(forms.ModelForm):
             )
 
         if ua_destino == ua_origem:
-            raise ValidationError("Operação não permitida: origem e destino são iguais.")
+            raise ValidationError(
+                "Operação não permitida: origem e destino são iguais."
+            )
 
-        # Restrição de edição para operador de inventário
         if is_editing and user and getattr(user, "is_operador_inventario", False):
             if self.instance.solicitado_por_id != user.id:
                 raise ValidationError(

--- a/bem_patrimonial/admins/inlines/inlines.py
+++ b/bem_patrimonial/admins/inlines/inlines.py
@@ -18,7 +18,6 @@ class MovimentacaoBensItemInlineFormSet(BaseInlineFormSet):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        # Desabilita o checkbox de DELETE em cada formulário
         for form in self.forms:
             if "DELETE" in form.fields:
                 form.fields["DELETE"].disabled = True
@@ -37,12 +36,11 @@ class MovimentacaoBensItemInlineFormSet(BaseInlineFormSet):
 
             bem = form.cleaned_data.get("bem")
             if not bem:
-                # linha vazia ignorada
+
                 continue
 
             bens_usados.append(bem)
 
-            # Validações por bem (as mesmas que você fazia no form antes)
             if bem.status == AGUARDANDO_APROVACAO:
                 raise ValidationError(
                     f"O bem '{bem.nome}' está aguardando aprovação do cadastro. "
@@ -80,7 +78,6 @@ class MovimentacaoBensItemInlineForm(ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        # Monta o rótulo com numero_patrimonial, nome, marca e modelo
         def _label(obj: BemPatrimonial):
             npat = obj.numero_patrimonial or "SEM-NUMERO"
             return f"{npat} - {obj.nome} ({obj.marca} / {obj.modelo})"
@@ -94,3 +91,7 @@ class MovimentacaoBensItemInline(admin.TabularInline):
     form = MovimentacaoBensItemInlineForm
     formset = MovimentacaoBensItemInlineFormSet
     autocomplete_fields = ("bem",)
+
+    def has_add_permission(self, request, obj=None):
+
+        return obj is None

--- a/bem_patrimonial/admins/movimentacao_bem_patrimonial.py
+++ b/bem_patrimonial/admins/movimentacao_bem_patrimonial.py
@@ -445,3 +445,13 @@ class MovimentacaoBemPatrimonialAdmin(admin.ModelAdmin):
             return verificar_movimentacoes_duplicadas(self, request, qs)
 
         return super().response_action(request, queryset)
+
+    def get_inline_formsets(self, request, formsets, inline_instances, obj=None):
+        inline_formsets = super().get_inline_formsets(
+            request, formsets, inline_instances, obj
+        )
+
+        if obj is not None:
+            for formset in inline_formsets:
+                formset.can_add = False
+        return inline_formsets

--- a/usuario/utils.py
+++ b/usuario/utils.py
@@ -27,6 +27,7 @@ def setup_grupos_e_permissoes():
     gestor_settings = {
         "_bempatrimonial": ["add", "change", "delete", "view"],
         "_movimentacaobempatrimonial": ["add", "change", "delete", "view"],
+        "_movimentacaobensitem": ["view", "add"],
         "_statusbempatrimonial": ["add", "change", "delete", "view"],
         "_usuario": ["add", "change", "view"],
         "_unidadeadministrativa": ["add", "change", "delete", "view"],
@@ -43,6 +44,7 @@ def setup_grupos_e_permissoes():
     operador_settings = {
         "_bempatrimonial": ["add", "change", "delete", "view"],
         "_movimentacaobempatrimonial": ["add", "change", "view"],
+        "_movimentacaobensitem": ["view", "add"],
         "_statusbempatrimonial": ["view"],
         "_unidadeadministrativa": ["view"],
         # Módulo de Suporte desabilitado temporariamente


### PR DESCRIPTION
📝 Descrição

Remove o botão “Adicionar outro(a) Item de movimentação” quando a
movimentação já está criada, impedindo inclusão de novos itens na tela
de edição. A adição continua permitida somente durante a criação da
movimentação, mantendo o fluxo correto do módulo.

------------------------------------------------------------------------

🔧 Alterações

Arquivos modificados:

-   bem_patrimonial/admins/inlines/inlines.py
    -   Implementado método has_add_permission() no inline
        MovimentacaoBensItemInline para permitir inclusão apenas na
        criação.
    -   (Opcional, se aplicado) Implementado has_delete_permission()
        para bloquear exclusão na edição.

------------------------------------------------------------------------

✨ Funcionalidades

-   ✅ Botão “Adicionar outro(a) Item de movimentação” aparece somente
    na criação
-   ✅ Botão é ocultado automaticamente na edição
-   ✅ Impede inclusão tardia de itens após a movimentação estar
    registrada
-   ✅ Mantém edição e visualização dos itens existentes
-   ✅ Implementação limpa e padrão via has_add_permission()
-   ✅ Não afeta outros inlines ou permissões do usuário

------------------------------------------------------------------------

🧪 Como Testar

1.  Acesse o Django Admin e abra Movimentações de Bens Patrimoniais.
2.  Clique em Adicionar Movimentação:
    -   O inline “Itens de Movimentação” deve exibir o botão “Adicionar
        outro(a)” normalmente.
3.  Salve a movimentação.
4.  Reabra a mesma movimentação:
    -   O botão não deve aparecer.
    -   Apenas os itens existentes devem ser exibidos.
5.  (Se aplicável) Verifique também ausência do botão de remover itens.
6.  Teste tanto com:
    -   Gestor de Patrimônio
    -   Operador de Inventário

------------------------------------------------------------------------

📌 Observações

-   Não altera regras de negócio da Movimentação.
-   Não altera permissões dos grupos.
-   Mudança focada em controle do fluxo e integridade dos itens da
    movimentação.
-   Alinhado com comportamento padrão do Django Admin.
