### PR TITLE
Feature(136171): Endpoints - Seleção de UO/UA para Atuação Após Logado

### DIFF
--- a/usuario/api_urls.py
+++ b/usuario/api_urls.py
@@ -9,6 +9,7 @@ from usuario.api_views import (
     PasswordChangeAPIView,
     FirstAccessPasswordChangeAPIView,
     UserProfileAPIView,
+    SelecionarUnidadeAdministrativaAPIView,
 )
 
 urlpatterns = [
@@ -17,6 +18,11 @@ urlpatterns = [
     path("token/refresh/", CustomTokenRefreshView.as_view(), name="token_refresh"),
     path("token/verify/", CustomTokenVerifyView.as_view(), name="token_verify"),
     path("me/", UserProfileAPIView.as_view(), name="user_profile"),
+    path(
+        "me/selecionar-ua/",
+        SelecionarUnidadeAdministrativaAPIView.as_view(),
+        name="selecionar_ua",
+    ),
     path(
         "password-reset/",
         PasswordResetRequestAPIView.as_view(),

--- a/usuario/api_views.py
+++ b/usuario/api_views.py
@@ -20,8 +20,13 @@ from usuario.serializers import (
     PasswordChangeSerializer,
     FirstAccessPasswordChangeSerializer,
     UserProfileSerializer,
+    SelecionarUnidadeAdministrativaSerializer,
 )
 from django.contrib.auth.tokens import PasswordResetTokenGenerator
+from django.db import transaction
+from django.contrib.contenttypes.models import ContentType
+from dados_comuns.models import HistoricoGeral
+from dados_comuns.utils import dict_changes
 
 
 def set_refresh_token_cookie(response, refresh_token):
@@ -411,3 +416,65 @@ class UserProfileAPIView(generics.RetrieveAPIView):
 
     def get_object(self):
         return self.request.user
+
+
+@extend_schema(
+    summary="Selecionar UA ativa",
+    description="Define a Unidade Administrativa ativa do usuario autenticado. Envie unidade_administrativa_id=null para selecionar UO (todas as UAs).",  # noqa: E501
+    request=SelecionarUnidadeAdministrativaSerializer,
+    responses={
+        200: UserProfileSerializer,
+        400: OpenApiResponse(description="Dados invalidos"),
+        401: OpenApiResponse(description="Nao autenticado"),
+    },
+    tags=["Autenticação"],
+)
+class SelecionarUnidadeAdministrativaAPIView(generics.GenericAPIView):
+    serializer_class = SelecionarUnidadeAdministrativaSerializer
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request, *args, **kwargs):
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        user = request.user
+        original = Usuario.objects.get(pk=user.pk)
+
+        ua = serializer.validated_data.get("ua_obj")
+        uo = serializer.validated_data.get("uo_obj")
+
+        update_fields = []
+        if user.unidade_administrativa_id != (ua.id if ua else None):
+            user.unidade_administrativa = ua
+            update_fields.append("unidade_administrativa")
+
+        if uo and user.unidade_orcamentaria_id != uo.id:
+            user.unidade_orcamentaria = uo
+            update_fields.append("unidade_orcamentaria")
+
+        with transaction.atomic():
+            if update_fields:
+                user.save(update_fields=update_fields)
+
+            changes = dict_changes(
+                original,
+                user,
+                fields=["unidade_administrativa", "unidade_orcamentaria"],
+            )
+            if changes:
+                ct = ContentType.objects.get_for_model(Usuario)
+                HistoricoGeral.objects.bulk_create(
+                    [
+                        HistoricoGeral(
+                            content_type=ct,
+                            object_id=str(user.pk),
+                            campo=field,
+                            valor_antigo=old,
+                            valor_novo=new,
+                            alterado_por=user,
+                        )
+                        for field, (old, new) in changes.items()
+                    ]
+                )
+
+        return Response(UserProfileSerializer(user).data, status=status.HTTP_200_OK)

--- a/usuario/serializers.py
+++ b/usuario/serializers.py
@@ -2,6 +2,8 @@ from rest_framework import serializers
 from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
 from django.contrib.auth.password_validation import validate_password
 from usuario.models import Usuario
+from dados_comuns.models import UnidadeAdministrativa, UnidadeOrcamentaria
+from dados_comuns.escopo import obter_unidade_orcamentaria_id_do_usuario
 
 
 class CustomTokenObtainPairSerializer(TokenObtainPairSerializer):
@@ -18,14 +20,6 @@ class CustomTokenObtainPairSerializer(TokenObtainPairSerializer):
             "is_gestor_patrimonio": self.user.is_gestor_patrimonio,
             "is_operador_inventario": self.user.is_operador_inventario,
             "must_change_password": self.user.must_change_password,
-            "unidade_administrativa": (
-                {
-                    "id": self.user.unidade_administrativa.id,
-                    "nome": self.user.unidade_administrativa.nome,
-                }
-                if self.user.unidade_administrativa
-                else None
-            ),
         }
 
         return data
@@ -144,7 +138,9 @@ class FirstAccessPasswordChangeSerializer(serializers.Serializer):
 class UserProfileSerializer(serializers.ModelSerializer):
     is_gestor_patrimonio = serializers.BooleanField(read_only=True)
     is_operador_inventario = serializers.BooleanField(read_only=True)
-    unidade_administrativa = serializers.SerializerMethodField()
+    uo_ativa = serializers.SerializerMethodField()
+    ua_ativa = serializers.SerializerMethodField()
+    opcoes_escopo = serializers.SerializerMethodField()
 
     class Meta:
         model = Usuario
@@ -157,12 +153,190 @@ class UserProfileSerializer(serializers.ModelSerializer):
             "is_gestor_patrimonio",
             "is_operador_inventario",
             "must_change_password",
-            "unidade_administrativa",
+            "uo_ativa",
+            "ua_ativa",
+            "opcoes_escopo",
         ]
         read_only_fields = fields
 
