### PR TITLE
Feature(138407) Melhorias de usabilidade no modulo de bens patromoniais

### DIFF
--- a/bem_patrimonial/admins/bem_patrimonial.py
+++ b/bem_patrimonial/admins/bem_patrimonial.py
@@ -10,6 +10,7 @@ from bem_patrimonial.admins.actions.extracao_numeros import (
     aplicar_extracao_numero,
     simular_extracao_numero,
 )
+from bem_patrimonial.admins.filters.bem_patrimonial_filters import SemNumeroFilter
 from bem_patrimonial.admins.forms.bem_patrimonial_form import BemPatrimonialAdminForm
 from bem_patrimonial.models import (
     BemPatrimonial,
@@ -197,17 +198,24 @@ class BemPatrimonialAdmin(ImportExportModelAdmin):
         "modelo",
         "localizacao",
         "numero_processo",
+        "unidade_administrativa__codigo",
+        "unidade_administrativa__nome", 
+    )
+
+    search_help_text = (
+        "Pesquise por número patrimonial, nome, descrição, marca, modelo, "
+        "localização, número de processo, código ou nome da Unidade Administrativa."
     )
     list_display_links = (
         "numero_patrimonial",
         "nome",
     )
-    search_help_text = "Pesquise por número patrimonial, nome, descrição, marca, modelo, localização ou número de processo."
+    
     resource_class = BemPatrimonialResource
 
     list_filter = (
         "status",
-        "sem_numeracao",
+        SemNumeroFilter,
         "numero_formato_antigo",
         ("criado_em", DateRangeFilter),
     )

--- a/bem_patrimonial/admins/filters/bem_patrimonial_filters.py
+++ b/bem_patrimonial/admins/filters/bem_patrimonial_filters.py
@@ -1,0 +1,14 @@
+from django.contrib import admin
+
+
+class SemNumeroFilter(admin.SimpleListFilter):
+    title = "Sem número"
+    parameter_name = "sem_numero"
+
+    def lookups(self, request, model_admin):
+        return (("1", "Somente bens sem número"),)
+
+    def queryset(self, request, queryset):
+        if self.value() == "1":
+            return queryset.filter(sem_numeracao=True)
+        return queryset

--- a/bem_patrimonial/management/commands/bem_patrimonial_remove_npat_da_descricao.py
+++ b/bem_patrimonial/management/commands/bem_patrimonial_remove_npat_da_descricao.py
@@ -1,0 +1,107 @@
+import re
+
+from django.core.management.base import BaseCommand
+from django.db import transaction
+
+from bem_patrimonial.models import BemPatrimonial, NPAT_NUM_REGEX
+
+
+class Command(BaseCommand):
+    help = (
+        "Remove o número patrimonial da descrição dos bens e limpa caracteres "
+        "especiais no início da descrição."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Apenas simula as alterações, sem salvar no banco.",
+        )
+        parser.add_argument(
+            "--limit",
+            type=int,
+            default=None,
+            help="Limita quantidade de registros processados.",
+        )
+
+    def handle(self, *args, **options):
+        dry_run = options["dry_run"]
+        limit = options["limit"]
+
+        qs = BemPatrimonial.objects.exclude(numero_patrimonial__isnull=True).exclude(
+            numero_patrimonial__exact=""
+        )
+
+        if limit:
+            qs = qs[:limit]
+
+        total_verificados = 0
+        total_alterados = 0
+
+        self.stdout.write(
+            self.style.WARNING(
+                f"Processando {qs.count()} bens "
+                f"({'DRY RUN' if dry_run else 'EXECUÇÃO REAL'})..."
+            )
+        )
+
+        with transaction.atomic():
+            for bem in qs.iterator():
+                total_verificados += 1
+                alterou = False
+
+                numero = (bem.numero_patrimonial or "").strip()
+                descricao_original = bem.descricao or ""
+                descricao_trabalhada = descricao_original
+
+                if numero:
+                    # REGRAS DE SEGURANÇA
+                    if not bem.numero_formato_antigo and not bem.sem_numeracao:
+                        # Deve estar no formato novo
+                        if not re.fullmatch(NPAT_NUM_REGEX, numero):
+                            self.stdout.write(
+                                self.style.WARNING(
+                                    f"[#{bem.pk}] Número '{numero}' deveria ser formato novo "
+                                    f"mas não bate regex. Ignorando."
+                                )
+                            )
+                            continue
+
+                    # REMOVE NPAT DA DESCRIÇÃO
+                    if numero in descricao_trabalhada:
+                        descricao_trabalhada = descricao_trabalhada.replace(
+                            numero, ""
+                        ).strip()
+                        alterou = True
+
+                # NOVA REGRA: remover caracteres especiais no início
+                descricao_limpa = re.sub(
+                    r"^[^A-Za-z0-9]+", "", descricao_trabalhada
+                ).strip()
+
+                if descricao_limpa != descricao_original:
+                    alterou = True
+
+                if alterou:
+                    total_alterados += 1
+
+                    self.stdout.write(f"[#{bem.pk}] Ajustando descrição:")
+                    self.stdout.write(f"  NPAT:   {numero}")
+                    self.stdout.write(f"  ANTES:  {descricao_original!r}")
+                    self.stdout.write(f"  DEPOIS: {descricao_limpa!r}")
+                    self.stdout.write("")
+
+                    if not dry_run:
+                        bem.descricao = descricao_limpa
+                        bem.save(update_fields=["descricao", "atualizado_em"])
+
+            if dry_run:
+                transaction.set_rollback(True)
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Finalizado. Verificados: {total_verificados} • Alterados: {total_alterados} "
+                f"{'(DRY RUN, nada salvo)' if dry_run else ''}"
+            )
+        )


