### PR TITLE
Feature(143007): Endpoints de Unidades Administrativas

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -21,6 +21,7 @@ from drf_spectacular.views import (
     SpectacularRedocView,
 )
 from usuario import api_urls as auth_api_urls
+from dados_comuns import api_urls as dados_comuns_api_urls
 
 admin.site.site_title = settings.ADMIN_SITE_TITLE
 admin.site.site_header = settings.ADMIN_SITE_HEADER
@@ -37,6 +38,7 @@ urlpatterns = [
     path("", AdminLoginView.as_view(), name="login"),
     path("admin/login/", AdminLoginView.as_view(), name="admin_login"),
     path("api/bens/", include("bem_patrimonial.urls")),
+    path("api/", include(dados_comuns_api_urls)),
     # API de Autenticação
     path("api/auth/", include(auth_api_urls)),
     # Swagger/OpenAPI Documentação

--- a/dados_comuns/api_serializers.py
+++ b/dados_comuns/api_serializers.py
@@ -1,0 +1,130 @@
+import re
+
+from rest_framework import serializers
+
+from dados_comuns.models import UnidadeAdministrativa
+
+
+class UnidadeAdministrativaListSerializer(serializers.ModelSerializer):
+    unidade_orcamentaria_codigo = serializers.CharField(
+        source="unidade_orcamentaria.codigo", read_only=True
+    )
+    unidade_orcamentaria_nome = serializers.CharField(
+        source="unidade_orcamentaria.nome", read_only=True
+    )
+    unidade_orcamentaria_sigla = serializers.CharField(
+        source="unidade_orcamentaria.sigla", read_only=True
+    )
+    status_display = serializers.CharField(source="get_status_display", read_only=True)
+
+    class Meta:
+        model = UnidadeAdministrativa
+        fields = [
+            "id",
+            "codigo",
+            "sigla",
+            "nome",
+            "status",
+            "status_display",
+            "unidade_orcamentaria",
+            "unidade_orcamentaria_codigo",
+            "unidade_orcamentaria_nome",
+            "unidade_orcamentaria_sigla",
+            "created_at",
+            "updated_at",
+        ]
+        read_only_fields = fields
+
+
+class UnidadeAdministrativaDetailSerializer(UnidadeAdministrativaListSerializer):
+    CODIGO_SUFIXO_RE = re.compile(r"^\d{3,4}$")
+
+    class Meta(UnidadeAdministrativaListSerializer.Meta):
+        read_only_fields = ["id", "created_at", "updated_at"]
+        extra_kwargs = {
+            "codigo": {
+                "help_text": "Informe o sufixo numérico com 3 ou 4 dígitos (ex.: 002 ou 1002). O sistema compõe automaticamente o código completo com o prefixo da Unidade Orçamentária."
+            }
+        }
+
+    def _extrair_sufixo_codigo(self, codigo, codigo_uo):
+        codigo = (codigo or "").strip()
+
+        if self.CODIGO_SUFIXO_RE.fullmatch(codigo):
+            return codigo
+
+        prefixo = f"{codigo_uo}."
+        if codigo.startswith(prefixo):
+            candidato = codigo[len(prefixo) :]
+            if self.CODIGO_SUFIXO_RE.fullmatch(candidato):
+                return candidato
+
+        return None
+
+    def validate(self, attrs):
+        uo = attrs.get("unidade_orcamentaria")
+        if self.instance and uo is None:
+            uo = self.instance.unidade_orcamentaria
+
+        if uo is None:
+            return attrs
+
+        codigo_informado = attrs.get("codigo")
+
+        if self.instance and codigo_informado is None:
+            if "unidade_orcamentaria" in attrs:
+                sufixo = self._extrair_sufixo_codigo(
+                    self.instance.codigo,
+                    self.instance.unidade_orcamentaria.codigo,
+                )
+                if not sufixo:
+                    raise serializers.ValidationError(
+                        {
+                            "codigo": "Ao alterar a Unidade Orçamentária, informe o código com 3 ou 4 dígitos numéricos."
+                        }
+                    )
+                attrs["codigo"] = f"{uo.codigo}.{sufixo}"
+            return attrs
+
+        if codigo_informado is None:
+            raise serializers.ValidationError(
+                {
+                    "codigo": "Informe o código da unidade administrativa com 3 ou 4 dígitos numéricos."
+                }
+            )
+
+        sufixo = self._extrair_sufixo_codigo(str(codigo_informado), uo.codigo)
+        if not sufixo:
+            raise serializers.ValidationError(
+                {
+                    "codigo": "Código inválido. Informe 3 ou 4 dígitos numéricos (ex.: 002 ou 1002)."
+                }
+            )
+
+        attrs["codigo"] = f"{uo.codigo}.{sufixo}"
+        return attrs
+
+
+class UnidadeAdministrativaExportSerializer(serializers.ModelSerializer):
+    status_display = serializers.CharField(source="get_status_display", read_only=True)
+
+    class Meta:
+        model = UnidadeAdministrativa
+        fields = ["codigo", "sigla", "nome", "status_display"]
+
+
+class UnidadeAdministrativaHistoricoAcaoSerializer(serializers.Serializer):
+    campo = serializers.CharField()
+    valor_antigo = serializers.CharField(allow_null=True)
+    valor_novo = serializers.CharField(allow_null=True)
+
+
+class UnidadeAdministrativaHistoricoGrupoSerializer(serializers.Serializer):
+    alterado_em = serializers.DateTimeField()
+    alterado_por = serializers.IntegerField(allow_null=True)
+    alterado_por_nome = serializers.CharField(allow_null=True)
+    acoes = UnidadeAdministrativaHistoricoAcaoSerializer(many=True)
+
+
+class UnidadeAdministrativaExportQuerySerializer(serializers.Serializer):
+    formato = serializers.ChoiceField(choices=["csv", "xls", "xlsx", "pdf"])

--- a/dados_comuns/api_urls.py
+++ b/dados_comuns/api_urls.py
@@ -1,0 +1,12 @@
+from rest_framework.routers import DefaultRouter
+
+from dados_comuns.api_views import UnidadeAdministrativaViewSet
+
+router = DefaultRouter()
+router.register(
+    r"unidades-administrativas",
+    UnidadeAdministrativaViewSet,
+    basename="unidades-administrativas",
+)
+
+urlpatterns = router.urls

--- a/dados_comuns/api_views.py
+++ b/dados_comuns/api_views.py
@@ -1,0 +1,504 @@
+from collections import defaultdict
+from datetime import datetime
+
+from django.contrib.contenttypes.models import ContentType
+from django.db import transaction
+from django.db.models.deletion import ProtectedError
+from django.http import HttpResponse
+
+from django_filters.rest_framework import DjangoFilterBackend
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import (
+    OpenApiParameter,
+    OpenApiResponse,
+    extend_schema,
+    extend_schema_view,
+)
+from rest_framework import viewsets
+from rest_framework.decorators import action
+from rest_framework.exceptions import (
+    NotFound,
+    PermissionDenied,
+    ValidationError as DRFValidationError,
+)
+from rest_framework.filters import OrderingFilter, SearchFilter
+from rest_framework.response import Response
+
+from dados_comuns.api_serializers import (
+    UnidadeAdministrativaDetailSerializer,
+    UnidadeAdministrativaExportQuerySerializer,
+    UnidadeAdministrativaHistoricoGrupoSerializer,
+    UnidadeAdministrativaListSerializer,
+)
+from dados_comuns.context import audit_as
+from dados_comuns.formats import UnidadeAdministrativaPDFFormat
+from dados_comuns.models import HistoricoGeral, UnidadeAdministrativa
+from dados_comuns.permissions import UnidadeAdministrativaPermission
+from dados_comuns.resources import UnidadeAdministrativaResource
+from dados_comuns.utils import dict_changes
+
+
+UA_ID_PATH_PARAM = OpenApiParameter(
+    name="id",
+    required=True,
+    type=OpenApiTypes.INT,
+    location=OpenApiParameter.PATH,
+    description="Identificador numérico único da unidade administrativa.",
+)
+
+
+@extend_schema_view(
+    list=extend_schema(
+        tags=["Unidades Administrativas"],
+        summary="Listar unidades administrativas",
+        description="Lista paginada com busca, filtros e ordenação.",
+        parameters=[
+            OpenApiParameter(
+                name="search",
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.QUERY,
+                description="Busca em: codigo, sigla, nome, unidade_orcamentaria__codigo e unidade_orcamentaria__nome.",
+            ),
+            OpenApiParameter(
+                name="ordering",
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.QUERY,
+                description="Ordenação por: id, codigo, sigla, nome, status, created_at, updated_at, unidade_orcamentaria__codigo. Use '-' para descendente.",
+            ),
+            OpenApiParameter(
+                name="status",
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.QUERY,
+                description="Filtra por status da unidade administrativa (ativa/inativa).",
+            ),
+            OpenApiParameter(
+                name="unidade_orcamentaria",
+                type=OpenApiTypes.INT,
+                location=OpenApiParameter.QUERY,
+                description="Filtra por ID da Unidade Orçamentária. Retorna 403 quando o usuário não possui acesso ao escopo solicitado.",
+            ),
+            OpenApiParameter(
+                name="page",
+                type=OpenApiTypes.INT,
+                location=OpenApiParameter.QUERY,
+                description="Número da página.",
+            ),
+            OpenApiParameter(
+                name="page_size",
+                type=OpenApiTypes.INT,
+                location=OpenApiParameter.QUERY,
+                description="Quantidade de itens por página (máximo 100).",
+            ),
+        ],
+        responses={
+            200: OpenApiResponse(description="Lista retornada com sucesso."),
+            401: OpenApiResponse(description="Usuário não autenticado."),
+            403: OpenApiResponse(description="Usuário sem permissão para acessar o recurso."),
+        },
+    ),
+    retrieve=extend_schema(
+        tags=["Unidades Administrativas"],
+        summary="Detalhar unidade administrativa",
+        parameters=[UA_ID_PATH_PARAM],
+        responses={
+            200: OpenApiResponse(description="Detalhe retornado com sucesso."),
+            401: OpenApiResponse(description="Usuário não autenticado."),
+            403: OpenApiResponse(description="Usuário sem permissão para acessar o recurso."),
+            404: OpenApiResponse(description="Unidade administrativa não encontrada."),
+        },
+    ),
+    create=extend_schema(
+        tags=["Unidades Administrativas"],
+        summary="Criar unidade administrativa",
+        description="Cria unidade administrativa. O campo 'codigo' deve receber apenas o sufixo numérico com 3 ou 4 dígitos (ex.: 002 ou 1002). O backend compõe o código final com o prefixo da unidade orçamentária (ex.: 01.16.10.002).",
+        responses={
+            201: OpenApiResponse(description="Unidade administrativa criada com sucesso."),
+            400: OpenApiResponse(description="Dados inválidos."),
+            401: OpenApiResponse(description="Usuário não autenticado."),
+            403: OpenApiResponse(description="Usuário sem permissão para criar."),
+        },
+    ),
+    update=extend_schema(
+        tags=["Unidades Administrativas"],
+        summary="Atualizar unidade administrativa",
+        parameters=[UA_ID_PATH_PARAM],
+        responses={
+            200: OpenApiResponse(description="Unidade administrativa atualizada com sucesso."),
+            400: OpenApiResponse(description="Dados inválidos."),
+            401: OpenApiResponse(description="Usuário não autenticado."),
+            403: OpenApiResponse(description="Usuário sem permissão para atualizar."),
+            404: OpenApiResponse(description="Unidade administrativa não encontrada."),
+        },
+    ),
+    partial_update=extend_schema(
+        tags=["Unidades Administrativas"],
+        summary="Atualizar parcialmente unidade administrativa",
+        parameters=[UA_ID_PATH_PARAM],
+        responses={
+            200: OpenApiResponse(description="Unidade administrativa atualizada com sucesso."),
+            400: OpenApiResponse(description="Dados inválidos."),
+            401: OpenApiResponse(description="Usuário não autenticado."),
+            403: OpenApiResponse(description="Usuário sem permissão para atualizar."),
+            404: OpenApiResponse(description="Unidade administrativa não encontrada."),
+        },
+    ),
+    destroy=extend_schema(
+        tags=["Unidades Administrativas"],
+        summary="Excluir unidade administrativa",
+        description="Somente superusuário ou gestor de patrimônio podem excluir. A exclusão pode falhar caso existam vínculos protegidos no banco (ex.: bens patrimoniais associados).",
+        parameters=[UA_ID_PATH_PARAM],
+        responses={
+            204: OpenApiResponse(description="Unidade administrativa excluída com sucesso."),
+            400: OpenApiResponse(description="Não foi possível excluir por regra de integridade/vínculos."),
+            401: OpenApiResponse(description="Usuário não autenticado."),
+            403: OpenApiResponse(description="Usuário sem permissão para excluir."),
+            404: OpenApiResponse(description="Unidade administrativa não encontrada."),
+        },
+    ),
+)
+class UnidadeAdministrativaViewSet(viewsets.ModelViewSet):
+    permission_classes = [UnidadeAdministrativaPermission]
+
+    filter_backends = [DjangoFilterBackend, SearchFilter, OrderingFilter]
+    filterset_fields = ["status", "unidade_orcamentaria"]
+    search_fields = [
+        "codigo",
+        "sigla",
+        "nome",
+        "unidade_orcamentaria__codigo",
+        "unidade_orcamentaria__nome",
+    ]
+    ordering_fields = [
+        "id",
+        "codigo",
+        "sigla",
+        "nome",
+        "status",
+        "created_at",
+        "updated_at",
+        "unidade_orcamentaria__codigo",
+    ]
+    ordering = ["unidade_orcamentaria__codigo", "codigo", "sigla", "nome"]
+
+    AUDIT_TRACK_FIELDS = (
+        "unidade_orcamentaria",
+        "codigo",
+        "sigla",
+        "nome",
+        "status",
+    )
+
+    def get_serializer_class(self):
+        if self.action == "list":
+            return UnidadeAdministrativaListSerializer
+        return UnidadeAdministrativaDetailSerializer
+
+    def get_queryset(self):
+        qs = UnidadeAdministrativa.objects.select_related("unidade_orcamentaria")
+
+        user = self.request.user
+        if getattr(user, "is_superuser", False):
+            return qs
+
+        uo_id = getattr(user, "unidade_orcamentaria_id", None)
+        if uo_id:
+            return qs.filter(unidade_orcamentaria_id=uo_id)
+
+        ua_id = getattr(user, "unidade_administrativa_id", None)
+        if ua_id:
+            return qs.filter(pk=ua_id)
+
+        return qs.none()
+
+    def get_object(self):
+        obj = super().get_object()
+        user = self.request.user
+
+        if getattr(user, "is_superuser", False):
+            return obj
+
+        user_uo_id = getattr(user, "unidade_orcamentaria_id", None)
+        user_ua_id = getattr(user, "unidade_administrativa_id", None)
+
+        if user_uo_id:
+            if obj.unidade_orcamentaria_id == user_uo_id:
+                return obj
+            raise NotFound()
+
+        if user_ua_id:
+            if obj.pk == user_ua_id:
+                return obj
+            raise NotFound()
+
+        raise NotFound()
+
+    def _uo_ids_permitidos(self, user):
+        if getattr(user, "is_superuser", False):
+            return None
+
+        if getattr(user, "unidade_orcamentaria_id", None):
+            return {user.unidade_orcamentaria_id}
+
+        if getattr(user, "unidade_administrativa_id", None):
+            uo_id = (
+                UnidadeAdministrativa.objects.filter(pk=user.unidade_administrativa_id)
+                .values_list("unidade_orcamentaria_id", flat=True)
+                .first()
+            )
+            return {uo_id} if uo_id else set()
+
+        return set()
+
+    def _validar_filtro_unidade_orcamentaria(self):
+        raw_uo = self.request.query_params.get("unidade_orcamentaria")
+        if raw_uo in (None, ""):
+            return
+
+        try:
+            requested_uo_id = int(raw_uo)
+        except (TypeError, ValueError):
+            return
+
+        uo_ids_permitidos = self._uo_ids_permitidos(self.request.user)
+        if uo_ids_permitidos is None:
+            return
+
+        if requested_uo_id not in uo_ids_permitidos:
+            raise PermissionDenied(
+                "Você não tem acesso à Unidade Orçamentária informada no filtro."
+            )
+
+    def list(self, request, *args, **kwargs):
+        self._validar_filtro_unidade_orcamentaria()
+        return super().list(request, *args, **kwargs)
+
+    def _validate_uo_scope(self, validated_data, instance=None):
+        user = self.request.user
+
+        nova_uo = validated_data.get("unidade_orcamentaria")
+        if instance is not None and nova_uo is None:
+            nova_uo = instance.unidade_orcamentaria
+
+        if nova_uo is None:
+            raise DRFValidationError(
+                {"unidade_orcamentaria": "Unidade Orçamentária é obrigatória."}
+            )
+
+        if getattr(user, "is_superuser", False):
+            return
+
+        user_uo = getattr(user, "unidade_orcamentaria", None)
+        if user_uo is None or nova_uo != user_uo:
+            raise DRFValidationError(
+                {
+                    "unidade_orcamentaria": "Você não pode cadastrar Unidade Administrativa em outra Unidade Orçamentária."  # noqa: E501
+                }
+            )
+
+    def _audit_changes(self, obj, original=None, operation="update"):
+        ct = ContentType.objects.get_for_model(UnidadeAdministrativa)
+
+        if operation == "update" and original is not None:
+            changes = dict_changes(
+                original,
+                obj,
+                fields=self.AUDIT_TRACK_FIELDS,
+            )
+            if not changes:
+                return
+
+            HistoricoGeral.objects.bulk_create(
+                [
+                    HistoricoGeral(
+                        content_type=ct,
+                        object_id=str(obj.pk),
+                        campo=field,
+                        valor_antigo=old,
+                        valor_novo=new,
+                        alterado_por=self.request.user,
+                    )
+                    for field, (old, new) in changes.items()
+                ]
+            )
+            return
+
+        if operation == "create":
+            HistoricoGeral.objects.create(
+                content_type=ct,
+                object_id=str(obj.pk),
+                campo="acao",
+                valor_antigo="",
+                valor_novo="criado",
+                alterado_por=self.request.user,
+            )
+            return
+
+        if operation == "delete":
+            HistoricoGeral.objects.create(
+                content_type=ct,
+                object_id=str(obj.pk),
+                campo="acao",
+                valor_antigo="existente",
+                valor_novo="excluido",
+                alterado_por=self.request.user,
+            )
+
+    def perform_create(self, serializer):
+        self._validate_uo_scope(serializer.validated_data)
+        with transaction.atomic():
+            with audit_as(self.request.user):
+                obj = serializer.save()
+            self._audit_changes(obj, operation="create")
+
+    def perform_update(self, serializer):
+        original = UnidadeAdministrativa.objects.get(pk=serializer.instance.pk)
+        self._validate_uo_scope(serializer.validated_data, instance=serializer.instance)
+
+        with transaction.atomic():
+            with audit_as(self.request.user):
+                obj = serializer.save()
+            self._audit_changes(obj, original=original, operation="update")
+
+    def perform_destroy(self, instance):
+        with transaction.atomic():
+            try:
+                self._audit_changes(instance, operation="delete")
+                with audit_as(self.request.user):
+                    instance.delete()
+            except ProtectedError:
+                raise DRFValidationError(
+                    {
+                        "detail": "Não foi possível excluir esta Unidade Administrativa porque existem vínculos ativos no sistema."
+                    }
+                )
+
+    @extend_schema(
+        tags=["Unidades Administrativas"],
+        summary="Histórico da unidade administrativa",
+        description="Retorna o histórico de alterações da unidade administrativa informada no ID.",
+        parameters=[UA_ID_PATH_PARAM],
+        responses={
+            200: OpenApiResponse(
+                response=UnidadeAdministrativaHistoricoGrupoSerializer(many=True),
+                description="Histórico retornado com sucesso.",
+            ),
+            401: OpenApiResponse(description="Usuário não autenticado."),
+            403: OpenApiResponse(description="Usuário sem permissão para visualizar histórico."),
+            404: OpenApiResponse(description="Unidade administrativa não encontrada."),
+        },
+    )
+    @action(
+        detail=True,
+        methods=["get"],
+        url_path="historico",
+        filter_backends=[],
+        pagination_class=None,
+    )
+    def historico(self, request, pk=None):
+        ua = self.get_object()
+
+        ct = ContentType.objects.get_for_model(UnidadeAdministrativa)
+        historicos = (
+            HistoricoGeral.objects.filter(content_type=ct, object_id=str(ua.pk))
+            .select_related("alterado_por")
+            .order_by("-alterado_em")
+        )
+
+        agrupado = defaultdict(list)
+        for item in historicos:
+            chave = (item.alterado_em.replace(microsecond=0), item.alterado_por_id)
+            agrupado[chave].append(item)
+
+        resposta = []
+        for (alterado_em, alterado_por_id), itens in agrupado.items():
+            resposta.append(
+                {
+                    "alterado_em": alterado_em,
+                    "alterado_por": alterado_por_id,
+                    "alterado_por_nome": (
+                        itens[0].alterado_por.nome if itens[0].alterado_por else None
+                    ),
+                    "acoes": [
+                        {
+                            "campo": i.campo,
+                            "valor_antigo": i.valor_antigo,
+                            "valor_novo": i.valor_novo,
+                        }
+                        for i in itens
+                    ],
+                }
+            )
+
+        resposta_ordenada = sorted(
+            resposta,
+            key=lambda row: row["alterado_em"],
+            reverse=True,
+        )
+
+        serializer = UnidadeAdministrativaHistoricoGrupoSerializer(
+            resposta_ordenada,
+            many=True,
+        )
+        return Response(serializer.data)
+
+    @extend_schema(
+        tags=["Unidades Administrativas"],
+        summary="Exportar unidades administrativas",
+        description="Exporta os dados filtrados para csv, xls, xlsx ou pdf.",
+        parameters=[
+            OpenApiParameter(
+                name="formato",
+                required=True,
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.QUERY,
+                enum=["csv", "xls", "xlsx", "pdf"],
+            )
+        ],
+        responses={
+            200: OpenApiResponse(description="Arquivo de exportação gerado com sucesso."),
+            400: OpenApiResponse(description="Parâmetros inválidos para exportação."),
+            401: OpenApiResponse(description="Usuário não autenticado."),
+            403: OpenApiResponse(description="Usuário sem permissão para exportar ou sem acesso ao escopo filtrado."),
+        },
+    )
+    @action(detail=False, methods=["get"], url_path="exportar")
+    def exportar(self, request):
+        serializer = UnidadeAdministrativaExportQuerySerializer(
+            data=request.query_params
+        )
+        serializer.is_valid(raise_exception=True)
+        formato = serializer.validated_data["formato"]
+        self._validar_filtro_unidade_orcamentaria()
+
+        queryset = self.filter_queryset(self.get_queryset())
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        filename = f"unidades_administrativas_{timestamp}.{formato}"
+
+        if formato == "pdf":
+            pdf_format = UnidadeAdministrativaPDFFormat()
+            pdf_format._export_request = request
+            pdf_format._export_queryset = queryset
+            pdf_bytes = pdf_format.export_data(None)
+
+            response = HttpResponse(pdf_bytes, content_type="application/pdf")
+            response["Content-Disposition"] = f'attachment; filename="{filename}"'
+            return response
+
+        resource = UnidadeAdministrativaResource()
+        dataset = resource.export(queryset)
+
+        if formato == "csv":
+            content = dataset.csv.encode("utf-8-sig")
+            content_type = "text/csv"
+        elif formato == "xls":
+            content = dataset.xls
+            content_type = "application/vnd.ms-excel"
+        else:
+            content = dataset.xlsx
+            content_type = (
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+            )
+
+        response = HttpResponse(content, content_type=content_type)
+        response["Content-Disposition"] = f'attachment; filename="{filename}"'
+        return response

--- a/dados_comuns/permissions.py
+++ b/dados_comuns/permissions.py
@@ -61,3 +61,52 @@ class BemPatrimonialPermission(BasePermission):
             )
 
         return True
