### PR TITLE
Feature(141819/136171): Deploy Teste -> Homologação

### DIFF
--- a/bem_patrimonial/admins/movimentacao_bem_patrimonial.py
+++ b/bem_patrimonial/admins/movimentacao_bem_patrimonial.py
@@ -325,6 +325,40 @@ class MovimentacaoBemPatrimonialAdmin(admin.ModelAdmin):
         "atualizado_em",
     )
 
+    search_fields = (
+        "numero_cimbpm",
+        "unidade_administrativa_origem__codigo",
+        "unidade_administrativa_origem__nome",
+        "unidade_administrativa_origem__sigla",
+        "unidade_administrativa_destino__codigo",
+        "unidade_administrativa_destino__nome",
+        "unidade_administrativa_destino__sigla",
+        "unidade_administrativa_origem__unidade_orcamentaria__codigo",
+        "unidade_administrativa_origem__unidade_orcamentaria__nome",
+        "unidade_administrativa_destino__unidade_orcamentaria__codigo",
+        "unidade_administrativa_destino__unidade_orcamentaria__nome",
+        "itens__bem__numero_patrimonial",
+        "itens__bem__nome",
+        "itens__bem__descricao",
+        "itens__bem__marca",
+        "itens__bem__modelo",
+        "itens__bem__localizacao",
+        "itens__bem__numero_processo",
+        "bem_patrimonial__numero_patrimonial",
+        "bem_patrimonial__nome",
+        "bem_patrimonial__descricao",
+        "bem_patrimonial__marca",
+        "bem_patrimonial__modelo",
+        "bem_patrimonial__localizacao",
+        "bem_patrimonial__numero_processo",
+    )
+
+    search_help_text = (
+        "Pesquise por número patrimonial, nome, descrição, marca, modelo, localização e "
+        "número de processo do bem, código/nome/sigla da UA (origem/destino), número CIMBPM e "
+        "Unidade Orçamentária."
+    )
+
     autocomplete_fields = (
         "unidade_administrativa_origem",
         "unidade_administrativa_destino",
@@ -418,7 +452,18 @@ class MovimentacaoBemPatrimonialAdmin(admin.ModelAdmin):
         return RequestForm
 
     def get_queryset(self, request):
-        qs = super().get_queryset(request)
+        qs = (
+            super()
+            .get_queryset(request)
+            .select_related(
+                "unidade_administrativa_origem",
+                "unidade_administrativa_destino",
+                "solicitado_por",
+                "aprovado_por",
+                "rejeitado_por",
+                "cancelado_por",
+            )
+        )
         return filtrar_queryset_movimentacao_por_escopo(request.user, qs)
 
     def save_model(self, request, obj, form, change):

--- a/bem_patrimonial/tests/tests_movimentacao_admin_search.py
+++ b/bem_patrimonial/tests/tests_movimentacao_admin_search.py
@@ -1,0 +1,197 @@
+from django.test import TestCase, RequestFactory
+from django.contrib.admin.sites import AdminSite
+from django.contrib.auth.models import Group
+
+from bem_patrimonial.models import (
+    BemPatrimonial,
+    MovimentacaoBemPatrimonial,
+    MovimentacaoBensItem,
+)
+from bem_patrimonial.admins.movimentacao_bem_patrimonial import (
+    MovimentacaoBemPatrimonialAdmin,
+)
+from bem_patrimonial.constants import APROVADO
+from dados_comuns.tests.factories import criar_ua, criar_uo
+from usuario.models import Usuario
+from usuario.constants import GRUPO_GESTOR_PATRIMONIO, GRUPO_OPERADOR_INVENTARIO
+
+
+class MovimentacaoAdminSearchTestCase(TestCase):
+
+    def setUp(self):
+        self.uo_a = criar_uo(codigo="UO-100", nome="UO Alfa", sigla="UOA")
+        self.uo_b = criar_uo(codigo="UO-200", nome="UO Beta", sigla="UOB")
+
+        self.ua1 = criar_ua(uo=self.uo_a, codigo="001", nome="DRE Centro", sigla="DRC")
+        self.ua2 = criar_ua(uo=self.uo_a, codigo="002", nome="DRE Sul", sigla="DRS")
+        self.ua3 = criar_ua(uo=self.uo_b, codigo="003", nome="DRE Norte", sigla="DRN")
+        self.ua4 = criar_ua(uo=self.uo_b, codigo="004", nome="DRE Leste", sigla="DRL")
+
+        self.grupo_gestor = Group.objects.get_or_create(name=GRUPO_GESTOR_PATRIMONIO)[0]
+        self.grupo_operador = Group.objects.get_or_create(
+            name=GRUPO_OPERADOR_INVENTARIO
+        )[0]
+
+        self.gestor_uo_a = Usuario.objects.create_user(
+            username="gestor_uo_a",
+            email="gestor_uo_a@test.com",
+            password="test123",
+            is_staff=True,
+            unidade_orcamentaria=self.uo_a,
+        )
+        self.gestor_uo_a.groups.add(self.grupo_gestor)
+
+        self.gestor_uo_b = Usuario.objects.create_user(
+            username="gestor_uo_b",
+            email="gestor_uo_b@test.com",
+            password="test123",
+            is_staff=True,
+            unidade_orcamentaria=self.uo_b,
+        )
+        self.gestor_uo_b.groups.add(self.grupo_gestor)
+
+        self.operador_ua2 = Usuario.objects.create_user(
+            username="operador_ua2",
+            email="operador_ua2@test.com",
+            password="test123",
+            is_staff=True,
+            unidade_administrativa=self.ua2,
+            unidade_orcamentaria=self.uo_a,
+        )
+        self.operador_ua2.groups.add(self.grupo_operador)
+
+        self.bem_ua1 = BemPatrimonial.objects.create(
+            nome="Bem UA1",
+            descricao="Descricao A",
+            valor_unitario=100.00,
+            marca="Marca A",
+            modelo="Modelo A",
+            numero_processo="PROC-001",
+            numero_patrimonial="000.000000001-0",
+            localizacao="Sala 101",
+            status=APROVADO,
+            unidade_administrativa=self.ua1,
+            criado_por=self.gestor_uo_a,
+        )
+
+        self.bem_ua2 = BemPatrimonial.objects.create(
+            nome="Bem UA2",
+            descricao="Descricao B",
+            valor_unitario=200.00,
+            marca="Marca B",
+            modelo="Modelo B",
+            numero_processo="PROC-002",
+            numero_patrimonial="000.000000002-0",
+            localizacao="Sala 202",
+            status=APROVADO,
+            unidade_administrativa=self.ua2,
+            criado_por=self.operador_ua2,
+        )
+
+        self.bem_ua3 = BemPatrimonial.objects.create(
+            nome="Bem UA3",
+            descricao="Descricao C",
+            valor_unitario=300.00,
+            marca="Marca C",
+            modelo="Modelo C",
+            numero_processo="PROC-003",
+            numero_patrimonial="000.000000003-0",
+            localizacao="Sala 303",
+            status=APROVADO,
+            unidade_administrativa=self.ua3,
+            criado_por=self.gestor_uo_b,
+        )
+
+        self.mov1 = MovimentacaoBemPatrimonial.objects.create(
+            bem_patrimonial=self.bem_ua1,
+            unidade_administrativa_origem=self.ua1,
+            unidade_administrativa_destino=self.ua2,
+            solicitado_por=self.gestor_uo_a,
+            numero_cimbpm="CIMBPM-001",
+        )
+        MovimentacaoBensItem.objects.create(movimentacao=self.mov1, bem=self.bem_ua1)
+
+        self.mov2 = MovimentacaoBemPatrimonial.objects.create(
+            bem_patrimonial=self.bem_ua2,
+            unidade_administrativa_origem=self.ua2,
+            unidade_administrativa_destino=self.ua1,
+            solicitado_por=self.operador_ua2,
+            numero_cimbpm="CIMBPM-002",
+        )
+        MovimentacaoBensItem.objects.create(movimentacao=self.mov2, bem=self.bem_ua2)
+
+        self.mov3 = MovimentacaoBemPatrimonial.objects.create(
+            bem_patrimonial=self.bem_ua3,
+            unidade_administrativa_origem=self.ua3,
+            unidade_administrativa_destino=self.ua4,
+            solicitado_por=self.gestor_uo_b,
+            numero_cimbpm="CIMBPM-003",
+        )
+        MovimentacaoBensItem.objects.create(movimentacao=self.mov3, bem=self.bem_ua3)
+
+        self.factory = RequestFactory()
+        self.site = AdminSite()
+        self.admin = MovimentacaoBemPatrimonialAdmin(
+            MovimentacaoBemPatrimonial, self.site
+        )
+
+    def _search(self, user, term):
+        request = self.factory.get(
+            "/admin/bem_patrimonial/movimentacaobempatrimonial/", {"q": term}
+        )
+        request.user = user
+        qs = self.admin.get_queryset(request)
+        qs, _ = self.admin.get_search_results(request, qs, term)
+        return qs
+
+    def _assert_search_contains(self, user, term, expected, not_expected=None):
+        qs = self._search(user, term)
+        self.assertIn(expected, qs)
+        if not_expected is not None:
+            self.assertNotIn(not_expected, qs)
+
+    def test_busca_por_campos_do_bem(self):
+        casos = [
+            ("000.000000001-0", self.mov1),
+            ("Bem UA1", self.mov1),
+            ("Descricao A", self.mov1),
+            ("Marca A", self.mov1),
+            ("Modelo A", self.mov1),
+            ("Sala 101", self.mov1),
+            ("PROC-001", self.mov1),
+            ("000.000000002-0", self.mov2),
+            ("Bem UA2", self.mov2),
+            ("Descricao B", self.mov2),
+            ("Marca B", self.mov2),
+            ("Modelo B", self.mov2),
+            ("Sala 202", self.mov2),
+            ("PROC-002", self.mov2),
+        ]
+
+        for termo, mov in casos:
+            with self.subTest(termo=termo):
+                self._assert_search_contains(self.gestor_uo_a, termo, mov, self.mov3)
+
+    def test_busca_por_numero_cimbpm(self):
+        self._assert_search_contains(
+            self.gestor_uo_a, "CIMBPM-002", self.mov2, self.mov1
+        )
+
+    def test_busca_por_ua_origem_destino(self):
+        qs = self._search(self.gestor_uo_a, "DRE Centro")
+        self.assertIn(self.mov1, qs)
+        self.assertIn(self.mov2, qs)
+        self.assertNotIn(self.mov3, qs)
+
+        qs = self._search(self.gestor_uo_a, "002")
+        self.assertIn(self.mov1, qs)
+        self.assertIn(self.mov2, qs)
+        self.assertNotIn(self.mov3, qs)
+
+    def test_busca_por_unidade_orcamentaria(self):
+        self._assert_search_contains(self.gestor_uo_b, "UO-200", self.mov3, self.mov1)
+        self._assert_search_contains(self.gestor_uo_b, "UO Beta", self.mov3, self.mov1)
+
+    def test_busca_respeita_escopo_operador(self):
+        qs = self._search(self.operador_ua2, "PROC-003")
+        self.assertNotIn(self.mov3, qs)

--- a/bem_patrimonial/tests/tests_movimentacao_admin_search.py
+++ b/bem_patrimonial/tests/tests_movimentacao_admin_search.py
@@ -188,6 +188,11 @@ class MovimentacaoAdminSearchTestCase(TestCase):
         self.assertIn(self.mov2, qs)
         self.assertNotIn(self.mov3, qs)
 
+        qs = self._search(self.gestor_uo_a, "DRC")
+        self.assertIn(self.mov1, qs)
+        self.assertIn(self.mov2, qs)
+        self.assertNotIn(self.mov3, qs)
+
     def test_busca_por_unidade_orcamentaria(self):
         self._assert_search_contains(self.gestor_uo_b, "UO-200", self.mov3, self.mov1)
         self._assert_search_contains(self.gestor_uo_b, "UO Beta", self.mov3, self.mov1)

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -72,6 +72,8 @@ CORS_ALLOW_HEADERS = [
     "user-agent",
     "x-csrftoken",
     "x-requested-with",
+    "x-ua-id",
+    "x-uo-id",
 ]
 
 CORS_ALLOW_METHODS = [

--- a/usuario/api_urls.py
+++ b/usuario/api_urls.py
@@ -9,6 +9,7 @@ from usuario.api_views import (
     PasswordChangeAPIView,
     FirstAccessPasswordChangeAPIView,
     UserProfileAPIView,
+    SelecionarUnidadeAdministrativaAPIView,
 )
 
 urlpatterns = [
@@ -17,6 +18,11 @@ urlpatterns = [
     path("token/refresh/", CustomTokenRefreshView.as_view(), name="token_refresh"),
     path("token/verify/", CustomTokenVerifyView.as_view(), name="token_verify"),
     path("me/", UserProfileAPIView.as_view(), name="user_profile"),
+    path(
+        "me/selecionar-ua/",
+        SelecionarUnidadeAdministrativaAPIView.as_view(),
+        name="selecionar_ua",
+    ),
     path(
         "password-reset/",
         PasswordResetRequestAPIView.as_view(),

--- a/usuario/api_views.py
+++ b/usuario/api_views.py
@@ -20,8 +20,13 @@ from usuario.serializers import (
     PasswordChangeSerializer,
     FirstAccessPasswordChangeSerializer,
     UserProfileSerializer,
+    SelecionarUnidadeAdministrativaSerializer,
 )
 from django.contrib.auth.tokens import PasswordResetTokenGenerator
+from django.db import transaction
+from django.contrib.contenttypes.models import ContentType
+from dados_comuns.models import HistoricoGeral
+from dados_comuns.utils import dict_changes
 
 
 def set_refresh_token_cookie(response, refresh_token):
@@ -411,3 +416,65 @@ class UserProfileAPIView(generics.RetrieveAPIView):
 
     def get_object(self):
         return self.request.user
+
+
+@extend_schema(
+    summary="Selecionar UA ativa",
+    description="Define a Unidade Administrativa ativa do usuario autenticado. Envie unidade_administrativa_id=null para selecionar UO (todas as UAs).",  # noqa: E501
+    request=SelecionarUnidadeAdministrativaSerializer,
+    responses={
+        200: UserProfileSerializer,
+        400: OpenApiResponse(description="Dados invalidos"),
+        401: OpenApiResponse(description="Nao autenticado"),
+    },
+    tags=["Autenticação"],
+)
+class SelecionarUnidadeAdministrativaAPIView(generics.GenericAPIView):
+    serializer_class = SelecionarUnidadeAdministrativaSerializer
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request, *args, **kwargs):
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        user = request.user
+        original = Usuario.objects.get(pk=user.pk)
+
+        ua = serializer.validated_data.get("ua_obj")
+        uo = serializer.validated_data.get("uo_obj")
+
+        update_fields = []
+        if user.unidade_administrativa_id != (ua.id if ua else None):
+            user.unidade_administrativa = ua
+            update_fields.append("unidade_administrativa")
+
+        if uo and user.unidade_orcamentaria_id != uo.id:
+            user.unidade_orcamentaria = uo
+            update_fields.append("unidade_orcamentaria")
+
+        with transaction.atomic():
+            if update_fields:
+                user.save(update_fields=update_fields)
+
+            changes = dict_changes(
+                original,
+                user,
+                fields=["unidade_administrativa", "unidade_orcamentaria"],
+            )
+            if changes:
+                ct = ContentType.objects.get_for_model(Usuario)
+                HistoricoGeral.objects.bulk_create(
+                    [
+                        HistoricoGeral(
+                            content_type=ct,
+                            object_id=str(user.pk),
+                            campo=field,
+                            valor_antigo=old,
+                            valor_novo=new,
+                            alterado_por=user,
+                        )
+                        for field, (old, new) in changes.items()
+                    ]
+                )
+
+        return Response(UserProfileSerializer(user).data, status=status.HTTP_200_OK)

--- a/usuario/serializers.py
+++ b/usuario/serializers.py
@@ -2,6 +2,8 @@ from rest_framework import serializers
 from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
 from django.contrib.auth.password_validation import validate_password
 from usuario.models import Usuario
+from dados_comuns.models import UnidadeAdministrativa, UnidadeOrcamentaria
+from dados_comuns.escopo import obter_unidade_orcamentaria_id_do_usuario
 
 
 class CustomTokenObtainPairSerializer(TokenObtainPairSerializer):
@@ -18,14 +20,6 @@ class CustomTokenObtainPairSerializer(TokenObtainPairSerializer):
             "is_gestor_patrimonio": self.user.is_gestor_patrimonio,
             "is_operador_inventario": self.user.is_operador_inventario,
             "must_change_password": self.user.must_change_password,
-            "unidade_administrativa": (
-                {
-                    "id": self.user.unidade_administrativa.id,
-                    "nome": self.user.unidade_administrativa.nome,
-                }
-                if self.user.unidade_administrativa
-                else None
-            ),
         }
 
         return data
@@ -144,7 +138,9 @@ class FirstAccessPasswordChangeSerializer(serializers.Serializer):
 class UserProfileSerializer(serializers.ModelSerializer):
     is_gestor_patrimonio = serializers.BooleanField(read_only=True)
     is_operador_inventario = serializers.BooleanField(read_only=True)
-    unidade_administrativa = serializers.SerializerMethodField()
+    uo_ativa = serializers.SerializerMethodField()
+    ua_ativa = serializers.SerializerMethodField()
+    opcoes_escopo = serializers.SerializerMethodField()
 
     class Meta:
         model = Usuario
@@ -157,12 +153,190 @@ class UserProfileSerializer(serializers.ModelSerializer):
             "is_gestor_patrimonio",
             "is_operador_inventario",
             "must_change_password",
-            "unidade_administrativa",
+            "uo_ativa",
+            "ua_ativa",
+            "opcoes_escopo",
         ]
         read_only_fields = fields
 
-    def get_unidade_administrativa(self, obj):
+    def get_uo_ativa(self, obj):
+        uo = obj.unidade_orcamentaria
+        if not uo and obj.unidade_administrativa:
+            uo = obj.unidade_administrativa.unidade_orcamentaria
+        if uo:
+            return {
+                "id": uo.id,
+                "codigo": uo.codigo,
+                "nome": uo.nome,
+                "label": f"{uo.codigo} - {uo.nome}",
+            }
+        return None
+
+    def get_ua_ativa(self, obj):
         ua = obj.unidade_administrativa
         if ua:
-            return {"id": ua.id, "nome": ua.nome}
+            return {
+                "id": ua.id,
+                "codigo": ua.codigo,
+                "nome": ua.nome,
+                "label": f"{ua.codigo} - {ua.nome}",
+            }
         return None
+
+    def get_opcoes_escopo(self, obj):
+        uos_qs = UnidadeOrcamentaria.objects.none()
+        uas_qs = UnidadeAdministrativa.objects.none()
+
+        if obj.is_superuser:
+            uos_qs = UnidadeOrcamentaria.objects.filter(ativa=True)
+            uas_qs = UnidadeAdministrativa.objects.filter(
+                status=UnidadeAdministrativa.ATIVA
+            )
+        elif obj.is_gestor_patrimonio:
+            uo_id = obter_unidade_orcamentaria_id_do_usuario(obj)
+            if uo_id:
+                uos_qs = UnidadeOrcamentaria.objects.filter(id=uo_id, ativa=True)
+                uas_qs = UnidadeAdministrativa.objects.filter(
+                    unidade_orcamentaria_id=uo_id,
+                    status=UnidadeAdministrativa.ATIVA,
+                )
+        elif obj.is_operador_inventario:
+            if obj.unidade_administrativa_id:
+                uas_qs = UnidadeAdministrativa.objects.filter(
+                    id=obj.unidade_administrativa_id,
+                    status=UnidadeAdministrativa.ATIVA,
+                )
+                uos_qs = UnidadeOrcamentaria.objects.filter(
+                    id=obj.unidade_administrativa.unidade_orcamentaria_id,
+                    ativa=True,
+                )
+
+        uas_qs = uas_qs.select_related("unidade_orcamentaria")
+        uas_por_uo = {}
+        for ua in uas_qs:
+            uas_por_uo.setdefault(ua.unidade_orcamentaria_id, []).append(
+                {
+                    "id": ua.id,
+                    "codigo": ua.codigo,
+                    "nome": ua.nome,
+                    "label": f"{ua.codigo} - {ua.nome}",
+                    "unidade_administrativa_id": ua.id,
+                    "unidade_orcamentaria_id": ua.unidade_orcamentaria_id,
+                }
+            )
+
+        permite_uo = bool(obj.is_superuser or obj.is_gestor_patrimonio)
+        grupos = []
+        for uo in uos_qs:
+            grupo = {
+                "uo": {
+                    "id": uo.id,
+                    "codigo": uo.codigo,
+                    "nome": uo.nome,
+                    "label": f"{uo.codigo} - {uo.nome}",
+                    "selecionavel": permite_uo,
+                    "unidade_administrativa_id": None,
+                    "unidade_orcamentaria_id": uo.id,
+                },
+                "uas": uas_por_uo.get(uo.id, []),
+            }
+            grupos.append(grupo)
+
+        return {
+            "grupos": grupos,
+        }
+
+
+class SelecionarUnidadeAdministrativaSerializer(serializers.Serializer):
+    unidade_administrativa_id = serializers.IntegerField(allow_null=True, required=True)
+    unidade_orcamentaria_id = serializers.IntegerField(allow_null=True, required=False)
+
+    def validate(self, attrs):
+        request = self.context.get("request")
+        user = getattr(request, "user", None)
+
+        if not user or not user.is_authenticated:
+            raise serializers.ValidationError("Usuario nao autenticado.")
+
+        ua_id = attrs.get("unidade_administrativa_id")
+        uo_id = attrs.get("unidade_orcamentaria_id")
+
+        ua = None
+        uo = None
+
+        if ua_id is not None:
+            try:
+                ua = UnidadeAdministrativa.objects.select_related(
+                    "unidade_orcamentaria"
+                ).get(id=ua_id)
+            except UnidadeAdministrativa.DoesNotExist:
+                raise serializers.ValidationError(
+                    {"unidade_administrativa_id": "Unidade Administrativa invalida."}
+                )
+            if ua.status != UnidadeAdministrativa.ATIVA:
+                raise serializers.ValidationError(
+                    {"unidade_administrativa_id": "Unidade Administrativa inativa."}
+                )
+            if uo_id is not None and ua.unidade_orcamentaria_id != uo_id:
+                raise serializers.ValidationError(
+                    {
+                        "unidade_orcamentaria_id": "Unidade Orcamentaria nao corresponde a Unidade Administrativa."
+                    }
+                )
+            uo = ua.unidade_orcamentaria
+            uo_id = uo.id
+        else:
+            if user.is_operador_inventario and not user.is_superuser:
+                raise serializers.ValidationError(
+                    "Operador nao pode selecionar Unidade Orcamentaria."
+                )
+
+            if uo_id is None:
+                uo_id = obter_unidade_orcamentaria_id_do_usuario(user)
+
+            if not uo_id:
+                raise serializers.ValidationError(
+                    {"unidade_orcamentaria_id": "Unidade Orcamentaria obrigatoria."}
+                )
+
+        if not user.is_superuser:
+            uo_usuario_id = obter_unidade_orcamentaria_id_do_usuario(user)
+            if uo_usuario_id and uo_id != uo_usuario_id:
+                raise serializers.ValidationError(
+                    "Usuario nao pode selecionar Unidade Orcamentaria diferente."
+                )
+
+            if (
+                user.is_operador_inventario
+                and ua
+                and user.unidade_administrativa_id != ua.id
+            ):
+                raise serializers.ValidationError(
+                    "Operador so pode selecionar a propria Unidade Administrativa."
+                )
+
+            if (
+                user.is_gestor_patrimonio
+                and ua
+                and uo_usuario_id
+                and ua.unidade_orcamentaria_id != uo_usuario_id
+            ):
+                raise serializers.ValidationError(
+                    "Gestor so pode selecionar UA da propria Unidade Orcamentaria."
+                )
+
+        if uo is None:
+            try:
+                uo = UnidadeOrcamentaria.objects.get(id=uo_id)
+            except UnidadeOrcamentaria.DoesNotExist:
+                raise serializers.ValidationError(
+                    {"unidade_orcamentaria_id": "Unidade Orcamentaria invalida."}
+                )
+        if not uo.ativa:
+            raise serializers.ValidationError(
+                {"unidade_orcamentaria_id": "Unidade Orcamentaria inativa."}
+            )
+
+        attrs["ua_obj"] = ua
+        attrs["uo_obj"] = uo
+        return attrs

--- a/usuario/tests/tests_escopo_api.py
+++ b/usuario/tests/tests_escopo_api.py
@@ -1,0 +1,264 @@
+from django.contrib.auth.models import Group
+from django.contrib.contenttypes.models import ContentType
+from rest_framework import status
+from rest_framework.test import APITestCase
+from itertools import count
+
+from dados_comuns.models import HistoricoGeral, UnidadeAdministrativa
+from dados_comuns.tests.factories import criar_ua, criar_uo
+from usuario.constants import GRUPO_GESTOR_PATRIMONIO, GRUPO_OPERADOR_INVENTARIO
+from usuario.models import Usuario
+
+
+class EscopoEndpointsTestCase(APITestCase):
+    _seq = count(1)
+
+    def setUp(self):
+        seq = next(self._seq)
+        uo1_codigo = f"UO-{seq:04d}-A"
+        uo2_codigo = f"UO-{seq:04d}-B"
+        ua1_codigo = f"UA-{seq:04d}-1"
+        ua2_codigo = f"UA-{seq:04d}-2"
+        ua3_codigo = f"UA-{seq:04d}-3"
+
+        self.uo1 = criar_uo(codigo=uo1_codigo, nome="UO 1")
+        self.uo2 = criar_uo(codigo=uo2_codigo, nome="UO 2")
+
+        self.ua1 = criar_ua(uo=self.uo1, codigo=ua1_codigo, sigla="UA1", nome="UA 1")
+        self.ua2 = criar_ua(uo=self.uo1, codigo=ua2_codigo, sigla="UA2", nome="UA 2")
+        self.ua3 = criar_ua(uo=self.uo2, codigo=ua3_codigo, sigla="UA3", nome="UA 3")
+
+        self.grupo_gestor = Group.objects.get_or_create(name=GRUPO_GESTOR_PATRIMONIO)[0]
+        self.grupo_operador = Group.objects.get_or_create(
+            name=GRUPO_OPERADOR_INVENTARIO
+        )[0]
+
+        self.gestor = Usuario.objects.create_user(
+            username="gestor",
+            email="gestor@teste.com",
+            password="test123",
+            nome="Gestor",
+            is_staff=True,
+            unidade_orcamentaria=self.uo1,
+        )
+        self.gestor.groups.add(self.grupo_gestor)
+
+        self.operador = Usuario.objects.create_user(
+            username="operador",
+            email="operador@teste.com",
+            password="test123",
+            nome="Operador",
+            is_staff=True,
+            unidade_orcamentaria=self.uo1,
+            unidade_administrativa=self.ua1,
+        )
+        self.operador.groups.add(self.grupo_operador)
+
+        self.superuser = Usuario.objects.create_user(
+            username="super",
+            email="super@teste.com",
+            password="test123",
+            nome="Super",
+            is_staff=True,
+            is_superuser=True,
+        )
+
+        self.me_url = "/api/auth/me/"
+        self.selecionar_ua_url = "/api/auth/me/selecionar-ua/"
+
+    def test_me_opcoes_escopo_gestor(self):
+        self.client.force_authenticate(user=self.gestor)
+        resp = self.client.get(self.me_url)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+        grupos = resp.data["opcoes_escopo"]["grupos"]
+        self.assertEqual(len(grupos), 1)
+        grupo = grupos[0]
+
+        self.assertEqual(grupo["uo"]["id"], self.uo1.id)
+        self.assertIsNone(grupo["uo"]["unidade_administrativa_id"])
+        self.assertEqual(grupo["uo"]["unidade_orcamentaria_id"], self.uo1.id)
+        uas = grupo["uas"]
+        ua_ids = {ua["id"] for ua in uas}
+        self.assertIn(self.ua1.id, ua_ids)
+        self.assertIn(self.ua2.id, ua_ids)
+        self.assertNotIn(self.ua3.id, ua_ids)
+
+    def test_me_opcoes_escopo_operador(self):
+        self.client.force_authenticate(user=self.operador)
+        resp = self.client.get(self.me_url)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+        grupos = resp.data["opcoes_escopo"]["grupos"]
+        self.assertEqual(len(grupos), 1)
+        grupo = grupos[0]
+
+        self.assertEqual(grupo["uo"]["id"], self.uo1.id)
+        self.assertIsNone(grupo["uo"]["unidade_administrativa_id"])
+        self.assertEqual(grupo["uo"]["unidade_orcamentaria_id"], self.uo1.id)
+        self.assertEqual(len(grupo["uas"]), 1)
+        self.assertEqual(grupo["uas"][0]["id"], self.ua1.id)
+
+    def test_me_opcoes_escopo_superuser(self):
+        self.client.force_authenticate(user=self.superuser)
+        resp = self.client.get(self.me_url)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+        grupos = resp.data["opcoes_escopo"]["grupos"]
+        self.assertGreaterEqual(len(grupos), 2)
+
+        grupos_por_uo = {grupo["uo"]["id"]: grupo for grupo in grupos}
+        self.assertIn(self.uo1.id, grupos_por_uo)
+        self.assertIn(self.uo2.id, grupos_por_uo)
+
+        grupo_uo1 = grupos_por_uo[self.uo1.id]
+        grupo_uo2 = grupos_por_uo[self.uo2.id]
+
+        self.assertIsNone(grupo_uo1["uo"]["unidade_administrativa_id"])
+        self.assertEqual(grupo_uo1["uo"]["unidade_orcamentaria_id"], self.uo1.id)
+        self.assertIsNone(grupo_uo2["uo"]["unidade_administrativa_id"])
+        self.assertEqual(grupo_uo2["uo"]["unidade_orcamentaria_id"], self.uo2.id)
+
+        ua_ids_uo1 = {ua["id"] for ua in grupo_uo1["uas"]}
+        ua_ids_uo2 = {ua["id"] for ua in grupo_uo2["uas"]}
+
+        self.assertIn(self.ua1.id, ua_ids_uo1)
+        self.assertIn(self.ua2.id, ua_ids_uo1)
+        self.assertIn(self.ua3.id, ua_ids_uo2)
+
+    def test_selecionar_ua_gestor(self):
+        self.client.force_authenticate(user=self.gestor)
+        resp = self.client.post(
+            self.selecionar_ua_url,
+            {"unidade_administrativa_id": self.ua2.id},
+            format="json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+        self.gestor.refresh_from_db()
+        self.assertEqual(self.gestor.unidade_administrativa_id, self.ua2.id)
+        self.assertEqual(self.gestor.unidade_orcamentaria_id, self.uo1.id)
+
+        ct = ContentType.objects.get_for_model(Usuario)
+        historicos = HistoricoGeral.objects.filter(
+            content_type=ct,
+            object_id=str(self.gestor.pk),
+            campo="unidade_administrativa",
+        )
+        self.assertTrue(historicos.exists())
+
+    def test_selecionar_uo_gestor_limpa_ua(self):
+        self.gestor.unidade_administrativa = self.ua1
+        self.gestor.save(update_fields=["unidade_administrativa"])
+
+        self.client.force_authenticate(user=self.gestor)
+        resp = self.client.post(
+            self.selecionar_ua_url,
+            {
+                "unidade_administrativa_id": None,
+                "unidade_orcamentaria_id": self.uo1.id,
+            },
+            format="json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+        self.gestor.refresh_from_db()
+        self.assertIsNone(self.gestor.unidade_administrativa_id)
+
+    def test_selecionar_uo_operador_nao_permitido(self):
+        self.client.force_authenticate(user=self.operador)
+        resp = self.client.post(
+            self.selecionar_ua_url,
+            {
+                "unidade_administrativa_id": None,
+                "unidade_orcamentaria_id": self.uo1.id,
+            },
+            format="json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_selecionar_ua_operador_sua_propria(self):
+        self.client.force_authenticate(user=self.operador)
+        resp = self.client.post(
+            self.selecionar_ua_url,
+            {"unidade_administrativa_id": self.ua1.id},
+            format="json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+    def test_selecionar_ua_gestor_outra_uo_nao_permitido(self):
+        self.client.force_authenticate(user=self.gestor)
+        resp = self.client.post(
+            self.selecionar_ua_url,
+            {"unidade_administrativa_id": self.ua3.id},
+            format="json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_selecionar_uo_superuser(self):
+        self.client.force_authenticate(user=self.superuser)
+        resp = self.client.post(
+            self.selecionar_ua_url,
+            {
+                "unidade_administrativa_id": None,
+                "unidade_orcamentaria_id": self.uo2.id,
+            },
+            format="json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+        self.superuser.refresh_from_db()
+        self.assertIsNone(self.superuser.unidade_administrativa_id)
+        self.assertEqual(self.superuser.unidade_orcamentaria_id, self.uo2.id)
+
+    def test_me_nao_exibe_ua_inativa(self):
+        self.ua2.status = UnidadeAdministrativa.INATIVA
+        self.ua2.save(update_fields=["status"])
+
+        self.client.force_authenticate(user=self.gestor)
+        resp = self.client.get(self.me_url)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+        grupos = resp.data["opcoes_escopo"]["grupos"]
+        grupo = grupos[0]
+        ua_ids = {ua["id"] for ua in grupo["uas"]}
+        self.assertNotIn(self.ua2.id, ua_ids)
+
+    def test_me_nao_exibe_uo_inativa(self):
+        self.uo2.ativa = False
+        self.uo2.save(update_fields=["ativa"])
+
+        self.client.force_authenticate(user=self.superuser)
+        resp = self.client.get(self.me_url)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+        grupos = resp.data["opcoes_escopo"]["grupos"]
+        grupos_por_uo = {grupo["uo"]["id"] for grupo in grupos}
+        self.assertNotIn(self.uo2.id, grupos_por_uo)
+
+    def test_selecionar_ua_inativa_rejeita(self):
+        self.ua2.status = UnidadeAdministrativa.INATIVA
+        self.ua2.save(update_fields=["status"])
+
+        self.client.force_authenticate(user=self.gestor)
+        resp = self.client.post(
+            self.selecionar_ua_url,
+            {"unidade_administrativa_id": self.ua2.id},
+            format="json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_selecionar_uo_inativa_rejeita(self):
+        self.uo2.ativa = False
+        self.uo2.save(update_fields=["ativa"])
+
+        self.client.force_authenticate(user=self.superuser)
+        resp = self.client.post(
+            self.selecionar_ua_url,
+            {
+                "unidade_administrativa_id": None,
+                "unidade_orcamentaria_id": self.uo2.id,
+            },
+            format="json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
Este pull request entrega uma melhoria ampla no gerenciamento de escopo do usuário e na experiência de busca do admin, além de ajustes adicionais para suporte ao frontend.

## 🧭 Seleção de Escopo (UA/UO) e Ajustes no Perfil do Usuário

- Criado o endpoint **`SelecionarUnidadeAdministrativaAPIView`**, permitindo que o usuário autenticado altere sua **UA/UO ativa**, com validação completa e registro de auditoria.
- Atualizado o **`UserProfileSerializer`**, que agora expõe:
  - `uo_ativa`
  - `ua_ativa`
  - `opcoes_escopo`
  
  Substituindo o antigo campo `unidade_administrativa`, trazendo mais clareza para o cliente e controle de escopo.
- Adicionado o serializer **`SelecionarUnidadeAdministrativaSerializer`**, garantindo que o usuário só possa selecionar unidades realmente permitidas para seu perfil.

## 🔍 Melhorias na Busca do Admin

- Expansão dos **`search_fields`** de `MovimentacaoBemPatrimonialAdmin` para incluir campos de UA, UO e Bem Patrimonial, tornando a busca muito mais eficiente e útil.
- Otimização de consultas usando **`select_related`**, melhorando desempenho ao carregar movimentações no Django Admin.
- Criada uma suíte de testes validando toda a nova lógica de busca e restrições de escopo no admin.

## 🌐 Configurações e Headers

- Inclusão dos headers **`x-ua-id`** e **`x-uo-id`** no `CORS_ALLOW_HEADERS`, possibilitando que o frontend envie identificadores de escopo nas requisições.

## 🔗 Atualizações de API e Imports

- Registro do novo endpoint de seleção de escopo em `usuario/api_urls.py`, além de ajustes de import onde necessário.

---

Estas mudanças oferecem uma base sólida para um sistema mais seguro, flexível e alinhado ao uso real dos usuários, além de preparar o backend para integrações frontend que dependem de escopo ativo.
