### PR TITLE
Feature 141997 – Criação de Novos Campos no Bem Patrimonial

### DIFF
--- a/bem_patrimonial/admins/bem_patrimonial.py
+++ b/bem_patrimonial/admins/bem_patrimonial.py
@@ -161,6 +161,7 @@ class HistoricoGeralInline(GenericTabularInline):
         "campo",
         "valor_antigo",
         "valor_novo",
+        "justificativa",
         "alterado_por",
         "alterado_em",
     )

--- a/bem_patrimonial/admins/bem_patrimonial.py
+++ b/bem_patrimonial/admins/bem_patrimonial.py
@@ -474,22 +474,18 @@ class BemPatrimonialAdmin(ImportExportModelAdmin):
             nome_alterado = nome_post != nome_original
             numero_alterado = numero_post != numero_original
 
-            if nome_alterado or numero_alterado:
-                if not justificativa:
-                    raise ValidationError({
-                        "justificativa": (
-                            "A justificativa é obrigatória quando o Nome ou "
-                            "o Número Patrimonial forem alterados."
-                        ),
-                        "nome": (
-                            "A justificativa é obrigatória quando o Nome ou "
-                            "o Número Patrimonial forem alterados."
-                        ),
-                        "numero_patrimonial": (
-                            "A justificativa é obrigatória quando o Nome ou "
-                            "o Número Patrimonial forem alterados."
-                        ),
-                    })
+            if (nome_alterado or numero_alterado) and not justificativa:
+                msg = (
+                    "A justificativa é obrigatória quando o Nome ou "
+                    "o Número Patrimonial forem alterados."
+                )
+                raise ValidationError(
+                    {
+                        "justificativa": msg,
+                        "nome": msg,
+                        "numero_patrimonial": msg,
+                    }
+                )
 
     def get_form(self, request, obj=None, **kwargs):
         base_form = super().get_form(request, obj, **kwargs)

--- a/config/templates/admin/bem_patrimonial/edit_inline/tabular-historico.html
+++ b/config/templates/admin/bem_patrimonial/edit_inline/tabular-historico.html
@@ -27,6 +27,9 @@
           <tbody>
             {% for inline_admin_form in inline_admin_formset %}
               <tr class="{% cycle "row1" "row2" %}">
+                {% for hidden in inline_admin_form.form.hidden_fields %}
+                  {{ hidden }}
+                {% endfor %}
                 {% for fieldset in inline_admin_form %}
                   {% for line in fieldset %}
                     {% for field in line %}

--- a/static/admin/baixa_fisica_autocomplete.js
+++ b/static/admin/baixa_fisica_autocomplete.js
@@ -126,9 +126,10 @@
                 }
                 const params = ['ua_origem=' + encodeURIComponent(uaVal)];
                 const ids = [];
-                $('select[name^="itens-"][name$="-bem"]').each(function() {
-                    appendBemIdIfNotDeleted(ids, this);
-                });
+                const selects = document.querySelectorAll('select[name^="itens-"][name$="-bem"]');
+                for (const selectEl of selects) {
+                    appendBemIdIfNotDeleted(ids, selectEl);
+                }
                 if (ids.length > 0) {
                     params.push('exclude_bens=' + encodeURIComponent(ids.join(',')));
                 }