+
+
+class UnidadeAdministrativaPermission(BasePermission):
+    """
+    Regras de acesso para API de Unidade Administrativa:
+    - Listagem/detalhe/historico: superuser, gestor e operador.
+    - Criacao/edicao/exclusao/exportacao: apenas superuser e gestor.
+    """
+
+    def _pode_acessar_modulo(self, user):
+        if not user or not user.is_authenticated:
+            return False
+        if getattr(user, "is_superuser", False):
+            return True
+        return bool(
+            getattr(user, "is_gestor_patrimonio", False)
+            or getattr(user, "is_operador_inventario", False)
+        )
+
+    def _pode_gerenciar(self, user):
+        return bool(
+            getattr(user, "is_superuser", False)
+            or getattr(user, "is_gestor_patrimonio", False)
+        )
+
+    def has_permission(self, request, view):
+        if not self._pode_acessar_modulo(request.user):
+            return False
+
+        action = getattr(view, "action", None)
+
+        if action in ("list", "retrieve", "historico"):
+            return True
+
+        if action in ("create", "update", "partial_update", "destroy", "exportar"):
+            return self._pode_gerenciar(request.user)
+
+        return self._pode_gerenciar(request.user)
+
+    def has_object_permission(self, request, view, obj):
+        action = getattr(view, "action", None)
+
+        if action in ("retrieve", "historico"):
+            return True
+
+        if action in ("update", "partial_update", "destroy"):
+            return self._pode_gerenciar(request.user)
+
+        return True

