### PR TITLE
Feature(136177): Exportação de Relatório de Unidades Administrativas

### DIFF
--- a/dados_comuns/admin.py
+++ b/dados_comuns/admin.py
@@ -1,8 +1,11 @@
 from django.contrib import admin
 from django.contrib import messages
 from django.core.exceptions import ValidationError
-from dados_comuns.libs.unidade_administrativa import uas_do_usuario
+from import_export.admin import ImportExportModelAdmin
+from import_export.formats.base_formats import CSV, XLS, XLSX
 from dados_comuns.models import UnidadeAdministrativa
+from dados_comuns.resources import UnidadeAdministrativaResource
+from dados_comuns.formats import UnidadeAdministrativaPDFFormat
 
 UNIDADE_ADMINISTRATIVA_ORIGEM_AUTOCOMPLETE = "unidade_administrativa_origem"
 
@@ -21,7 +24,15 @@ class StatusFilter(admin.SimpleListFilter):
 
 
 @admin.register(UnidadeAdministrativa)
-class UnidadeAdministrativaAdmin(admin.ModelAdmin):
+class UnidadeAdministrativaAdmin(ImportExportModelAdmin):
+    resource_class = UnidadeAdministrativaResource
+
+    def has_import_permission(self, request):
+        return False
+
+    def has_export_permission(self, request):
+        return request.user.is_gestor_patrimonio
+
     list_display = (
         "codigo",
         "sigla",
@@ -106,3 +117,13 @@ class UnidadeAdministrativaAdmin(admin.ModelAdmin):
                 request,
                 f"Unidade '{obj.nome}' inativada com sucesso. O histórico foi preservado.",
             )
+
+    def get_export_formats(self):
+        return [CSV, XLSX, XLS, UnidadeAdministrativaPDFFormat]
+
+    def get_export_data(self, file_format, queryset, *args, **kwargs):
+        if isinstance(file_format, UnidadeAdministrativaPDFFormat):
+            request = kwargs.get("request")
+            file_format._export_request = request
+            file_format._export_queryset = queryset
+        return super().get_export_data(file_format, queryset, *args, **kwargs)

