### PR TITLE
Feature (138396) Parametrização de Prazo do Inventário

### DIFF
--- a/inventario/models.py
+++ b/inventario/models.py
@@ -1,5 +1,6 @@
 from django.core.exceptions import ValidationError
 from django.db import models
+from django.db.models import Q
 from django.utils import timezone
 
 from bem_patrimonial.models import BemPatrimonial
@@ -38,10 +39,65 @@ class ParametroInventarioAnual(models.Model):
         constraints = [
             models.UniqueConstraint(
                 fields=["ano_referencia"],
-                condition=models.Q(ativo=True),
+                condition=Q(ativo=True),
                 name="unique_parametro_inventario_anual_ativo_por_ano",
             )
         ]
+        ordering = ["-ano_referencia", "-periodo_inicial"]
+
+    def __str__(self):
+        return (
+            f"{self.ano_referencia} | "
+            f"{self.periodo_inicial:%d/%m/%Y} → {self.periodo_final:%d/%m/%Y}"
+        )
+
+    def clean(self):
+        super().clean()
+
+        if not self.periodo_inicial or not self.periodo_final:
+            raise ValidationError("Período inicial e período final são obrigatórios.")
+
+        if self.periodo_inicial > self.periodo_final:
+            raise ValidationError(
+                {
+                    "periodo_final": "O período final deve ser maior ou igual ao período inicial."
+                }
+            )
+
+        conflito = ParametroInventarioAnual.objects.filter(
+            ano_referencia=self.ano_referencia
+        ).exclude(pk=self.pk)
+
+        conflito = conflito.filter(
+            Q(periodo_inicial__lte=self.periodo_final)
+            & Q(periodo_final__gte=self.periodo_inicial)
+        )
+
+        if conflito.exists():
+            raise ValidationError(
+                "Já existe um período cadastrado que se sobrepõe a este intervalo."
+            )
+
+        if self.ativo:
+            ja_ativo = ParametroInventarioAnual.objects.filter(
+                ano_referencia=self.ano_referencia,
+                ativo=True,
+            ).exclude(pk=self.pk)
+
+            if ja_ativo.exists():
+                raise ValidationError("Já existe um parâmetro ativo para este ano.")
+
+    def save(self, *args, **kwargs):
+        self.full_clean()
+        super().save(*args, **kwargs)
+
+    @property
+    def esta_vigente(self):
+        """
+        Indica se o período está em aberto no dia atual.
+        """
+        hoje = timezone.localdate()
+        return self.periodo_inicial <= hoje <= self.periodo_final
 
 
 class InventarioUA(models.Model):


### PR DESCRIPTION
# Parametrização do período do inventário — O que foi feito e regras

## História
- Criar na **home** e no **menu lateral** o item **Inventário**, com sub-menu **Parametrização do período do inventário**.
- Exibir **listagem** dos períodos já cadastrados.
- Permitir **edição apenas do período do ano vigente**.
- Permitir **cadastro** de novo período informando **data inicial (De)** e **data final (Até)** (datepicker).
- Permitir **múltiplos períodos no mesmo ano**, **sem sobreposição**.
- Apesar de permitir múltiplos períodos, o sistema deve considerar **sempre se há um período em aberto** para cadastro/uso.
- O **botão de conciliação do inventário** deve ficar **travado/destravado** conforme o parâmetro cadastrado pelo Gestor de Patrimônio (História **#136831**).

---

## Implementação (Back-end)

### Model
- Criado/ajustado o model **`ParametroInventarioAnual`** com:
  - `ano_referencia` (ano do inventário anual)
  - `periodo_inicial` (De)
  - `periodo_final` (Até)
  - `ativo` (flag)
- Regra: **apenas 1 parâmetro ativo por ano** (constraint com `condition=Q(ativo=True)`).

### Regras de validação
1. **Obrigatório existir parâmetro ativo** para o ano corrente quando o fluxo exigir validação por período.
2. **Janela permitida**:
   - A data atual (`timezone.localdate()`) deve estar **entre `periodo_inicial` e `periodo_final`** para permitir ações sensíveis (ex.: criar/fechar inventário anual; liberar conciliação).
3. **Edição apenas do ano vigente**:
   - Períodos de anos anteriores devem ficar **somente leitura** (sem alteração).
4. **Múltiplos períodos no ano, sem sobreposição**:
   - Ao criar/editar um período do mesmo `ano_referencia`, validar que:
     - `periodo_inicial <= periodo_final`
     - Não pode existir outro período com interseção de datas.
   - Interseção típica:
     - Novo período `[ini, fim]` conflita com existente `[ini2, fim2]` se:
       - `ini <= fim2` e `fim >= ini2`
   - A validação ignora o próprio registro em edição (quando houver `pk`).
5. **Período em aberto**
   - É permitido ter múltiplos períodos cadastrados no ano, **porém** o sistema deve identificar se **existe período vigente (aberto)**:
     - Período em aberto = `periodo_inicial <= hoje <= periodo_final`
   - O sistema deve **usar o período vigente** como referência para liberar ações (ex.: conciliação), e impedir abrir fluxo fora do período.

---

## Implementação (Admin / UI)

### Menu e Home
- Adicionado item **Inventário** na home e no menu lateral.
- Sub-menu: **Parametrização do período do inventário** apontando para a listagem de `ParametroInventarioAnual`.

### Tela de listagem
- Exibe:
  - Ano de referência
  - Período (De / Até)
  - Ativo
- Filtros por ano e ativo.
- Ordenação por ano (desc) e ativo.

### Edição
- **Apenas o ano vigente** pode ser editado (datas).
- Anos anteriores: edição bloqueada (somente leitura).

### Cadastro
- Form com datepicker:
  - **De** (`periodo_inicial`)
  - **Até** (`periodo_final`)
- Validações:
  - datas obrigatórias
  - sem sobreposição
  - consistência de intervalo

---

## Integração com Inventário e Conciliação (regras principais)

### 1) Bloqueio/desbloqueio por período (História #136831)
- O botão/ação de **conciliação** deve ficar:
  - **Desabilitado** se **não existir período vigente** (hoje fora do intervalo).
  - **Habilitado** quando houver **período vigente** para o ano corrente.
- Mensagem sugerida quando bloqueado:
  - “Conciliação indisponível: fora do período parametrizado do inventário.”

### 2) Inventário anual: criação/fechamento condicionado ao período
- Para inventário do tipo **ANUAL**:
  - Valida a existência do parâmetro ativo do ano corrente.
  - Valida se **hoje** está dentro do intervalo.
- Para inventário do tipo **EVENTUAL**:
  - Período do inventário é definido por `periodo_final` do próprio inventário (não depende do parâmetro anual para exigir datas).

### 3) Regra “período em aberto”
- Mesmo com múltiplos períodos cadastrados:
  - A permissão de ações (ex.: conciliação, criação/fechamento anual) segue **o período vigente**.
  - Se **nenhum** período estiver vigente, as ações ficam bloqueadas.

---

## Mensagens de erro/validação (padrões sugeridos)
- Sobreposição:
  - “Já existe um período cadastrado que se sobrepõe a este intervalo.”
- Fora do período:
  - “A ação só pode ser realizada entre DD/MM/AAAA e DD/MM/AAAA (período parametrizado).”
- Sem parâmetro ativo:
  - “Não existe parâmetro ativo para inventário anual do ano XXXX.”
- Edição de ano não vigente:
  - “Só é permitido editar o período do ano vigente.”