--- a/dados_comuns/tests/tests_permissions_api.py
+++ b/dados_comuns/tests/tests_permissions_api.py
@@ -1,0 +1,144 @@
+from types import SimpleNamespace
+
+from django.test import SimpleTestCase
+
+from bem_patrimonial import constants as bem_constants
+from dados_comuns.permissions import (
+    BemPatrimonialPermission,
+    UnidadeAdministrativaPermission,
+)
+
+
+class PermissionsAPITestCase(SimpleTestCase):
+    def _request(self, user):
+        return SimpleNamespace(user=user)
+
+    def _view(self, action):
+        return SimpleNamespace(action=action)
+
+    def _user(
+        self,
+        *,
+        authenticated=True,
+        superuser=False,
+        gestor=False,
+        operador=False,
+    ):
+        return SimpleNamespace(
+            is_authenticated=authenticated,
+            is_superuser=superuser,
+            is_gestor_patrimonio=gestor,
+            is_operador_inventario=operador,
+        )
+
+    def test_bem_has_permission_cobre_ramos_principais(self):
+        perm = BemPatrimonialPermission()
+
+        user_sem_auth = self._user(authenticated=False)
+        self.assertFalse(perm.has_permission(self._request(user_sem_auth), self._view("list")))
+
+        user_super = self._user(superuser=True)
+        for action in ("create", "list", "retrieve", "update", "partial_update", "foo"):
+            with self.subTest(action=action):
+                self.assertTrue(perm.has_permission(self._request(user_super), self._view(action)))
+
+        user_operador = self._user(operador=True)
+        self.assertFalse(
+            perm.has_permission(self._request(user_operador), self._view("destroy"))
+        )
+
+        user_gestor = self._user(gestor=True)
+        self.assertTrue(
+            perm.has_permission(self._request(user_gestor), self._view("destroy"))
+        )
+
+    def test_bem_has_object_permission_cobre_ramos(self):
+        perm = BemPatrimonialPermission()
+        user_operador = self._user(operador=True)
+        user_gestor = self._user(gestor=True)
+
+        excluido = SimpleNamespace(excluido=True, status="qualquer")
+        self.assertFalse(
+            perm.has_object_permission(self._request(user_gestor), self._view("retrieve"), excluido)
+        )
+
+        baixa = SimpleNamespace(excluido=False, status=bem_constants.BAIXA_FISICA)
+        self.assertTrue(
+            perm.has_object_permission(self._request(user_gestor), self._view("retrieve"), baixa)
+        )
+        self.assertTrue(
+            perm.has_object_permission(self._request(user_gestor), self._view("historico"), baixa)
+        )
+        self.assertFalse(
+            perm.has_object_permission(self._request(user_gestor), self._view("update"), baixa)
+        )
+
+        normal = SimpleNamespace(excluido=False, status="ativo")
+        self.assertFalse(
+            perm.has_object_permission(self._request(user_operador), self._view("destroy"), normal)
+        )
+        self.assertTrue(
+            perm.has_object_permission(self._request(user_gestor), self._view("destroy"), normal)
+        )
+        self.assertTrue(
+            perm.has_object_permission(self._request(user_operador), self._view("update"), normal)
+        )
+
+    def test_ua_has_permission_cobre_ramos_principais(self):
+        perm = UnidadeAdministrativaPermission()
+
+        self.assertFalse(
+            perm.has_permission(self._request(self._user(authenticated=False)), self._view("list"))
+        )
+
+        superuser = self._user(superuser=True)
+        for action in (
+            "list",
+            "retrieve",
+            "historico",
+            "create",
+            "update",
+            "partial_update",
+            "destroy",
+            "exportar",
+            "acao_desconhecida",
+        ):
+            with self.subTest(action=action):
+                self.assertTrue(perm.has_permission(self._request(superuser), self._view(action)))
+
+        operador = self._user(operador=True)
+        self.assertTrue(perm.has_permission(self._request(operador), self._view("list")))
+        self.assertTrue(perm.has_permission(self._request(operador), self._view("historico")))
+        self.assertFalse(perm.has_permission(self._request(operador), self._view("create")))
+        self.assertFalse(perm.has_permission(self._request(operador), self._view("acao_desconhecida")))
+
+    def test_ua_has_object_permission_cobre_ramos(self):
+        perm = UnidadeAdministrativaPermission()
+        operador = self._user(operador=True)
+        gestor = self._user(gestor=True)
+        obj = SimpleNamespace()
+
+        self.assertTrue(
+            perm.has_object_permission(self._request(operador), self._view("retrieve"), obj)
+        )
+        self.assertTrue(
+            perm.has_object_permission(self._request(operador), self._view("historico"), obj)
+        )
+
+        self.assertFalse(
+            perm.has_object_permission(self._request(operador), self._view("destroy"), obj)
+        )
+        self.assertTrue(
+            perm.has_object_permission(self._request(gestor), self._view("destroy"), obj)
+        )
+
+        self.assertFalse(
+            perm.has_object_permission(self._request(operador), self._view("update"), obj)
+        )
+        self.assertTrue(
+            perm.has_object_permission(self._request(gestor), self._view("partial_update"), obj)
+        )
+
+        self.assertTrue(
+            perm.has_object_permission(self._request(operador), self._view("acao_desconhecida"), obj)
+        )