--- a/dados_comuns/formats.py
+++ b/dados_comuns/formats.py
@@ -1,0 +1,241 @@
+import os
+from io import BytesIO
+from django.conf import settings
+from django.utils import timezone
+from import_export.formats.base_formats import Format
+from reportlab.lib import colors
+from reportlab.lib.pagesizes import A4
+from reportlab.lib.units import cm
+from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
+from reportlab.lib.enums import TA_CENTER
+from reportlab.platypus import (
+    SimpleDocTemplate,
+    Table,
+    TableStyle,
+    Paragraph,
+    Spacer,
+    Image,
+)
+
+
+class UnidadeAdministrativaPDFFormat(Format):
+
+    def get_title(self):
+        return "pdf"
+
+    def create_dataset(self, in_stream):
+        raise NotImplementedError("Importação não é suportada para PDF.")
+
+    def export_data(self, dataset, **kwargs):
+        request = getattr(self, "_export_request", None)
+        queryset = getattr(self, "_export_queryset", None)
+        uas_list = list(queryset) if queryset is not None else []
+
+        buffer = BytesIO()
+        doc = SimpleDocTemplate(
+            buffer,
+            pagesize=A4,
+            leftMargin=0.3 * cm,
+            rightMargin=0.3 * cm,
+            topMargin=0.9 * cm,
+            bottomMargin=0.9 * cm,
+            title="Relatório de Unidades Administrativas",
+            author=(
+                request.user.get_full_name() or request.user.username
+                if request
+                else "Sistema Bens Físicos"
+            ),
+        )
+
+        elements = self._criar_cabecalho() + self._criar_tabela_unidades(uas_list)
+
+        doc.build(
+            elements,
+            onFirstPage=self._adicionar_numero_pagina,
+            onLaterPages=self._adicionar_numero_pagina,
+        )
+
+        pdf_bytes = buffer.getvalue()
+        buffer.close()
+        return pdf_bytes
+
+    def _criar_cabecalho(self):
+        styles = getSampleStyleSheet()
+
+        def _carregar_logo(filename, fallback_text):
+            static_root = settings.STATIC_ROOT or (
+                settings.STATICFILES_DIRS[0] if settings.STATICFILES_DIRS else None
+            )
+            if static_root:
+                logo_path = os.path.join(static_root, "img", filename)
+                if os.path.exists(logo_path):
+                    try:
+                        return Image(logo_path, width=3 * cm, height=1.5 * cm)
+                    except Exception:
+                        pass
+            return Paragraph(fallback_text, styles["Heading1"])
+
+        title_style = ParagraphStyle(
+            "CustomTitle",
+            parent=styles["Heading1"],
+            fontSize=18,
+            textColor=colors.HexColor("#149f67"),
+            alignment=TA_CENTER,
+            spaceAfter=6,
+        )
+        subtitle_style = ParagraphStyle(
+            "CustomSubtitle",
+            parent=styles["Normal"],
+            fontSize=10,
+            textColor=colors.HexColor("#666666"),
+            alignment=TA_CENTER,
+        )
+
+        header_row = [
+            _carregar_logo("bens_default_logo.png", "SME"),
+            [
+                Paragraph("Relatório de Unidades Administrativas", title_style),
+                Paragraph(
+                    "Secretaria Municipal de Educação - Prefeitura de São Paulo",
+                    subtitle_style,
+                ),
+            ],
+            _carregar_logo("prefeitura_default_logo.png", "PMSP"),
+        ]
+
+        header_table = Table([header_row], colWidths=[3.5 * cm, None, 3.5 * cm])
+        header_table.setStyle(
+            TableStyle(
+                [
+                    ("ALIGN", (0, 0), (0, 0), "LEFT"),
+                    ("ALIGN", (1, 0), (1, 0), "CENTER"),
+                    ("ALIGN", (2, 0), (2, 0), "RIGHT"),
+                    ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+                ]
+            )
+        )
+
+        return [header_table, Spacer(1, 0.4 * cm)]
+
+    def _criar_tabela_unidades(self, uas_list):
+        styles = getSampleStyleSheet()
+        if not uas_list:
+            return [
+                Paragraph(
+                    "<i>Nenhuma unidade administrativa encontrada com os filtros aplicados.</i>",
+                    styles["Normal"],
+                )
+            ]
+
+        cell_style = ParagraphStyle(
+            "CellStyle", parent=styles["Normal"], fontSize=7, leading=8, wordWrap="CJK"
+        )
+        cell_style_center = ParagraphStyle(
+            "CellStyleCenter",
+            parent=styles["Normal"],
+            fontSize=7,
+            leading=8,
+            wordWrap="CJK",
+            alignment=TA_CENTER,
+        )
+        data = [["Código", "Sigla", "Nome", "Status"]]
+
+        for ua in uas_list:
+            data.append(
+                [
+                    Paragraph(str(ua.codigo) if ua.codigo else "-", cell_style_center),
+                    Paragraph(str(ua.sigla) if ua.sigla else "-", cell_style),
+                    Paragraph(str(ua.nome) if ua.nome else "-", cell_style),
+                    Paragraph(
+                        ua.get_status_display() if ua.status else "-", cell_style_center
+                    ),
+                ]
+            )
+
+        table = Table(
+            data,
+            colWidths=[2 * cm, 5.5 * cm, 10 * cm, 2 * cm],
+            repeatRows=1,
+            splitByRow=True,
+        )
+        table.setStyle(
+            TableStyle(
+                [
+                    ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#149f67")),
+                    ("TEXTCOLOR", (0, 0), (-1, 0), colors.white),
+                    ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+                    ("FONTSIZE", (0, 0), (-1, 0), 7),
+                    ("ALIGN", (0, 0), (-1, 0), "CENTER"),
+                    ("VALIGN", (0, 0), (-1, 0), "MIDDLE"),
+                    ("BOTTOMPADDING", (0, 0), (-1, 0), 6),
+                    ("TOPPADDING", (0, 0), (-1, 0), 6),
+                    ("FONTNAME", (0, 1), (-1, -1), "Helvetica"),
+                    ("FONTSIZE", (0, 1), (-1, -1), 7),
+                    ("VALIGN", (0, 1), (-1, -1), "TOP"),
+                    ("LEFTPADDING", (0, 0), (-1, -1), 3),
+                    ("RIGHTPADDING", (0, 0), (-1, -1), 3),
+                    ("TOPPADDING", (0, 1), (-1, -1), 4),
+                    ("BOTTOMPADDING", (0, 1), (-1, -1), 4),
+                    ("GRID", (0, 0), (-1, -1), 0.5, colors.grey),
+                    (
+                        "ROWBACKGROUNDS",
+                        (0, 1),
+                        (-1, -1),
+                        [colors.white, colors.HexColor("#f8f9fa")],
+                    ),
+                ]
+            )
+        )
+
+        return [table]
+
+    def _adicionar_numero_pagina(self, canvas, doc):
+        from django.utils.timezone import localtime
+
+        canvas.saveState()
+
+        request = getattr(self, "_export_request", None)
+        data_emissao = localtime(timezone.now()).strftime("%d/%m/%Y %H:%M")
+        usuario = "Sistema"
+        rf_text = ""
+
+        if request and hasattr(request, "user") and request.user.is_authenticated:
+            user = request.user
+            usuario = (
+                user.nome
+                if (hasattr(user, "nome") and user.nome)
+                else (
+                    user.get_full_name().strip()
+                    if user.get_full_name()
+                    else user.username
+                )
+            )
+            if hasattr(user, "rf") and user.rf:
+                rf_text = f" - RF: {user.rf}"
+
+        footer_text = f"Emitido em: {data_emissao} | Por: {usuario}{rf_text}"
+        canvas.setFont("Helvetica", 8)
+        canvas.setFillColor(colors.grey)
+        canvas.drawString(0.5 * cm, 0.5 * cm, footer_text)
+        canvas.drawCentredString(
+            A4[0] / 2, 0.5 * cm, f"Página {canvas.getPageNumber()}"
+        )
+        canvas.restoreState()
+
+    def is_binary(self):
+        return True
+
+    def get_read_mode(self):
+        return "rb"
+
+    def get_extension(self):
+        return "pdf"
+
+    def get_content_type(self):
+        return "application/pdf"
+
+    def can_import(self):
+        return False
+
+    def can_export(self):
+        return True

