### PR TITLE
Feature 142229 Ajuste no processo de abertura e fechamento automatico e finalizacao das conciliacoes

### DIFF
--- a/config/templates/admin/inventario/conciliacaoua/change_form.html
+++ b/config/templates/admin/inventario/conciliacaoua/change_form.html
@@ -2,16 +2,37 @@
 {% load i18n admin_urls %}
 
 {% block object-tools-items %}
-	{{ block.super }}
-	{% if original %}
-		<li>
-			<a
-				href="{% url 'download_conciliacao_pdf' original.pk %}"
-				class="button"
-				style="background: #0b5ed7; border-color: #0b5ed7; color: #fff;"
-			>
-				Exportar Conciliação
-			</a>
-		</li>
-	{% endif %}
+  {{ block.super }}
+  {% if original %}
+
+    {% if original.esta_aberto %}
+      <li>
+        <form id="finalizar-conciliacao-form" method="post"
+              action="{% url 'admin:inventario_conciliacaoua_finalizar' original.pk %}"
+              style="display:none;">
+          {% csrf_token %}
+        </form>
+
+        <a
+          href="#"
+          class="button"
+          style="background:#ba2121; border-color:#ba2121; color:#fff;"
+          onclick="if (confirm('Esta ação é irreversível. Deseja finalizar a conciliação agora?')) { document.getElementById('finalizar-conciliacao-form').submit(); } return false;"
+        >
+          Finalizar Conciliação
+        </a>
+      </li>
+    {% endif %}
+
+    <li>
+      <a
+        href="{% url 'download_conciliacao_pdf' original.pk %}"
+        class="button"
+        style="background:#0b5ed7; border-color:#0b5ed7; color:#fff;"
+      >
+        Exportar Conciliação
+      </a>
+    </li>
+
+  {% endif %}
 {% endblock %}

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -35,7 +35,7 @@ services:
       dockerfile: Dockerfile.dev
     container_name: sme_bens_fisicos_web
     command: >
-      python -m debugpy --wait-for-client --listen 0.0.0.0:5678
+      python -Xfrozen_modules=off -m debugpy --wait-for-client --listen 0.0.0.0:5678
       manage.py runserver 0.0.0.0:8000
     volumes:
       - .:/code

--- a/inventario/admin.py
+++ b/inventario/admin.py
@@ -176,7 +176,7 @@ class ItemConciliacaoInline(admin.TabularInline):
 class ConciliacaoUAAdmin(admin.ModelAdmin):
     form = ConciliacaoUAAdminForm
     change_form_template = "admin/inventario/conciliacaoua/change_form.html"
-    
+
     list_display = [
         "numero_conciliacao",
         "unidade_administrativa",
@@ -209,7 +209,7 @@ class ConciliacaoUAAdmin(admin.ModelAdmin):
     ]
 
     inlines = [ItemConciliacaoInline]
