### PR TITLE
Refactor(136174): Deploy Teste -> Homologação

### DIFF
--- a/bem_patrimonial/admins/filters/movimentacao_filters.py
+++ b/bem_patrimonial/admins/filters/movimentacao_filters.py
@@ -7,11 +7,23 @@ from bem_patrimonial import constants
 
 
 class MovimentacaoAtrasadaFilter(admin.SimpleListFilter):
-    title = "Atraso"
+    title = "Movimentação atrasada"
     parameter_name = "atrasada"
 
     def lookups(self, request, model_admin):
-        return (("1", "Sim"),)
+        return (("1", "Sim"), ("0", "Não"))
+
+    def choices(self, changelist):
+        yield {
+            "selected": self.value() in (None, "0"),
+            "query_string": changelist.get_query_string({self.parameter_name: "0"}),
+            "display": "Não",
+        }
+        yield {
+            "selected": self.value() == "1",
+            "query_string": changelist.get_query_string({self.parameter_name: "1"}),
+            "display": "Sim",
+        }
 
     def queryset(self, request, queryset):
         if self.value() == "1":


### PR DESCRIPTION
Este pull request aprimora o filtro `MovimentacaoAtrasadaFilter` no Django Admin, tornando sua utilização mais clara e oferecendo maior controle aos usuários ao filtrar movimentações atrasadas.

## 🔍 Melhorias de usabilidade e opções do filtro

- O título do filtro foi alterado de **"Atraso"** para **"Movimentação atrasada"**, deixando mais explícito o propósito do filtro na interface.
- As opções retornadas em `lookups` foram ampliadas para incluir:
  - **"Sim"** — exibe apenas movimentações atrasadas
  - **"Não"** — exibe apenas movimentações não atrasadas
- A lógica de exibição das escolhas foi customizada para:
  - manter a seleção correta entre "Sim" e "Não",
  - gerar corretamente a query string correspondente,
  - exibir as duas opções de forma clara e consistente na lista do admin.

Com essas melhorias, o filtro se torna mais intuitivo e permite aos usuários analisar as movimentações com mais precisão, tanto atrasadas quanto não atrasadas.