--- a/dados_comuns/resources.py
+++ b/dados_comuns/resources.py
@@ -1,0 +1,18 @@
+from import_export import resources, fields
+from dados_comuns.models import UnidadeAdministrativa
+
+
+class UnidadeAdministrativaResource(resources.ModelResource):
+
+    status_display = fields.Field(
+        column_name="Status",
+        attribute="status",
+    )
+
+    class Meta:
+        model = UnidadeAdministrativa
+        fields = ("codigo", "sigla", "nome", "status_display")
+        export_order = ("codigo", "sigla", "nome", "status_display")
+
+    def dehydrate_status_display(self, ua):
+        return ua.get_status_display()

--- a/dados_comuns/tests/tests_exportacao_unidades.py
+++ b/dados_comuns/tests/tests_exportacao_unidades.py
@@ -1,0 +1,160 @@
+from django.test import TestCase, RequestFactory
+from django.contrib.admin.sites import AdminSite
+from django.contrib.auth.models import Group
+from dados_comuns.models import UnidadeAdministrativa
+from dados_comuns.admin import UnidadeAdministrativaAdmin
+from dados_comuns.formats import UnidadeAdministrativaPDFFormat
+from dados_comuns.resources import UnidadeAdministrativaResource
+from usuario.models import Usuario
+from usuario.constants import GRUPO_GESTOR_PATRIMONIO, GRUPO_OPERADOR_INVENTARIO
+
+
+class ExportacaoUnidadeAdministrativaTestCase(TestCase):
+
+    def setUp(self):
+        UnidadeAdministrativa.objects.create(
+            codigo="01.01.01.0001",
+            sigla="SME",
+            nome="Secretaria Municipal de Educação",
+            status=UnidadeAdministrativa.ATIVA,
+        )
+        UnidadeAdministrativa.objects.create(
+            codigo="01.01.02.0002",
+            sigla="PMSP/SME/SME-GAB/MEMORIAL",
+            nome="COORDENADORIA DOS CENTROS EDUCACIONAIS UNIFICADOS",
+            status=UnidadeAdministrativa.INATIVA,
+        )
+
+        grupo_gestor, _ = Group.objects.get_or_create(name=GRUPO_GESTOR_PATRIMONIO)
+
+        self.gestor_com_rf = Usuario.objects.create_user(
+            username="gestor_rf",
+            email="gestor.rf@test.com",
+            password="test123",
+            nome="José da Silva",
+            rf="123456",
+            is_staff=True,
+        )
+        self.gestor_com_rf.groups.add(grupo_gestor)
+
+        self.gestor_sem_rf = Usuario.objects.create_user(
+            username="gestor_sem_rf",
+            email="gestor.sem.rf@test.com",
+            password="test123",
+            nome="Maria Santos",
+            rf=None,
+            is_staff=True,
+        )
+        self.gestor_sem_rf.groups.add(grupo_gestor)
+
+        grupo_operador, _ = Group.objects.get_or_create(name=GRUPO_OPERADOR_INVENTARIO)
+        self.operador = Usuario.objects.create_user(
+            username="operador",
+            email="operador@test.com",
+            password="test123",
+            nome="Operador Teste",
+            rf="654321",
+            is_staff=True,
+        )
+        self.operador.groups.add(grupo_operador)
+
+        self.site = AdminSite()
+        self.admin = UnidadeAdministrativaAdmin(UnidadeAdministrativa, self.site)
+        self.factory = RequestFactory()
+
+    def _gerar_pdf(self, usuario, queryset=None):
+        if queryset is None:
+            queryset = UnidadeAdministrativa.objects.all()
+
+        request = self.factory.get("/admin/dados_comuns/unidadeadministrativa/")
+        request.user = usuario
+
+        pdf_format = UnidadeAdministrativaPDFFormat()
+        pdf_format._export_request = request
+        pdf_format._export_queryset = queryset
+
+        return pdf_format.export_data(None)
+
+    def test_pdf_gerado_com_estrutura_valida(self):
+        pdf_bytes = self._gerar_pdf(self.gestor_com_rf)
+
+        self.assertIsInstance(pdf_bytes, bytes)
+        self.assertTrue(pdf_bytes.startswith(b"%PDF"))
+        self.assertIn(b"%%EOF", pdf_bytes)
+        self.assertGreater(len(pdf_bytes), 1000)
+        self.assertIn(b"/Author (gestor_rf)", pdf_bytes)
+
+    def test_pdf_gerado_sem_rf_cadastrado(self):
+        pdf_bytes = self._gerar_pdf(self.gestor_sem_rf)
+
+        self.assertIsInstance(pdf_bytes, bytes)
+        self.assertTrue(pdf_bytes.startswith(b"%PDF"))
+        self.assertIn(b"%%EOF", pdf_bytes)
+        self.assertGreater(len(pdf_bytes), 1000)
+        self.assertIn(b"/Author (gestor_sem_rf)", pdf_bytes)
+
+    def test_exportacao_excel_com_status_legivel(self):
+        resource = UnidadeAdministrativaResource()
+        dataset = resource.export(UnidadeAdministrativa.objects.all())
+
+        self.assertEqual(len(dataset), 2)
+        status_values = [row[3] for row in dataset]
+        self.assertIn("Ativa", status_values)
+        self.assertIn("Inativa", status_values)
+
+    def test_formatos_exportacao_disponiveis(self):
+        formats = self.admin.get_export_formats()
+        format_titles = [f().get_title() for f in formats]
+
+        self.assertIn("csv", format_titles)
+        self.assertIn("xlsx", format_titles)
+        self.assertIn("pdf", format_titles)
+
+    def test_importacao_desabilitada(self):
+        request = self.factory.get("/admin/dados_comuns/unidadeadministrativa/")
+        request.user = self.gestor_com_rf
+
+        self.assertFalse(self.admin.has_import_permission(request))
+
+    def test_campos_exportados_ordem_correta(self):
+        resource = UnidadeAdministrativaResource()
+        expected_order = ("codigo", "sigla", "nome", "status_display")
+
+        self.assertEqual(resource.Meta.export_order, expected_order)
+
+    def test_pdf_paginacao_multiplas_paginas(self):
+        for i in range(50):
+            UnidadeAdministrativa.objects.create(
+                codigo=f"99.99.{i:02d}.{i:04d}",
+                sigla=f"UA-{i:03d}",
+                nome=f"Unidade Administrativa de Teste {i}",
+                status=UnidadeAdministrativa.ATIVA,
+            )
+
+        pdf_bytes = self._gerar_pdf(self.gestor_com_rf)
+
+        self.assertGreater(len(pdf_bytes), 50000)
+        page_count = pdf_bytes.count(b"/Page")
+        self.assertGreater(page_count, 1)
+
+    def test_operador_nao_pode_exportar(self):
+        request = self.factory.get("/admin/dados_comuns/unidadeadministrativa/")
+        request.user = self.operador
+
+        self.assertFalse(self.admin.has_export_permission(request))
+
+    def test_gestor_pode_exportar(self):
+        request = self.factory.get("/admin/dados_comuns/unidadeadministrativa/")
+        request.user = self.gestor_com_rf
+
+        self.assertTrue(self.admin.has_export_permission(request))
+
+    def test_quantidade_registros_exportados(self):
+        resource = UnidadeAdministrativaResource()
+        queryset = UnidadeAdministrativa.objects.all()
+        dataset = resource.export(queryset)
+
+        total_esperado = queryset.count()
+        linhas_dados = [row for row in dataset if row != dataset.headers]
+
+        self.assertEqual(len(linhas_dados), total_esperado)