-    def get_unidade_administrativa(self, obj):
+    def get_uo_ativa(self, obj):
+        uo = obj.unidade_orcamentaria
+        if not uo and obj.unidade_administrativa:
+            uo = obj.unidade_administrativa.unidade_orcamentaria
+        if uo:
+            return {
+                "id": uo.id,
+                "codigo": uo.codigo,
+                "nome": uo.nome,
+                "label": f"{uo.codigo} - {uo.nome}",
+            }
+        return None
+
+    def get_ua_ativa(self, obj):
         ua = obj.unidade_administrativa
         if ua:
-            return {"id": ua.id, "nome": ua.nome}
+            return {
+                "id": ua.id,
+                "codigo": ua.codigo,
+                "nome": ua.nome,
+                "label": f"{ua.codigo} - {ua.nome}",
+            }
         return None
+
+    def get_opcoes_escopo(self, obj):
+        uos_qs = UnidadeOrcamentaria.objects.none()
+        uas_qs = UnidadeAdministrativa.objects.none()
+
+        if obj.is_superuser:
+            uos_qs = UnidadeOrcamentaria.objects.filter(ativa=True)
+            uas_qs = UnidadeAdministrativa.objects.filter(
+                status=UnidadeAdministrativa.ATIVA
+            )
+        elif obj.is_gestor_patrimonio:
+            uo_id = obter_unidade_orcamentaria_id_do_usuario(obj)
+            if uo_id:
+                uos_qs = UnidadeOrcamentaria.objects.filter(id=uo_id, ativa=True)
+                uas_qs = UnidadeAdministrativa.objects.filter(
+                    unidade_orcamentaria_id=uo_id,
+                    status=UnidadeAdministrativa.ATIVA,
+                )
+        elif obj.is_operador_inventario:
+            if obj.unidade_administrativa_id:
+                uas_qs = UnidadeAdministrativa.objects.filter(
+                    id=obj.unidade_administrativa_id,
+                    status=UnidadeAdministrativa.ATIVA,
+                )
+                uos_qs = UnidadeOrcamentaria.objects.filter(
+                    id=obj.unidade_administrativa.unidade_orcamentaria_id,
+                    ativa=True,
+                )
+
+        uas_qs = uas_qs.select_related("unidade_orcamentaria")
+        uas_por_uo = {}
+        for ua in uas_qs:
+            uas_por_uo.setdefault(ua.unidade_orcamentaria_id, []).append(
+                {
+                    "id": ua.id,
+                    "codigo": ua.codigo,
+                    "nome": ua.nome,
+                    "label": f"{ua.codigo} - {ua.nome}",
+                    "unidade_administrativa_id": ua.id,
+                    "unidade_orcamentaria_id": ua.unidade_orcamentaria_id,
+                }
+            )
+
+        permite_uo = bool(obj.is_superuser or obj.is_gestor_patrimonio)
+        grupos = []
+        for uo in uos_qs:
+            grupo = {
+                "uo": {
+                    "id": uo.id,
+                    "codigo": uo.codigo,
+                    "nome": uo.nome,
+                    "label": f"{uo.codigo} - {uo.nome}",
+                    "selecionavel": permite_uo,
+                    "unidade_administrativa_id": None,
+                    "unidade_orcamentaria_id": uo.id,
+                },
+                "uas": uas_por_uo.get(uo.id, []),
+            }
+            grupos.append(grupo)
+
+        return {
+            "grupos": grupos,
+        }
+
+
+class SelecionarUnidadeAdministrativaSerializer(serializers.Serializer):
+    unidade_administrativa_id = serializers.IntegerField(allow_null=True, required=True)
+    unidade_orcamentaria_id = serializers.IntegerField(allow_null=True, required=False)
+
+    def validate(self, attrs):
+        request = self.context.get("request")
+        user = getattr(request, "user", None)
+
+        if not user or not user.is_authenticated:
+            raise serializers.ValidationError("Usuario nao autenticado.")
+
+        ua_id = attrs.get("unidade_administrativa_id")
+        uo_id = attrs.get("unidade_orcamentaria_id")
+
+        ua = None
+        uo = None
+
+        if ua_id is not None:
+            try:
+                ua = UnidadeAdministrativa.objects.select_related(
+                    "unidade_orcamentaria"
+                ).get(id=ua_id)
+            except UnidadeAdministrativa.DoesNotExist:
+                raise serializers.ValidationError(
+                    {"unidade_administrativa_id": "Unidade Administrativa invalida."}
+                )
+            if ua.status != UnidadeAdministrativa.ATIVA:
+                raise serializers.ValidationError(
+                    {"unidade_administrativa_id": "Unidade Administrativa inativa."}
+                )
+            if uo_id is not None and ua.unidade_orcamentaria_id != uo_id:
+                raise serializers.ValidationError(
+                    {
+                        "unidade_orcamentaria_id": "Unidade Orcamentaria nao corresponde a Unidade Administrativa."
+                    }
+                )
+            uo = ua.unidade_orcamentaria
+            uo_id = uo.id
+        else:
+            if user.is_operador_inventario and not user.is_superuser:
+                raise serializers.ValidationError(
+                    "Operador nao pode selecionar Unidade Orcamentaria."
+                )
+
+            if uo_id is None:
+                uo_id = obter_unidade_orcamentaria_id_do_usuario(user)
+
+            if not uo_id:
+                raise serializers.ValidationError(
+                    {"unidade_orcamentaria_id": "Unidade Orcamentaria obrigatoria."}
+                )
+
+        if not user.is_superuser:
+            uo_usuario_id = obter_unidade_orcamentaria_id_do_usuario(user)
+            if uo_usuario_id and uo_id != uo_usuario_id:
+                raise serializers.ValidationError(
+                    "Usuario nao pode selecionar Unidade Orcamentaria diferente."
+                )
+
+            if (
+                user.is_operador_inventario
+                and ua
+                and user.unidade_administrativa_id != ua.id
+            ):
+                raise serializers.ValidationError(
+                    "Operador so pode selecionar a propria Unidade Administrativa."
+                )
+
+            if (
+                user.is_gestor_patrimonio
+                and ua
+                and uo_usuario_id
+                and ua.unidade_orcamentaria_id != uo_usuario_id
+            ):
+                raise serializers.ValidationError(
+                    "Gestor so pode selecionar UA da propria Unidade Orcamentaria."
+                )
+
+        if uo is None:
+            try:
+                uo = UnidadeOrcamentaria.objects.get(id=uo_id)
+            except UnidadeOrcamentaria.DoesNotExist:
+                raise serializers.ValidationError(
+                    {"unidade_orcamentaria_id": "Unidade Orcamentaria invalida."}
+                )
+        if not uo.ativa:
+            raise serializers.ValidationError(
+                {"unidade_orcamentaria_id": "Unidade Orcamentaria inativa."}
+            )
+
+        attrs["ua_obj"] = ua
+        attrs["uo_obj"] = uo
+        return attrs