--- a/static/admin/bem_patrimonial.js
+++ b/static/admin/bem_patrimonial.js
@@ -301,8 +301,8 @@
   function showError(containerId, msgs){
     const box = id(containerId);
     if (!msgs || !msgs.length){
+      box?.classList.add('hide');
       if (box){
-        box.classList.add('hide');
         box.innerHTML = '';
       }
       return;

--- a/usuario/admin.py
+++ b/usuario/admin.py
@@ -336,55 +336,57 @@ class CustomUserModelAdmin(UserAdmin):
             kwargs["queryset"] = qs.filter(unidade_orcamentaria_id=uo_id)
 
     def get_form(self, request, obj=None, **kwargs):
-
         request._obj_usuario_admin = obj
-
         form = super().get_form(request, obj, **kwargs)
+        self._configure_groups_field(form, obj)
+        self._configure_uo_field(form, request, obj)
+        self._wrap_form_clean_with_validation(form, request)
+        return form
 
-        if hasattr(form, "base_fields") and "groups" in form.base_fields:
-            form.base_fields["groups"] = forms.ModelMultipleChoiceField(
-                queryset=self._get_grupo_queryset(),
-                required=False,
-                label="Grupo",
-                widget=GroupSingleSelectWidget,
+    def _configure_groups_field(self, form, obj):
+        if not (hasattr(form, "base_fields") and "groups" in form.base_fields):
+            return
+        form.base_fields["groups"] = forms.ModelMultipleChoiceField(
+            queryset=self._get_grupo_queryset(),
+            required=False,
+            label="Grupo",
+            widget=GroupSingleSelectWidget,
+        )
+        if obj and obj.pk:
+            grupo_inicial = self._grupo_preferencial(obj)
+            form.base_fields["groups"].initial = (
+                [grupo_inicial.pk] if grupo_inicial else []
             )
-            if obj and obj.pk:
-                grupo_inicial = self._grupo_preferencial(obj)
-                form.base_fields["groups"].initial = (
-                    [grupo_inicial.pk] if grupo_inicial else []
-                )
-            else:
-                form.base_fields["groups"].initial = []
-        if hasattr(form, "base_fields") and "unidade_orcamentaria" in form.base_fields:
-            form.base_fields["unidade_orcamentaria"].required = True
+        else:
+            form.base_fields["groups"].initial = []
 
-        if (
-            obj is None
-            and hasattr(form, "base_fields")
-            and "unidade_orcamentaria" in form.base_fields
-            and request.user.unidade_orcamentaria_id
-        ):
+    def _configure_uo_field(self, form, request, obj):
+        if not (hasattr(form, "base_fields") and "unidade_orcamentaria" in form.base_fields):
+            return
+        form.base_fields["unidade_orcamentaria"].required = True
+        if obj is None and request.user.unidade_orcamentaria_id:
             initial_uo_id = self._resolver_uo_id_contexto_admin(request)
             if initial_uo_id:
                 form.base_fields["unidade_orcamentaria"].initial = initial_uo_id
-
-        if not request.user.is_superuser and "unidade_orcamentaria" in form.base_fields:
+        if not request.user.is_superuser:
             form.base_fields["unidade_orcamentaria"].disabled = True
             if request.user.unidade_orcamentaria_id:
                 form.base_fields["unidade_orcamentaria"].initial = (
                     request.user.unidade_orcamentaria_id
                 )
 
+    def _wrap_form_clean_with_validation(self, form, request):
         original_clean = form.clean
         request_ref = request
 
         def custom_clean(form_self):
             cleaned_data = original_clean(form_self)
-            _apply_usuario_clean_validation(form_ref=request_ref, admin=self, cleaned_data=cleaned_data)
+            _apply_usuario_clean_validation(
+                form_ref=request_ref, admin=self, cleaned_data=cleaned_data
+            )
             return cleaned_data
 
         form.clean = custom_clean
-        return form
 
     def save_related(self, request, form, formsets, change):
         super().save_related(request, form, formsets, change)


### PR DESCRIPTION

# Feature 141997 – Criação de Novos Campos no Bem Patrimonial

## História
**141997 – [Bens Físicos] Criação de novos campos de informação no Bem Patrimonial**

Esta implementação adiciona suporte à exibição da **justificativa das alterações**
no histórico do Bem Patrimonial dentro do Django Admin.

---

# Objetivo

Permitir que o campo **justificativa** seja exibido no histórico de alterações do
Bem Patrimonial, possibilitando maior rastreabilidade e transparência nas
modificações realizadas.

Além disso, foi ajustado o template do inline de histórico para garantir que os
**campos ocultos do formulário sejam renderizados corretamente**, evitando
inconsistências na submissão.

---

# Alterações Realizadas

## 1. Admin – Inclusão do campo `justificativa` no histórico

Arquivo:
bem_patrimonial/admins/bem_patrimonial.py

Alteração realizada na classe:
HistoricoGeralInline

### Antes

fields = (
    "campo",
    "valor_antigo",
    "valor_novo",
    "alterado_por",
    "alterado_em",
)

### Depois

fields = (
    "campo",
    "valor_antigo",
    "valor_novo",
    "justificativa",
    "alterado_por",
    "alterado_em",
)

### Resultado

O histórico exibido no admin agora apresenta também a **justificativa informada
na alteração do bem**.

---

## 2. Template do Admin – Renderização de campos ocultos

Arquivo:
config/templates/admin/bem_patrimonial/edit_inline/tabular-historico.html

Foi adicionada a renderização explícita dos **hidden fields** dentro da linha
do inline.

### Alteração adicionada

{% for hidden in inline_admin_form.form.hidden_fields %}
  {{ hidden }}
{% endfor %}

### Trecho atualizado

<tbody>
  {% for inline_admin_form in inline_admin_formset %}
    <tr class="{% cycle "row1" "row2" %}">
      {% for hidden in inline_admin_form.form.hidden_fields %}
        {{ hidden }}
      {% endfor %}
      {% for fieldset in inline_admin_form %}
        {% for line in fieldset %}
          {% for field in line %}

### Motivo

Garantir que **campos ocultos necessários ao funcionamento do inline**
sejam enviados corretamente no POST.

Sem essa renderização, podem ocorrer problemas como:

- inconsistência no gerenciamento do formset
- erros na submissão do formulário
- perda de valores ocultos necessários para o Django Admin

---

# Impacto

## Backend
Nenhuma alteração em models ou regras de negócio.

## Admin
Melhoria visual e funcional do histórico.

## Banco de dados
Nenhuma alteração.

---

# Resultado Esperado

No **histórico de alterações do Bem Patrimonial**, o admin agora exibirá:

- Campo alterado
- Valor antigo
- Valor novo
- Justificativa
- Usuário que realizou a alteração
- Data da alteração

---

# Benefícios

- Maior rastreabilidade das alterações
- Melhoria na auditoria de modificações
- Melhor transparência para gestão patrimonial
