### PR TITLE
Feature 141851 Permitir RF maiuscula e minuscula no inicio

### DIFF
--- a/usuario/models.py
+++ b/usuario/models.py
@@ -15,8 +15,8 @@ class Usuario(AbstractUser):
         blank=True,
         validators=[
             RegexValidator(
-                regex=r"^[A-Z][0-9]+$",
-                message="RF deve começar com uma letra maiúscula e conter apenas números após ela. Ex: F53399."
+                regex=r"^[A-Za-z][0-9]+$",
+                message="RF deve começar com uma letra e conter apenas números após ela. Ex: F53399 ou f53399."
             )
         ],
     )

--- a/usuario/tests/tests_models.py
+++ b/usuario/tests/tests_models.py
@@ -217,17 +217,18 @@ class UsuarioRFFieldTestCase(TestCase):
         usuario = Usuario(
             username="user_rf_invalid",
             nome="Usuario RF Invalido",
-            rf="FG093393",
+            rf="FG093393",  # duas letras → inválido
             email="rfinvalid@teste.com",
             unidade_administrativa=self.unidade,
         )
         usuario.set_password("Senha@123")
+
         with self.assertRaises(ValidationError) as context:
             usuario.full_clean()
 
         self.assertIn("rf", context.exception.error_dict)
         self.assertIn(
-            "RF deve começar com uma letra maiúscula e conter apenas números após ela. Ex: F53399.",
+            "RF deve começar com uma letra e conter apenas números após ela. Ex: F53399 ou f53399.",
             str(context.exception),
         )
 


### PR DESCRIPTION
# 141851 – Ajuste na validação do campo RF (letra maiúscula ou minúscula)

## 📋 Descrição

Ajuste na regra de validação do campo **RF** do modelo de usuário para permitir
que o identificador comece tanto com **letra maiúscula quanto minúscula**,
seguida exclusivamente por números.

O objetivo é tornar a validação mais flexível sem comprometer o padrão esperado
do identificador funcional.

---

## 🎯 Objetivo

Permitir que o campo RF aceite os seguintes formatos válidos:

- `F53399` ✅
- `f53399` ✅

E rejeite formatos inválidos, como:

- `FG093393` ❌ (mais de uma letra)
- `B099090P` ❌ (letra no final)
- `123456` ❌ (não inicia com letra)
- `F12-345` ❌ (caractere especial)

---

## 🔧 Alterações Realizadas

### Model (`usuario/models.py`)

Atualização do validador Regex do campo `rf`:

```python
rf = models.CharField(
    "RF",
    max_length=20,
    null=True,
    blank=True,
    validators=[
        RegexValidator(
            regex=r"^[A-Za-z][0-9]+$",
            message=(
                "RF deve começar com uma letra e conter apenas números após ela. "
                "Ex: F53399 ou f53399."
            )
        )
    ],
)