-    actions = ["action_finalizar_conciliacao"]
+    actions = []
 
     class Media:
         css = {
@@ -229,9 +229,7 @@ class ConciliacaoUAAdmin(admin.ModelAdmin):
         return False
 
     def get_actions(self, request):
-        actions = super().get_actions(request)
-        actions.pop("delete_selected", None)
-        return actions
+        return {}
 
     def get_form(self, request, obj=None, **kwargs):
         """
@@ -384,7 +382,9 @@ class ConciliacaoUAAdmin(admin.ModelAdmin):
                 situacao=constants.NAO_ENCONTRADO
             ).count(),
             "Divergentes": obj.itens.filter(situacao=constants.DIVERGENTE).count(),
-            "Em processo de baixa": obj.itens.filter(situacao=constants.EM_PROCESSO_BAIXA_FISICA).count(),
+            "Em processo de baixa": obj.itens.filter(
+                situacao=constants.EM_PROCESSO_BAIXA_FISICA
+            ).count(),
             "Baixa Física": obj.itens.filter(situacao=constants.BAIXA_FISICA).count(),
         }
 
@@ -409,36 +409,6 @@ class ConciliacaoUAAdmin(admin.ModelAdmin):
     acao_visualizar.short_description = "Ação"
     acao_visualizar.allow_tags = True
 
-    @admin.action(description="Finalizar conciliacões selecionadas")
-    def action_finalizar_conciliacao(self, request, queryset):
-        finalizados = 0
-        erros = 0
-
-        for conciliacao in queryset:
-            if conciliacao.status == constants.CONCILIACAO_FECHADO:
-                erros += 1
-                continue
-
-            try:
-                finalizar_conciliacao(conciliacao, request.user)
-                finalizados += 1
-            except Exception as e:
-                erros += 1
-                messages.error(
-                    request,
-                    f"Erro ao finalizar {conciliacao.numero_conciliacao}: {str(e)}",
-                )
-
-        if finalizados > 0:
-            messages.success(
-                request, f"{finalizados} conciliação(ões) finalizada(s) com sucesso"
-            )
-
-        if erros > 0:
-            messages.warning(
-                request, f"{erros} conciliação(s) não puderam ser finalizadas"
-            )
-
     def get_urls(self):
         urls = super().get_urls()
         custom_urls = [
@@ -452,8 +422,32 @@ class ConciliacaoUAAdmin(admin.ModelAdmin):
                 self.admin_site.admin_view(self.excluir_ocorrencia_view),
                 name="inventario_item_excluir_ocorrencia",
             ),
+            path(
+                "<int:pk>/finalizar/",
+                self.admin_site.admin_view(self.finalizar_conciliacao_view),
+                name="inventario_conciliacaoua_finalizar",
+            ),
         ]
         return custom_urls + urls
+
+    def finalizar_conciliacao_view(self, request, pk: int):
+        obj = self.get_object(request, pk)
+        if not obj:
+            messages.error(request, "Conciliação não encontrada.")
+            return redirect("admin:inventario_conciliacaoua_changelist")
+
+        if not obj.esta_aberto:
+            messages.warning(request, "Conciliação já está finalizada.")
+            return redirect("admin:inventario_conciliacaoua_change", obj.pk)
+
+        if request.method == "POST":
+            try:
+                finalizar_conciliacao(obj, request.user)
+                messages.success(request, "Conciliação finalizada com sucesso.")
+            except Exception as e:
+                messages.error(request, f"Erro ao finalizar conciliação: {e}")
+
+        return redirect("admin:inventario_conciliacaoua_change", obj.pk)
 
     def registrar_ocorrencia_view(self, request, item_id):
         try:
@@ -575,5 +569,5 @@ class ConciliacaoUAAdmin(admin.ModelAdmin):
         return render(request, "admin/conciliacao/excluir_ocorrencia.html", context)
 
     def changelist_view(self, request, extra_context=None):
-        # processar_conciliacao_anual_automatica(request.user)
+        processar_conciliacao_anual_automatica(request.user)
         return super().changelist_view(request, extra_context)

--- a/inventario/forms.py
+++ b/inventario/forms.py
@@ -16,6 +16,14 @@ class ConciliacaoUAAdminForm(forms.ModelForm):
         self.request = kwargs.pop("request", None)
         super().__init__(*args, **kwargs)
 
+        if not self.instance.pk:
+            if "tipo" in self.fields:
+                self.fields["tipo"].choices = [
+                    (constants.CONCILIACAO_EVENTUAL, "Eventual"),
+                ]
+                self.fields["tipo"].initial = constants.CONCILIACAO_EVENTUAL
+                self.fields["tipo"].disabled = True
+                
         if "unidade_administrativa" in self.fields:
             self.fields["unidade_administrativa"].required = True
         if "tipo" in self.fields:

--- a/inventario/utils_conciliacao/conciliacao_automatica.py
+++ b/inventario/utils_conciliacao/conciliacao_automatica.py
@@ -87,14 +87,14 @@ def processar_conciliacao_anual_automatica(usuario):
         eventual_aberta = ConciliacaoUA.objects.filter(
             unidade_administrativa=ua,
             tipo=constants.CONCILIACAO_EVENTUAL,
-            status=constants.CONCILIACAO_EM_ABERTO,
-            periodo_final__year=ano_referencia,
+            status=constants.CONCILIACAO_EM_ABERTO
         ).first()
 
         if inicio <= hoje <= fim:
 
-            if eventual_aberta:
+            if eventual_aberta and not anual_existente:
                 fechar_pelo_sistema(eventual_aberta)
+            
             if not anual_existente:
                 criar_conciliacao_anual(ua, ano_referencia)
 


### PR DESCRIPTION
# 🧾 Conciliação Anual Automática

## 🎯 Contexto e Objetivo

Esta entrega implementa melhorias no fluxo de **Conciliação de Inventário**, atendendo à necessidade de **automatizar a abertura da conciliação anual**, simplificar a criação de conciliações eventuais e melhorar a experiência do usuário no Django Admin.

A funcionalidade atende aos perfis:
- **Super-usuário**
- **Gestor de Patrimônio**
- **Operador de Inventário**

---

## 📌 Requisitos da História

1. **Abertura automática da conciliação anual**
   - O sistema deve abrir automaticamente uma conciliação anual para cada Unidade Administrativa no dia **01/01**.
   - Quando a conciliação anual é aberta, todas as conciliações **eventuais ainda abertas** devem ser **encerradas automaticamente**, garantindo apenas uma conciliação ativa.

2. **Criação manual apenas de conciliações eventuais**
   - Usuários não podem criar conciliações do tipo **Anual** manualmente.
   - O formulário de criação deve permitir apenas o tipo **Eventual**, fixado automaticamente.

3. **Finalização de conciliação via tela interna**
   - A ação de finalizar conciliações via menu de ações em lote deve ser removida.
   - A finalização passa a ocorrer diretamente na **tela interna da conciliação**, por meio de um botão dedicado.

---

## ✨ Principais Mudanças Implementadas

### 🔄 Abertura Automática da Conciliação Anual

- Implementado processamento automático da conciliação anual ao acessar a listagem do Admin.
- O sistema:
  - Verifica se já existe conciliação anual para a UA.
  - Fecha conciliações eventuais abertas quando necessário.
  - Cria automaticamente a conciliação anual dentro do período permitido.

**Arquivo:** `inventario/utils_conciliacao/conciliacao_automatica.py`  
**Ponto de entrada:** `processar_conciliacao_anual_automatica`

---

### 📝 Restrição de Criação Manual

- Ajuste no formulário do Admin para:
  - Fixar o campo **Tipo** como `Eventual`.
  - Remover a opção de escolha pelo tipo `Anual`.
  - Desabilitar o campo para evitar alteração manual.

**Arquivo:** `inventario/forms.py`  
**Classe:** `ConciliacaoUAAdminForm`

---

### 🖥️ Novo Botão “Finalizar Conciliação”

- Removida a ação em lote “Finalizar conciliações selecionadas”.
- Criada rota dedicada no Admin para finalizar uma conciliação individual.
- Incluído botão **Finalizar Conciliação** na tela interna, ao lado do botão **Exportar**.
- A ação utiliza POST com CSRF e confirmação explícita do usuário.

**Arquivos envolvidos:**
- `inventario/admin.py`
- `config/templates/admin/inventario/conciliacaoua/change_form.html`

---

### 🚫 Remoção de Ações em Lote

- Desativadas todas as actions no changelist de conciliações.
- Garante que a finalização ocorra apenas de forma controlada e individual.

---

## 📜 Regras de Negócio Aplicadas

- Apenas **uma conciliação ativa** por Unidade Administrativa.
- Conciliação anual:
  - Criada automaticamente.
  - Nunca criada manualmente.
- Conciliação eventual:
  - Pode ser criada manualmente.
  - Encerrada automaticamente quando a anual é aberta.
- Conciliações fechadas:
  - Não permitem edição.
  - Não exibem botão de salvar.

---

## ✅ Resultado Final

- Fluxo de conciliação mais simples, seguro e guiado.
- Redução de erros operacionais.
- Total aderência às regras do processo anual de inventário.
- Interface administrativa mais clara e objetiva para os usuários.

---

📎 **Observação:**  
A automação anual foi integrada ao fluxo normal do Admin sem dependência de tarefas agendadas externas, garantindo execução consistente ao longo do uso do sistema.