--- a/dados_comuns/tests/tests_unidade_administrativa_api.py
+++ b/dados_comuns/tests/tests_unidade_administrativa_api.py
@@ -1,0 +1,331 @@
+from unittest.mock import patch
+
+from django.contrib.auth.models import Group
+from django.db.models.deletion import ProtectedError
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from dados_comuns.models import UnidadeAdministrativa
+from dados_comuns.tests.factories import criar_ua, criar_uo
+from usuario.constants import GRUPO_GESTOR_PATRIMONIO, GRUPO_OPERADOR_INVENTARIO
+from usuario.models import Usuario
+
+
+class UnidadeAdministrativaAPITestCase(APITestCase):
+    LIST_FIELDS = {
+        "id",
+        "codigo",
+        "sigla",
+        "nome",
+        "status",
+        "status_display",
+        "unidade_orcamentaria",
+        "unidade_orcamentaria_codigo",
+        "unidade_orcamentaria_nome",
+        "unidade_orcamentaria_sigla",
+        "created_at",
+        "updated_at",
+    }
+
+    def setUp(self):
+        self.uo1 = criar_uo(codigo="10.10.10", nome="UO 1")
+        self.uo2 = criar_uo(codigo="20.20.20", nome="UO 2")
+
+        self.ua1 = criar_ua(
+            uo=self.uo1,
+            codigo="10.10.10.001",
+            sigla="UA1",
+            nome="Unidade 1",
+            status=UnidadeAdministrativa.ATIVA,
+        )
+        self.ua2 = criar_ua(
+            uo=self.uo1,
+            codigo="10.10.10.002",
+            sigla="UA2",
+            nome="Unidade 2",
+            status=UnidadeAdministrativa.INATIVA,
+        )
+        self.ua3 = criar_ua(
+            uo=self.uo2,
+            codigo="20.20.20.003",
+            sigla="UA3",
+            nome="Unidade 3",
+            status=UnidadeAdministrativa.ATIVA,
+        )
+
+        grupo_gestor = Group.objects.get_or_create(name=GRUPO_GESTOR_PATRIMONIO)[0]
+        grupo_operador = Group.objects.get_or_create(name=GRUPO_OPERADOR_INVENTARIO)[0]
+
+        self.gestor = Usuario.objects.create_user(
+            username="gestor_ua_api",
+            email="gestor.ua.api@test.com",
+            password="test123",
+            nome="Gestor UA",
+            is_staff=True,
+            unidade_orcamentaria=self.uo1,
+        )
+        self.gestor.groups.add(grupo_gestor)
+
+        self.operador = Usuario.objects.create_user(
+            username="operador_ua_api",
+            email="operador.ua.api@test.com",
+            password="test123",
+            nome="Operador UA",
+            is_staff=True,
+            unidade_orcamentaria=self.uo1,
+            unidade_administrativa=self.ua1,
+        )
+        self.operador.groups.add(grupo_operador)
+
+        self.superuser = Usuario.objects.create_user(
+            username="super_ua_api",
+            email="super.ua.api@test.com",
+            password="test123",
+            nome="Super UA",
+            is_staff=True,
+            is_superuser=True,
+        )
+
+        self.list_url = reverse("unidades-administrativas-list")
+
+    def _auth(self, user):
+        self.client.force_authenticate(user)
+
+    def _payload_ua(self, *, uo_id, codigo=None, sigla="UA", nome="Unidade", status_="ativa"):
+        payload = {
+            "unidade_orcamentaria": uo_id,
+            "sigla": sigla,
+            "nome": nome,
+            "status": status_,
+        }
+        if codigo is not None:
+            payload["codigo"] = codigo
+        return payload
+
+    def _assert_response_fields(self, payload):
+        self.assertEqual(set(payload.keys()), self.LIST_FIELDS)
+
+    def _get_detail_url(self, ua_id):
+        return reverse("unidades-administrativas-detail", args=[ua_id])
+
+    def test_nao_autenticado_retorna_401_no_get(self):
+        response = self.client.get(self.list_url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_listagem_respeita_escopo_por_perfil(self):
+        cenarios = [
+            (self.gestor, {self.ua1.id, self.ua2.id}, {self.ua3.id}),
+            (self.operador, {self.ua1.id, self.ua2.id}, {self.ua3.id}),
+            (self.superuser, {self.ua1.id, self.ua2.id, self.ua3.id}, set()),
+        ]
+
+        for user, deve_ter, nao_deve_ter in cenarios:
+            with self.subTest(user=user.username):
+                self._auth(user)
+                response = self.client.get(self.list_url)
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+                ids = {row["id"] for row in response.data["results"]}
+                self.assertTrue(deve_ter.issubset(ids))
+                self.assertTrue(ids.isdisjoint(nao_deve_ter))
+                self._assert_response_fields(response.data["results"][0])
+
+    def test_listagem_filtros_ordenacao_e_campos(self):
+        self._auth(self.gestor)
+
+        response = self.client.get(
+            self.list_url,
+            {
+                "status": UnidadeAdministrativa.ATIVA,
+                "search": "Unidade 1",
+                "ordering": "-codigo",
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["results"]), 1)
+        self.assertEqual(response.data["results"][0]["id"], self.ua1.id)
+        self.assertIn("unidade_orcamentaria_sigla", response.data["results"][0])
+
+        response_id = self.client.get(self.list_url, {"ordering": "-id"})
+        ids = [row["id"] for row in response_id.data["results"]]
+        self.assertEqual(ids, sorted(ids, reverse=True))
+
+    def test_retrieve_campos_completos_e_escopo(self):
+        self._auth(self.gestor)
+
+        ok = self.client.get(self._get_detail_url(self.ua1.id))
+        self.assertEqual(ok.status_code, status.HTTP_200_OK)
+        self.assertEqual(ok.data["id"], self.ua1.id)
+        self.assertEqual(ok.data["status_display"], "Ativa")
+        self.assertEqual(ok.data["unidade_orcamentaria_sigla"], self.uo1.sigla)
+        self._assert_response_fields(ok.data)
+
+        fora_escopo = self.client.get(self._get_detail_url(self.ua3.id))
+        self.assertEqual(fora_escopo.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_filtro_unidade_orcamentaria_fora_escopo_retorna_403(self):
+        self._auth(self.gestor)
+        response = self.client.get(self.list_url, {"unidade_orcamentaria": self.uo2.id})
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertIn("detail", response.data)
+
+    def test_criacao_codigo_valido_em_varios_formatos(self):
+        self._auth(self.gestor)
+        cenarios = [
+            ("050", "10.10.10.050"),
+            ("1002", "10.10.10.1002"),
+            ("10.10.10.777", "10.10.10.777"),
+        ]
+
+        for codigo_in, codigo_out in cenarios:
+            with self.subTest(codigo=codigo_in):
+                response = self.client.post(
+                    self.list_url,
+                    self._payload_ua(
+                        uo_id=self.uo1.id,
+                        codigo=codigo_in,
+                        sigla=f"UA{codigo_in}",
+                        nome=f"Unidade {codigo_in}",
+                    ),
+                    format="json",
+                )
+                self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+                self.assertEqual(response.data["codigo"], codigo_out)
+
+    def test_criacao_com_erro_de_validacao(self):
+        self._auth(self.gestor)
+
+        cenarios = [
+            (self._payload_ua(uo_id=self.uo1.id, codigo=None), "codigo"),
+            (self._payload_ua(uo_id=self.uo1.id, codigo="AB12"), "codigo"),
+            (self._payload_ua(uo_id=self.uo2.id, codigo="20.20.20.050"), "unidade_orcamentaria"),
+        ]
+
+        for payload, campo_esperado in cenarios:
+            with self.subTest(campo=campo_esperado, payload=payload):
+                response = self.client.post(self.list_url, payload, format="json")
+                self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+                self.assertIn(campo_esperado, response.data)
+
+    def test_superuser_pode_criar_em_qualquer_uo(self):
+        self._auth(self.superuser)
+        response = self.client.post(
+            self.list_url,
+            self._payload_ua(
+                uo_id=self.uo2.id,
+                codigo="090",
+                sigla="UA90",
+                nome="UA do Superuser",
+            ),
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data["unidade_orcamentaria"], self.uo2.id)
+        self.assertEqual(response.data["codigo"], "20.20.20.090")
+
+    def test_operador_nao_pode_criar_editar_excluir(self):
+        self._auth(self.operador)
+
+        create_resp = self.client.post(
+            self.list_url,
+            self._payload_ua(
+                uo_id=self.uo1.id,
+                codigo="060",
+                sigla="UA60",
+                nome="Unidade Sem Permissao",
+            ),
+            format="json",
+        )
+        self.assertEqual(create_resp.status_code, status.HTTP_403_FORBIDDEN)
+
+        detail_url = self._get_detail_url(self.ua1.id)
+        patch_resp = self.client.patch(detail_url, {"nome": "Nome Alterado"}, format="json")
+        self.assertEqual(patch_resp.status_code, status.HTTP_403_FORBIDDEN)
+
+        delete_resp = self.client.delete(detail_url)
+        self.assertEqual(delete_resp.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_patch_troca_uo_com_codigo_legado_invalido_rejeita(self):
+        ua_legado = criar_ua(
+            uo=self.uo1,
+            codigo="CODIGO-LEGADO",
+            sigla="UAL",
+            nome="UA Legado",
+            status=UnidadeAdministrativa.ATIVA,
+        )
+
+        self._auth(self.superuser)
+        response = self.client.patch(
+            self._get_detail_url(ua_legado.id),
+            {"unidade_orcamentaria": self.uo2.id},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("codigo", response.data)
+
+    def test_historico_retorna_lista_e_ignora_filtros(self):
+        self._auth(self.gestor)
+        detail_url = self._get_detail_url(self.ua1.id)
+        patch_resp = self.client.patch(detail_url, {"nome": "Unidade 1 Alterada"}, format="json")
+        self.assertEqual(patch_resp.status_code, status.HTTP_200_OK)
+
+        historico_url = reverse("unidades-administrativas-historico", args=[self.ua1.id])
+        response = self.client.get(
+            historico_url,
+            {
+                "search": "abc",
+                "ordering": "-id",
+                "status": UnidadeAdministrativa.INATIVA,
+                "page": 10,
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIsInstance(response.data, list)
+        self.assertGreaterEqual(len(response.data), 1)
+        self.assertIn("acoes", response.data[0])
+
+    def test_exportacao_por_formato_permitido(self):
+        self._auth(self.gestor)
+        formatos = {
+            "csv": "text/csv",
+            "xls": "application/vnd.ms-excel",
+            "xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            "pdf": "application/pdf",
+        }
+
+        for formato, content_type in formatos.items():
+            with self.subTest(formato=formato):
+                response = self.client.get(
+                    reverse("unidades-administrativas-exportar"),
+                    {"formato": formato},
+                )
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+                self.assertEqual(response["Content-Type"], content_type)
+                self.assertIn("attachment;", response["Content-Disposition"])
+
+    def test_exportacao_validacoes_e_permissoes(self):
+        self._auth(self.operador)
+        bloqueado = self.client.get(reverse("unidades-administrativas-exportar"), {"formato": "csv"})
+        self.assertEqual(bloqueado.status_code, status.HTTP_403_FORBIDDEN)
+
+        self._auth(self.gestor)
+        invalido = self.client.get(reverse("unidades-administrativas-exportar"), {"formato": "xml"})
+        self.assertEqual(invalido.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("formato", invalido.data)
+
+    def test_delete_quando_protected_error_retorna_400(self):
+        self._auth(self.gestor)
+        detail_url = self._get_detail_url(self.ua1.id)
+
+        with patch.object(
+            UnidadeAdministrativa,
+            "delete",
+            side_effect=ProtectedError("protegido", []),
+        ):
+            response = self.client.delete(detail_url)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("detail", response.data)


### PR DESCRIPTION
## 🎯 Objetivo principal

- Implementar e padronizar endpoints REST de Unidades Administrativas para integração com Front-End.
- Garantir escopo de acesso por perfil, exportação de dados, histórico de alterações e documentação OpenAPI em português.
- Aumentar confiabilidade via testes automatizados com cobertura alta.

## 🔌 Endpoints adicionados e comportamento

Novos endpoints (router DRF em dados_comuns/api_urls.py):

- GET /api/unidades-administrativas/
- POST /api/unidades-administrativas/
- GET /api/unidades-administrativas/{id}/
- PUT /api/unidades-administrativas/{id}/
- PATCH /api/unidades-administrativas/{id}/
- DELETE /api/unidades-administrativas/{id}/
- GET /api/unidades-administrativas/{id}/historico/
- GET /api/unidades-administrativas/exportar/?formato=csv|xls|xlsx|pdf

## 🧠 Regras de negócio implementadas

- Escopo de dados por usuário:

  - Superusuário: acesso total.
  - Usuário com Unidade Orçamentária: enxerga UAs da própria UO.
  - Usuário com Unidade Administrativa e sem UO: enxerga somente a própria UA.

- Filtro por unidade_orcamentaria fora do escopo retorna 403 com mensagem explícita.
- Campo codigo:

  - Aceita sufixo numérico de 3 ou 4 dígitos.
  - Backend compõe o código final com prefixo da Unidade Orçamentária.
  - Aceita código completo válido no mesmo padrão.
  - Ao trocar UO em registro legado sem sufixo válido, retorna erro de validação.

- Exclusão:

  - Permitida apenas para superusuário e gestor (via permission class).
  - Tratamento de ProtectedError com retorno 400 e mensagem clara.

- Histórico:

  - Endpoint dedicado por id.
  - Sem paginação/filtros de listagem aplicados no histórico.

## 🛡️ Permissões

Permissões centralizadas em dados_comuns/permissions.py:

- UnidadeAdministrativaPermission

  - list/retrieve/historico: superuser, gestor, operador.
  - create/update/partial_update/destroy/exportar: superuser e gestor.

## 📘 Documentação OpenAPI (Swagger)

Melhorias aplicadas em dados_comuns/api_views.py:

- Descrições em português.
- Parâmetro de path id documentado explicitamente (evita texto padrão em inglês).
- Códigos HTTP documentados por endpoint.
- Endpoint de histórico com resposta 200 explicitamente descrita.
- Descrição dos campos suportados em search, ordering e filtros de listagem.

## 🧪 Testes automatizados

Resumo da suíte:

- Total executado: 18 testes.
- Foco: autenticação, escopo, CRUD, validações de código, histórico, exportação e permissões.

### Arquivo: dados_comuns/tests/tests_unidade_administrativa_api.py (14 testes)

1. test_nao_autenticado_retorna_401_no_get: garante autenticação obrigatória na listagem.
2. test_listagem_respeita_escopo_por_perfil: valida escopo para gestor, operador e superusuário, incluindo contrato de campos.
3. test_listagem_filtros_ordenacao_e_campos: valida filtros, busca, ordenação por codigo/id e presença de unidade_orcamentaria_sigla.
4. test_retrieve_campos_completos_e_escopo: valida payload completo do detalhe e bloqueio por escopo (404).
5. test_filtro_unidade_orcamentaria_fora_escopo_retorna_403: valida proteção de escopo no filtro de UO.
6. test_criacao_codigo_valido_em_varios_formatos: valida criação com sufixo 3/4 dígitos e com código completo.
7. test_criacao_com_erro_de_validacao: valida erros para código ausente/inválido e criação fora de escopo do gestor.
8. test_superuser_pode_criar_em_qualquer_uo: garante criação irrestrita por superusuário.
9. test_operador_nao_pode_criar_editar_excluir: garante bloqueio de create/patch/delete para operador.
10. test_patch_troca_uo_com_codigo_legado_invalido_rejeita: garante rejeição de atualização em legado inválido.
11. test_historico_retorna_lista_e_ignora_filtros: valida endpoint de histórico sem efeitos de filtros/paginação da listagem.
12. test_exportacao_por_formato_permitido: valida exportação bem-sucedida em csv, xls, xlsx e pdf.
13. test_exportacao_validacoes_e_permissoes: valida bloqueio para operador e rejeição de formato inválido.
14. test_delete_quando_protected_error_retorna_400: valida tratamento de ProtectedError com retorno 400.

### Arquivo: dados_comuns/tests/tests_permissions_api.py (4 testes)

1. test_bem_has_permission_cobre_ramos_principais: cobre has_permission da BemPatrimonialPermission para ações/perfis principais.
2. test_bem_has_object_permission_cobre_ramos: cobre has_object_permission da BemPatrimonialPermission (objeto excluído, baixa física, destroy, update).
3. test_ua_has_permission_cobre_ramos_principais: cobre has_permission da UnidadeAdministrativaPermission para leitura, gestão e ação desconhecida.
4. test_ua_has_object_permission_cobre_ramos: cobre has_object_permission da UnidadeAdministrativaPermission para retrieve, historico, update, partial_update, destroy e ação desconhecida.

## 📊 Resultado de execução e cobertura

Execução realizada:

 ``` bash
docker compose -f docker-compose-dev.yml exec web python manage.py test dados_comuns.tests.tests_unidade_administrativa_api dados_comuns.tests.tests_permissions_api
```
- Resultado: 18 testes, todos passando.

## ✅ Checklist final da PR

- Endpoints REST de Unidades Administrativas implementados.
- Permissões por perfil aplicadas e testadas.
- Histórico por id implementado e documentado.
- Exportação csv/xls/xlsx/pdf implementada e testada.
- Swagger/OpenAPI revisado em português e com códigos HTTP documentados.
- Testes automatizados criados/ajustados com cobertura alta.