--- a/usuario/tests/tests_escopo_api.py
+++ b/usuario/tests/tests_escopo_api.py
@@ -1,0 +1,264 @@
+from django.contrib.auth.models import Group
+from django.contrib.contenttypes.models import ContentType
+from rest_framework import status
+from rest_framework.test import APITestCase
+from itertools import count
+
+from dados_comuns.models import HistoricoGeral, UnidadeAdministrativa
+from dados_comuns.tests.factories import criar_ua, criar_uo
+from usuario.constants import GRUPO_GESTOR_PATRIMONIO, GRUPO_OPERADOR_INVENTARIO
+from usuario.models import Usuario
+
+
+class EscopoEndpointsTestCase(APITestCase):
+    _seq = count(1)
+
+    def setUp(self):
+        seq = next(self._seq)
+        uo1_codigo = f"UO-{seq:04d}-A"
+        uo2_codigo = f"UO-{seq:04d}-B"
+        ua1_codigo = f"UA-{seq:04d}-1"
+        ua2_codigo = f"UA-{seq:04d}-2"
+        ua3_codigo = f"UA-{seq:04d}-3"
+
+        self.uo1 = criar_uo(codigo=uo1_codigo, nome="UO 1")
+        self.uo2 = criar_uo(codigo=uo2_codigo, nome="UO 2")
+
+        self.ua1 = criar_ua(uo=self.uo1, codigo=ua1_codigo, sigla="UA1", nome="UA 1")
+        self.ua2 = criar_ua(uo=self.uo1, codigo=ua2_codigo, sigla="UA2", nome="UA 2")
+        self.ua3 = criar_ua(uo=self.uo2, codigo=ua3_codigo, sigla="UA3", nome="UA 3")
+
+        self.grupo_gestor = Group.objects.get_or_create(name=GRUPO_GESTOR_PATRIMONIO)[0]
+        self.grupo_operador = Group.objects.get_or_create(
+            name=GRUPO_OPERADOR_INVENTARIO
+        )[0]
+
+        self.gestor = Usuario.objects.create_user(
+            username="gestor",
+            email="gestor@teste.com",
+            password="test123",
+            nome="Gestor",
+            is_staff=True,
+            unidade_orcamentaria=self.uo1,
+        )
+        self.gestor.groups.add(self.grupo_gestor)
+
+        self.operador = Usuario.objects.create_user(
+            username="operador",
+            email="operador@teste.com",
+            password="test123",
+            nome="Operador",
+            is_staff=True,
+            unidade_orcamentaria=self.uo1,
+            unidade_administrativa=self.ua1,
+        )
+        self.operador.groups.add(self.grupo_operador)
+
+        self.superuser = Usuario.objects.create_user(
+            username="super",
+            email="super@teste.com",
+            password="test123",
+            nome="Super",
+            is_staff=True,
+            is_superuser=True,
+        )
+
+        self.me_url = "/api/auth/me/"
+        self.selecionar_ua_url = "/api/auth/me/selecionar-ua/"
+
+    def test_me_opcoes_escopo_gestor(self):
+        self.client.force_authenticate(user=self.gestor)
+        resp = self.client.get(self.me_url)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+        grupos = resp.data["opcoes_escopo"]["grupos"]
+        self.assertEqual(len(grupos), 1)
+        grupo = grupos[0]
+
+        self.assertEqual(grupo["uo"]["id"], self.uo1.id)
+        self.assertIsNone(grupo["uo"]["unidade_administrativa_id"])
+        self.assertEqual(grupo["uo"]["unidade_orcamentaria_id"], self.uo1.id)
+        uas = grupo["uas"]
+        ua_ids = {ua["id"] for ua in uas}
+        self.assertIn(self.ua1.id, ua_ids)
+        self.assertIn(self.ua2.id, ua_ids)
+        self.assertNotIn(self.ua3.id, ua_ids)
+
+    def test_me_opcoes_escopo_operador(self):
+        self.client.force_authenticate(user=self.operador)
+        resp = self.client.get(self.me_url)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+        grupos = resp.data["opcoes_escopo"]["grupos"]
+        self.assertEqual(len(grupos), 1)
+        grupo = grupos[0]
+
+        self.assertEqual(grupo["uo"]["id"], self.uo1.id)
+        self.assertIsNone(grupo["uo"]["unidade_administrativa_id"])
+        self.assertEqual(grupo["uo"]["unidade_orcamentaria_id"], self.uo1.id)
+        self.assertEqual(len(grupo["uas"]), 1)
+        self.assertEqual(grupo["uas"][0]["id"], self.ua1.id)
+
+    def test_me_opcoes_escopo_superuser(self):
+        self.client.force_authenticate(user=self.superuser)
+        resp = self.client.get(self.me_url)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+        grupos = resp.data["opcoes_escopo"]["grupos"]
+        self.assertGreaterEqual(len(grupos), 2)
+
+        grupos_por_uo = {grupo["uo"]["id"]: grupo for grupo in grupos}
+        self.assertIn(self.uo1.id, grupos_por_uo)
+        self.assertIn(self.uo2.id, grupos_por_uo)
+
+        grupo_uo1 = grupos_por_uo[self.uo1.id]
+        grupo_uo2 = grupos_por_uo[self.uo2.id]
+
+        self.assertIsNone(grupo_uo1["uo"]["unidade_administrativa_id"])
+        self.assertEqual(grupo_uo1["uo"]["unidade_orcamentaria_id"], self.uo1.id)
+        self.assertIsNone(grupo_uo2["uo"]["unidade_administrativa_id"])
+        self.assertEqual(grupo_uo2["uo"]["unidade_orcamentaria_id"], self.uo2.id)
+
+        ua_ids_uo1 = {ua["id"] for ua in grupo_uo1["uas"]}
+        ua_ids_uo2 = {ua["id"] for ua in grupo_uo2["uas"]}
+
+        self.assertIn(self.ua1.id, ua_ids_uo1)
+        self.assertIn(self.ua2.id, ua_ids_uo1)
+        self.assertIn(self.ua3.id, ua_ids_uo2)
+
+    def test_selecionar_ua_gestor(self):
+        self.client.force_authenticate(user=self.gestor)
+        resp = self.client.post(
+            self.selecionar_ua_url,
+            {"unidade_administrativa_id": self.ua2.id},
+            format="json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+        self.gestor.refresh_from_db()
+        self.assertEqual(self.gestor.unidade_administrativa_id, self.ua2.id)
+        self.assertEqual(self.gestor.unidade_orcamentaria_id, self.uo1.id)
+
+        ct = ContentType.objects.get_for_model(Usuario)
+        historicos = HistoricoGeral.objects.filter(
+            content_type=ct,
+            object_id=str(self.gestor.pk),
+            campo="unidade_administrativa",
+        )
+        self.assertTrue(historicos.exists())
+
+    def test_selecionar_uo_gestor_limpa_ua(self):
+        self.gestor.unidade_administrativa = self.ua1
+        self.gestor.save(update_fields=["unidade_administrativa"])
+
+        self.client.force_authenticate(user=self.gestor)
+        resp = self.client.post(
+            self.selecionar_ua_url,
+            {
+                "unidade_administrativa_id": None,
+                "unidade_orcamentaria_id": self.uo1.id,
+            },
+            format="json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+        self.gestor.refresh_from_db()
+        self.assertIsNone(self.gestor.unidade_administrativa_id)
+
+    def test_selecionar_uo_operador_nao_permitido(self):
+        self.client.force_authenticate(user=self.operador)
+        resp = self.client.post(
+            self.selecionar_ua_url,
+            {
+                "unidade_administrativa_id": None,
+                "unidade_orcamentaria_id": self.uo1.id,
+            },
+            format="json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_selecionar_ua_operador_sua_propria(self):
+        self.client.force_authenticate(user=self.operador)
+        resp = self.client.post(
+            self.selecionar_ua_url,
+            {"unidade_administrativa_id": self.ua1.id},
+            format="json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+    def test_selecionar_ua_gestor_outra_uo_nao_permitido(self):
+        self.client.force_authenticate(user=self.gestor)
+        resp = self.client.post(
+            self.selecionar_ua_url,
+            {"unidade_administrativa_id": self.ua3.id},
+            format="json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_selecionar_uo_superuser(self):
+        self.client.force_authenticate(user=self.superuser)
+        resp = self.client.post(
+            self.selecionar_ua_url,
+            {
+                "unidade_administrativa_id": None,
+                "unidade_orcamentaria_id": self.uo2.id,
+            },
+            format="json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+        self.superuser.refresh_from_db()
+        self.assertIsNone(self.superuser.unidade_administrativa_id)
+        self.assertEqual(self.superuser.unidade_orcamentaria_id, self.uo2.id)
+
+    def test_me_nao_exibe_ua_inativa(self):
+        self.ua2.status = UnidadeAdministrativa.INATIVA
+        self.ua2.save(update_fields=["status"])
+
+        self.client.force_authenticate(user=self.gestor)
+        resp = self.client.get(self.me_url)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+        grupos = resp.data["opcoes_escopo"]["grupos"]
+        grupo = grupos[0]
+        ua_ids = {ua["id"] for ua in grupo["uas"]}
+        self.assertNotIn(self.ua2.id, ua_ids)
+
+    def test_me_nao_exibe_uo_inativa(self):
+        self.uo2.ativa = False
+        self.uo2.save(update_fields=["ativa"])
+
+        self.client.force_authenticate(user=self.superuser)
+        resp = self.client.get(self.me_url)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+        grupos = resp.data["opcoes_escopo"]["grupos"]
+        grupos_por_uo = {grupo["uo"]["id"] for grupo in grupos}
+        self.assertNotIn(self.uo2.id, grupos_por_uo)
+
+    def test_selecionar_ua_inativa_rejeita(self):
+        self.ua2.status = UnidadeAdministrativa.INATIVA
+        self.ua2.save(update_fields=["status"])
+
+        self.client.force_authenticate(user=self.gestor)
+        resp = self.client.post(
+            self.selecionar_ua_url,
+            {"unidade_administrativa_id": self.ua2.id},
+            format="json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_selecionar_uo_inativa_rejeita(self):
+        self.uo2.ativa = False
+        self.uo2.save(update_fields=["ativa"])
+
+        self.client.force_authenticate(user=self.superuser)
+        resp = self.client.post(
+            self.selecionar_ua_url,
+            {
+                "unidade_administrativa_id": None,
+                "unidade_orcamentaria_id": self.uo2.id,
+            },
+            format="json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
## 🧭 Contexto
Este PR implementa a selecao de UO/UA ativa no backend, com retorno consolidado no `/me` e endpoint dedicado para persistir a escolha. O foco e permitir ao usuario trocar o escopo sem novo login, respeitando perfis e exibindo apenas unidades ativas.

## ✅ O que foi feito
- Endpoint `GET /api/auth/me/` passou a retornar `uo_ativa`, `ua_ativa` e `opcoes_escopo` agrupado por UO, com dados suficientes para o frontend montar o combobox e enviar a selecao.
- Endpoint `POST /api/auth/me/selecionar-ua/` criado para persistir a UA ativa (ou a UO quando `unidade_administrativa_id` for `null`).
- Validacoes de perfil e de consistencia (UO x UA) centralizadas no serializer, bloqueando selecao indevida.
- Filtro de unidades ativas aplicado no retorno e na selecao (UO inativa ou UA inativa sao rejeitadas).
- Auditoria registrada em `HistoricoGeral` quando houver alteracao de UO/UA no usuario.

## 🧩 Detalhes tecnicos relevantes
- UO ativa e UA ativa retornam com `id`, `codigo`, `nome` e `label`.
- `opcoes_escopo.grupos` segue o formato:
  - `uo`: item selecionavel (quando perfil permite) com `unidade_administrativa_id: null` e `unidade_orcamentaria_id`.
  - `uas`: lista de UAs da UO, cada uma com `unidade_administrativa_id` e `unidade_orcamentaria_id`.
- Para OPERADOR, a UO vem marcada com `selecionavel: false`.
- Apenas UOs com `ativa=True` e UAs com `status=ATIVA` sao retornadas/aceitas.

## 🗂️ Arquivos alterados
- usuario/serializers.py
- usuario/api_views.py
- usuario/api_urls.py
- usuario/tests/tests_escopo_api.py

## 🧪 Testes
Arquivo: usuario/tests/tests_escopo_api.py
`test_me_opcoes_escopo_gestor`: valida retorno de grupos para GESTOR e lista de UAs da sua UO.
`test_me_opcoes_escopo_operador`: valida retorno para OPERADOR com apenas sua UA.
`test_me_opcoes_escopo_superuser`: valida retorno para SUPER-USUARIO com grupos de UOs e UAs de cada UO.
`test_selecionar_ua_gestor`: seleciona UA valida para gestor e verifica auditoria.
`test_selecionar_uo_gestor_limpa_ua`: seleciona UO e confirma limpeza da UA ativa.
`test_selecionar_uo_operador_nao_permitido`: garante que operador nao pode selecionar UO.
`test_selecionar_ua_operador_sua_propria`: garante que operador pode selecionar apenas sua UA.
`test_selecionar_ua_gestor_outra_uo_nao_permitido`: bloqueia selecao de UA fora da UO do gestor.
`test_selecionar_uo_superuser`: permite selecao de UO para super-usuario.
`test_me_nao_exibe_ua_inativa`: verifica que UA inativa nao aparece no `/me`.
`test_me_nao_exibe_uo_inativa`: verifica que UO inativa nao aparece no `/me`.
`test_selecionar_ua_inativa_rejeita`: rejeita selecao de UA inativa.
`test_selecionar_uo_inativa_rejeita`: rejeita selecao de UO inativa.

## 📦 Payloads principais
### GET /api/auth/me/
- `uo_ativa` / `ua_ativa`: estado atual do usuario.
- `opcoes_escopo.grupos`: lista agrupada por UO, com UO e UAs prontas para selecao.

Exemplo de retorno:
```json
{
  "uo_ativa": {
    "id": 1,
    "codigo": "01.16.10",
    "nome": "SECRETARIA MUNICIPAL DE EDUCACAO",
    "label": "01.16.10 - SECRETARIA MUNICIPAL DE EDUCACAO"
  },
  "ua_ativa": null,
  "opcoes_escopo": {
    "grupos": [
      {
        "uo": {
          "id": 1,
          "codigo": "01.16.10",
          "nome": "SECRETARIA MUNICIPAL DE EDUCACAO",
          "label": "01.16.10 - SECRETARIA MUNICIPAL DE EDUCACAO",
          "selecionavel": true,
          "unidade_administrativa_id": null,
          "unidade_orcamentaria_id": 1
        },
        "uas": [
          {
            "id": 129,
            "codigo": "00.00.00.002",
            "nome": "COTIC",
            "label": "00.00.00.002 - COTIC",
            "unidade_administrativa_id": 129,
            "unidade_orcamentaria_id": 1
          }
        ]
      }
    ]
  }
}
```

### POST /api/auth/me/selecionar-ua/
Selecionar UO:
```json
{ "unidade_administrativa_id": null, "unidade_orcamentaria_id": 1 }
```

Selecionar UA:
```json
{ "unidade_administrativa_id": 129 }
```

## 📝 Observacoes
- O frontend pode selecionar o item ativo comparando `ua_ativa` (se existir) ou `uo_ativa` contra as opcoes retornadas em `grupos`.
- UOs e UAs retornam o mesmo conjunto de campos necessarios para o POST.