### PR DESCRIPTION
## 📋 Resumo

Implementação da funcionalidade de exportação de relatório consolidado das Unidades Administrativas (UAs) no Django Admin, permitindo ao Gestor de Patrimônio visualizar e exportar dados em múltiplos formatos (PDF, Excel, CSV).

## 🎯 Objetivos

- Permitir exportação de relatório consolidado das UAs cadastradas
- Gerar relatórios em formatos PDF (customizado), Excel e CSV
- Incluir rodapé institucional com data de emissão, nome e RF do usuário
- Garantir controle de acesso (apenas Gestor de Patrimônio)
- Desabilitar funcionalidade de importação

## Alterações Técnicas

### Arquivos Criados
- **`dados_comuns/formats.py`** - Geração customizada de PDF com ReportLab
- **`dados_comuns/resources.py`** - Estrutura de exportação Excel/CSV
- **`dados_comuns/tests/tests_exportacao_unidades.py`** - Suite de 10 testes

### Arquivos Modificados
- **`dados_comuns/admin.py`** - Herda de `ImportExportModelAdmin`, adiciona permissões de exportação e formatos disponíveis

## 🔒 Controle de Acesso

### Regras de Permissão
- ✅ **Gestor de Patrimônio:** Pode exportar relatórios em todos os formatos
- ❌ **Operador de Inventário:** Sem permissão de exportação
- ❌ **Todos os usuários:** Importação desabilitada permanentemente

