### PR TITLE
Feature 142229 Paramentro de finalizacao automatica

### DIFF
--- a/inventario/models.py
+++ b/inventario/models.py
@@ -239,6 +239,9 @@ class ConciliacaoUA(models.Model):
         if self.tipo != constants.CONCILIACAO_ANUAL:
             return
 
+        if self.pk:
+            return
+
         hoje = timezone.localdate()
         ano_referencia = self._get_ano_referencia()
         ano_corrente = hoje.year
@@ -259,7 +262,7 @@ class ConciliacaoUA(models.Model):
 
         if not (data_inicio <= hoje <= data_fim):
             raise ValidationError(
-                f"A conciliação anual {ano_referencia} só pode ser criada ou fechada entre "
+                f"A conciliação anual {ano_referencia} só pode ser criada entre "
                 f"{data_inicio:%d/%m/%Y} e {data_fim:%d/%m/%Y}."
             )
 
@@ -304,8 +307,6 @@ class ConciliacaoUA(models.Model):
     def finalizar(self, usuario):
         if self.status == constants.CONCILIACAO_FECHADO:
             return
-
-        self._validar_parametro_anual_por_data_atual()
 
         self.status = constants.CONCILIACAO_FECHADO
         self.fechado_por = usuario


### PR DESCRIPTION
# 🧾 Ajuste de Validação da Conciliação Anual 

## 🎯 Contexto e Objetivo

Este pull request complementa a implementação da **abertura automática da conciliação anual**, ajustando a regra de validação por período para refletir corretamente o fluxo de negócio definido.

O objetivo é garantir que:
- a **validação por período** seja aplicada **apenas na criação (abertura)** da conciliação anual;
- a **finalização** de uma conciliação anual **não seja bloqueada** após o término do período parametrizado.

---

## 📌 Problema Identificado

A validação `_validar_parametro_anual_por_data_atual` estava sendo aplicada tanto para **criação** quanto para **finalização** da conciliação anual.

Com isso, ao tentar **finalizar uma conciliação anual após o período final do parâmetro**, o sistema lançava erro, por exemplo:

> “A conciliação anual 2025 só pode ser criada ou fechada entre 01/01/2026 e 05/01/2026.”

Esse comportamento não condiz com a regra de negócio, pois:
- a conciliação anual **já existe**;
- só pode existir **uma conciliação anual por UA**;
- após criada, a única ação possível é **fechar**, inclusive após o período final.

---

## ✨ Ajustes Implementados

### 🔒 Validação restrita à criação da conciliação anual

- A validação por período foi ajustada para ocorrer **somente quando a conciliação anual está sendo criada**.
- Quando o registro já existe (`self.pk`), a validação não é aplicada.

**Arquivo:** `inventario/models.py`  
**Método:** `_validar_parametro_anual_por_data_atual`

```python
if self.pk:
    return
```

Com isso:
- ❌ Não é possível **abrir** conciliação anual fora do período permitido.
- ✅ É possível **finalizar** a conciliação anual mesmo após o período final.

---

### 🧹 Remoção da validação no fluxo de finalização

- A chamada à validação por período foi removida do método `finalizar`.
- O fechamento passa a depender apenas do status atual da conciliação.

**Método afetado:** `ConciliacaoUA.finalizar`

---

## 📜 Regras de Negócio Garantidas

- A conciliação anual:
  - só pode ser **criada** dentro do período parametrizado;
  - pode ser **finalizada a qualquer momento após sua criação**.
- O fechamento automático pelo sistema ocorre **após o período final**, conforme a automação já existente.
- Mantém-se a garantia de **uma única conciliação anual por Unidade Administrativa**.

---

## ✅ Resultado Final

- Correção de bloqueio indevido na finalização da conciliação anual.
- Regras de negócio alinhadas ao processo real de inventário.
- Fluxo mais robusto e previsível para usuários e automações.

---

📎 **Observação**  
Este PR é complementar à implementação principal da história **142229 – Abertura automática da conciliação anual**, focando exclusivamente no ajuste fino da validação por período.
