### PR TITLE
Feature Filtro de bens baixados a mais de um ano

### DIFF
--- a/bem_patrimonial/admins/bem_patrimonial.py
+++ b/bem_patrimonial/admins/bem_patrimonial.py
@@ -5,6 +5,7 @@ from django.db.models import OuterRef, Subquery
 from django.http import HttpResponseRedirect
 from django.urls import reverse
 from django.utils.html import format_html
+from django.utils import timezone
 
 from bem_patrimonial.admins.actions.extracao_numeros import (
     aplicar_extracao_numero,
@@ -13,6 +14,7 @@ from bem_patrimonial.admins.actions.extracao_numeros import (
 from bem_patrimonial.admins.filters.bem_patrimonial_filters import SemNumeroFilter
 from bem_patrimonial.admins.forms.bem_patrimonial_form import BemPatrimonialAdminForm
 from bem_patrimonial.models import (
+    BaixaFisicaBensItem,
     BemPatrimonial,
     StatusBemPatrimonial,
 )
@@ -28,6 +30,9 @@ from django.contrib.contenttypes.admin import GenericTabularInline
 from django.db.models.functions import Cast
 from bem_patrimonial import constants
 from dados_comuns.models import HistoricoGeral, UnidadeAdministrativa
+from bem_patrimonial.admins.filters.baixados_periodo_filter import (
+    BaixadosMaisDeUmPeriodoFilter,
+)
 
 
 @admin.action(description="Aprovar bens selecionados")
@@ -218,6 +223,7 @@ class BemPatrimonialAdmin(ImportExportModelAdmin):
         SemNumeroFilter,
         "numero_formato_antigo",
         ("criado_em", DateRangeFilter),
+        BaixadosMaisDeUmPeriodoFilter,
     )
 
     readonly_fields = (
@@ -463,6 +469,28 @@ class BemPatrimonialAdmin(ImportExportModelAdmin):
         else:
             qs = qs.none()
 
+        baixa_data_sq = (
+            BaixaFisicaBensItem.objects.filter(bem_id=OuterRef("pk"))
+            .order_by("-baixa__data_baixa")
+            .values("baixa__data_baixa")[:1]
+        )
+        qs = qs.annotate(
+            baixa_data=Subquery(baixa_data_sq),
+        )
+        is_changelist = (
+            request.resolver_match
+            and request.resolver_match.url_name.endswith("_changelist")
+        )
+
+        if is_changelist and "baixados_mais_de_um_periodo" not in request.GET:
+            ano_corrente = timezone.localdate().year
+            ano_limite = ano_corrente - 1
+
+            qs = qs.exclude(
+                status=constants.BAIXA_FISICA,
+                baixa_data__year__lt=ano_limite,
+            )
+
         ct = ContentType.objects.get_for_model(BemPatrimonial)
         pk_as_char = Cast(OuterRef("pk"), output_field=models.CharField())
 
@@ -487,6 +515,21 @@ class BemPatrimonialAdmin(ImportExportModelAdmin):
             queryset = queryset.filter(unidade_administrativa=ua_user)
         else:
             queryset = queryset.none()
+
+        baixa_data_sq = (
+            BaixaFisicaBensItem.objects.filter(bem_id=OuterRef("pk"))
+            .order_by("-baixa__data_baixa")
+            .values("baixa__data_baixa")[:1]
+        )
+        queryset = queryset.annotate(baixa_data=Subquery(baixa_data_sq))
+
+        if "baixados_mais_de_um_periodo" not in request.GET:
+            ano_corrente = timezone.localdate().year
+            ano_limite = ano_corrente - 1
+            queryset = queryset.exclude(
+                status=constants.BAIXA_FISICA,
+                baixa_data__year__lt=ano_limite,
+            )
 
         return queryset
 

--- a/bem_patrimonial/admins/filters/baixados_periodo_filter.py
+++ b/bem_patrimonial/admins/filters/baixados_periodo_filter.py
@@ -1,0 +1,37 @@
+from django.contrib import admin
+from django.utils import timezone
+
+from bem_patrimonial import constants
+
+
+class BaixadosMaisDeUmPeriodoFilter(admin.SimpleListFilter):
+    title = "Baixados a mais de um período"
+    parameter_name = "baixados_mais_de_um_periodo"
+
+    def lookups(self, request, model_admin):
+        return (
+            ("1", "Sim"),
+            ("0", "Não"),
+        )
+
+    def queryset(self, request, queryset):
+        val = self.value()
+        if val not in ("0", "1"):
+            return queryset
+
+        ano_corrente = timezone.localdate().year
+        ano_minimo_visivel = ano_corrente - 1  # período = ano anterior ao corrente
+
+        # depende de queryset já anotado com "baixa_data"
+        if val == "1":
+            # antigos (antes do período)
+            return queryset.filter(
+                status=constants.BAIXA_FISICA,
+                baixa_data__year__lt=ano_minimo_visivel,
+            )
+
+        # do período em diante (2025 e 2026 quando corrente=2026)
+        return queryset.filter(
+            status=constants.BAIXA_FISICA,
+            baixa_data__year__gte=ano_minimo_visivel,
+        )


### PR DESCRIPTION
# Filtro de Bens Baixados por Período (Admin Django)

## Objetivo

Implementar no **Django Admin** de Bens Patrimoniais uma regra para:

- **Não exibir por padrão** bens baixados há mais de um período;
- Permitir **filtragem manual** desses bens;
- **Manter acesso ao detalhe** do bem via URL (não gerar erro de “objeto não existe”);
- Garantir consistência entre **listagem**, **filtro** e **exportação**.

---

## Conceito de Período

- **Período** = **ano anterior ao ano corrente**
- Exemplo:
  - Ano corrente: **2026**
  - Período válido: **2025**
  - **Mostrar por padrão**: bens baixados em **2025 e 2026**
  - **Ocultar por padrão**: bens baixados em **2024 ou antes**

Formalmente:

ano_minimo_visivel = ano_corrente - 1

---

## Regra de Negócio Aplicada

### Comportamento padrão (sem filtro selecionado)

- A **listagem** de bens:
  - Exibe bens ativos normalmente;
  - Exibe bens com `BAIXA_FISICA` **somente se**:
    - `ano(data_baixa) >= (ano_corrente - 1)`
- Bens baixados antes desse período **não aparecem por padrão**.

### Comportamento com filtro aplicado

Filtro **“Baixados a mais de um período”**:

- **Sim** → Lista somente bens baixados **antes** do período
- **Não** → Lista somente bens baixados **do período em diante**

---

## Implementação Técnica

### Anotação da Data de Baixa

A data de baixa (`data_baixa`) é obtida via relacionamento com `BaixaFisicaBensItem`
e `BaixaFisicaBemPatrimonial`, utilizando `Subquery` para recuperar a data mais recente.

---

### Filtro Customizado no Admin

Arquivo: `bem_patrimonial/admins/filters/baixados_periodo_filter.py`

Implementa um `SimpleListFilter` para permitir ao usuário listar bens
baixados fora do período padrão.

---

### Aplicação do Default Apenas no Changelist

O filtro automático é aplicado **somente na listagem** (`changelist`),
não afetando o acesso direto ao detalhe do bem (`change_view`).

---

### Exportação

A mesma regra de período é aplicada ao export quando o filtro não é informado,
mantendo coerência entre tela e relatórios.

---

## Benefícios

- Regra de negócio clara
- Nenhum impacto em URLs existentes
- Coerência entre listagem e exportação
- Manutenção simples
- Preserva histórico dos dados