## 📊 Formatos de Exportação

### 1. PDF (Customizado)
- **Layout:** A4 com margens de 0.3cm (laterais) e 0.9cm (topo/rodapé)
- **Cabeçalho:** Logos institucionais + título + subtítulo
- **Tabela:** 4 colunas com formatação customizada
- **Rodapé:** Data, usuário, RF, número da página
- **Paginação:** Automática com quebra de linha inteligente
- **Encoding:** Binary (application/pdf)

### 2. Excel (XLSX/XLS)
- **Colunas:** Código, Sigla, Nome, Status
- **Status:** Exibido como texto legível ("Ativa"/"Inativa")
- **Ordem:** Preservada conforme definição no resource

### 3. CSV
- **Separador:** Vírgula (padrão)
- **Encoding:** UTF-8
- **Compatível:** Excel, Google Sheets, LibreOffice

## 📝 Campos Exportados

| Campo | Descrição | Alinhamento (PDF) |
|-------|-----------|-------------------|
| **Código** | Código da UA (ex: "01.01.01.0001") | Centro |
| **Sigla** | Sigla da UA (ex: "SME") | Esquerda |
| **Nome** | Nome completo da UA | Esquerda |
| **Status** | "Ativa" ou "Inativa" | Centro |

## 🎨 Layout do PDF

