### PR TITLE
Feature 141997 Ajsuste edicao bem pelo super admin

### DIFF
--- a/bem_patrimonial/admins/bem_patrimonial.py
+++ b/bem_patrimonial/admins/bem_patrimonial.py
@@ -161,6 +161,7 @@ class HistoricoGeralInline(GenericTabularInline):
         "campo",
         "valor_antigo",
         "valor_novo",
+        "justificativa",
         "alterado_por",
         "alterado_em",
     )

--- a/config/templates/admin/bem_patrimonial/edit_inline/tabular-historico.html
+++ b/config/templates/admin/bem_patrimonial/edit_inline/tabular-historico.html
@@ -27,6 +27,9 @@
           <tbody>
             {% for inline_admin_form in inline_admin_formset %}
               <tr class="{% cycle "row1" "row2" %}">
+                {% for hidden in inline_admin_form.form.hidden_fields %}
+                  {{ hidden }}
+                {% endfor %}
                 {% for fieldset in inline_admin_form %}
                   {% for line in fieldset %}
                     {% for field in line %}


### PR DESCRIPTION

# Feature 141997 – Criação de Novos Campos no Bem Patrimonial

## História
**141997 – [Bens Físicos] Criação de novos campos de informação no Bem Patrimonial**

Esta implementação adiciona suporte à exibição da **justificativa das alterações**
no histórico do Bem Patrimonial dentro do Django Admin.

---

# Objetivo

Permitir que o campo **justificativa** seja exibido no histórico de alterações do
Bem Patrimonial, possibilitando maior rastreabilidade e transparência nas
modificações realizadas.

Além disso, foi ajustado o template do inline de histórico para garantir que os
**campos ocultos do formulário sejam renderizados corretamente**, evitando
inconsistências na submissão.

---

# Alterações Realizadas

## 1. Admin – Inclusão do campo `justificativa` no histórico

Arquivo:
bem_patrimonial/admins/bem_patrimonial.py

Alteração realizada na classe:
HistoricoGeralInline

### Antes

fields = (
    "campo",
    "valor_antigo",
    "valor_novo",
    "alterado_por",
    "alterado_em",
)

### Depois

fields = (
    "campo",
    "valor_antigo",
    "valor_novo",
    "justificativa",
    "alterado_por",
    "alterado_em",
)

### Resultado

O histórico exibido no admin agora apresenta também a **justificativa informada
na alteração do bem**.

---

## 2. Template do Admin – Renderização de campos ocultos

Arquivo:
config/templates/admin/bem_patrimonial/edit_inline/tabular-historico.html

Foi adicionada a renderização explícita dos **hidden fields** dentro da linha
do inline.

### Alteração adicionada

{% for hidden in inline_admin_form.form.hidden_fields %}
  {{ hidden }}
{% endfor %}

### Trecho atualizado

<tbody>
  {% for inline_admin_form in inline_admin_formset %}
    <tr class="{% cycle "row1" "row2" %}">
      {% for hidden in inline_admin_form.form.hidden_fields %}
        {{ hidden }}
      {% endfor %}
      {% for fieldset in inline_admin_form %}
        {% for line in fieldset %}
          {% for field in line %}

### Motivo

Garantir que **campos ocultos necessários ao funcionamento do inline**
sejam enviados corretamente no POST.

Sem essa renderização, podem ocorrer problemas como:

- inconsistência no gerenciamento do formset
- erros na submissão do formulário
- perda de valores ocultos necessários para o Django Admin

---

# Impacto

## Backend
Nenhuma alteração em models ou regras de negócio.

## Admin
Melhoria visual e funcional do histórico.

## Banco de dados
Nenhuma alteração.

---

# Resultado Esperado

No **histórico de alterações do Bem Patrimonial**, o admin agora exibirá:

- Campo alterado
- Valor antigo
- Valor novo
- Justificativa
- Usuário que realizou a alteração
- Data da alteração

---

# Benefícios

- Maior rastreabilidade das alterações
- Melhoria na auditoria de modificações
- Melhor transparência para gestão patrimonial