### PR DESCRIPTION
# Ajustes no Módulo de Bens Patrimoniais

## 📋 Resumo

Ajustes de usabilidade e consistência de dados no módulo de **Bens Patrimoniais**, incluindo:

- Melhoria na busca para aceitar **código e nome da Unidade Administrativa**
- Filtro lateral **“Sem número”** baseado diretamente na flag `sem_numeracao`
- Criação de um **management command** para:
  - Remover o **número patrimonial** da descrição quando estiver duplicado
  - Limpar caracteres especiais no início da descrição, mantendo apenas o texto útil

---

## 🎯 Objetivo

Garantir uma experiência de consulta mais eficiente e descrições de bens mais limpas, removendo redundâncias e entradas incorretas. Ao mesmo tempo, facilitar:

- A filtragem rápida por Unidade Administrativa
- A identificação de bens sem número patrimonial
- A padronização e limpeza textual das descrições via comando automatizado

---

## 🧭 Ajustes no Django Admin (`BemPatrimonialAdmin`)

### 1. Busca por Unidade Administrativa
- Inclusão dos campos:
  - `unidade_administrativa__codigo`
  - `unidade_administrativa__nome`
- Permite pesquisa direta pelo código ou nome da UA na barra de busca superior.

### 2. Filtro lateral “Sem número”
- Mantém o filtro baseado exclusivamente na flag `sem_numeracao=True`.
- Ajuda a localizar bens configurados explicitamente como sem número patrimonial.

---

## 🛠 Management Command: limpeza de descrições

**Arquivo criado:**
`bem_patrimonial/management/commands/bem_patrimonial_remove_npat_da_descricao.py`

### Objetivos:
- Remover o valor de `numero_patrimonial` quando encontrado na `descricao`.
- Remover caracteres especiais no início da descrição (ex.: `- MONITOR` → `MONITOR`).
- Garantir que números que deveriam estar no formato novo **não sejam removidos** se estiverem incorretos.

---

## 📐 Regras de Negócio do Command

1. **Inclui somente bens com número patrimonial válido**.
2. **Segurança para formato novo**:
   - Se não for formato antigo nem sem numeração, o NPAT só será removido se bater com `NPAT_NUM_REGEX`.
3. **Remoção do número patrimonial** quando duplicado na descrição.
4. **Limpeza de prefixos inválidos**:
   - Remove caracteres iniciais que **não** sejam letras ou números.

---

## ⚙️ Execução do Command

### Parâmetros:
- `--dry-run` → simula sem salvar
- `--limit N` → processa apenas N bens

### Exemplos:

```
python manage.py bem_patrimonial_remove_npat_da_descricao --dry-run
python manage.py bem_patrimonial_remove_npat_da_descricao
python manage.py bem_patrimonial_remove_npat_da_descricao --limit 100
```

---

## 🧪 Cenários de Teste Recomendados

- Buscar bens por código/nome da UA.
- Validar o filtro “Sem número”.
- Executar o command em `--dry-run` e confirmar:
  - Remoção correta do NPAT
  - Limpeza de caracteres especiais iniciais
  - Proteção para NPAT fora do padrão novo

---

## ✅ Checklist

- [x] Busca por código/nome da Unidade Administrativa habilitada  
- [x] Filtro lateral “Sem número” baseado na flag `sem_numeracao`  
- [x] Command criado com validação segura (formato novo/antigo/sem numeração)  
- [x] Remoção segura de número patrimonial duplicado na descrição  
- [x] Limpeza de caracteres especiais iniciais  
- [x] Suporte a `--dry-run` e `--limit`  