### Cabeçalho
```
[Logo SME]     Relatório de Unidades Administrativas      [Logo PMSP]
            Secretaria Municipal de Educação - Prefeitura de São Paulo
```

### Rodapé
```
Emitido em: 27/11/2025 15:30 | Por: José da Silva - RF: 123456        Página 1
```

## 🔄 Fluxo de Uso

1. Usuário Gestor acessa Django Admin
2. Navega para "Unidades Administrativas"
3. Aplica filtros desejados (status, busca)
4. Clica em botão "Exportar"
5. Seleciona formato (PDF, XLSX, XLS ou CSV)
6. Download automático do arquivo gerado
7. Arquivo contém:
   - Todos os registros filtrados
   - Rodapé com dados do usuário e data/hora
   - Formatação institucional (PDF)

## 🧪 Testes

### Execução
```bash
# Docker
docker compose -f docker-compose.yml exec web python manage.py test dados_comuns.tests.tests_exportacao_unidades

# Local
python manage.py test dados_comuns.tests.tests_exportacao_unidades
```

**Cobertura de testes:**
1. `test_pdf_gerado_com_estrutura_valida` - Valida estrutura PDF com RF
2. `test_pdf_gerado_sem_rf_cadastrado` - Valida PDF sem RF cadastrado
3. `test_exportacao_excel_com_status_legivel` - Verifica status em Excel
4. `test_formatos_exportacao_disponiveis` - Valida formatos (CSV, XLSX, PDF)
5. `test_importacao_desabilitada` - Confirma bloqueio de importação
6. `test_campos_exportados_ordem_correta` - Verifica ordem dos campos
7. `test_pdf_paginacao_multiplas_paginas` - Testa paginação (50+ registros)
8. `test_operador_nao_pode_exportar` - Valida restrição de acesso
9. `test_gestor_pode_exportar` - Valida permissão de gestor
10. `test_quantidade_registros_exportados` - Valida contagem correta

### Cobertura
- ✅ Estrutura e conteúdo de PDFs
- ✅ Tratamento de RF ausente
- ✅ Exportação Excel com status legível
- ✅ Formatos disponíveis
- ✅ Importação bloqueada
- ✅ Ordem de campos
- ✅ Paginação múltiplas páginas
- ✅ Controle de permissões (Gestor vs Operador)
- ✅ Contagem de registros

### Teste Manual
1. Acesse o sistema
2. Login como Gestor de Patrimônio
3. Acesse "Unidades Administrativas"
4. Clique em "Exportar"
5. Teste cada formato: PDF, XLSX, XLS, CSV
6. Verifique rodapé do PDF com seus dados
7. Tente acessar como Operador (deve falhar)

## ✅ Checklist

- [x] Código implementado e testado
- [x] Testes unitários criados (9 casos)
- [x] Todos os testes passando
- [x] Controle de permissões validado
- [x] Importação desabilitada
- [x] PDF com formatação institucional
- [x] Excel/CSV funcionais
- [x] Rodapé com dados do usuário
- [x] Paginação testada
- [x] Documentação criada
