### PR TITLE
Backend: Criação de Bens Patrimoniais

### DIFF
--- a/bem_patrimonial/serializers/bem_patrimonial_serializers.py
+++ b/bem_patrimonial/serializers/bem_patrimonial_serializers.py
@@ -8,6 +8,7 @@ from rest_framework import serializers
 
 from bem_patrimonial.models import BemPatrimonial
 from bem_patrimonial import constants
+from dados_comuns.models import UnidadeAdministrativa
 
 
 class _BemPatrimonialBaseMixin(serializers.Serializer):
@@ -381,3 +382,83 @@ class BemPatrimonialDetailSerializer(
             if hasattr(e, "message_dict"):
                 raise serializers.ValidationError(e.message_dict)
             raise serializers.ValidationError(str(e))
+
+
+class BemItemCriacaoSerializer(serializers.Serializer):
+    """Dados únicos de cada bem na criação em lote."""
+
+    numero_patrimonial = serializers.CharField(required=False, allow_blank=True, default="")
+    numero_formato_antigo = serializers.BooleanField(required=False, default=False)
+    sem_numeracao = serializers.BooleanField(required=False, default=False)
+    localizacao = serializers.CharField(required=False, allow_blank=True, default="")
+
+
+class BemPatrimonialMultiCreateSerializer(_BemPatrimonialBaseMixin, serializers.Serializer):
+    """
+    Criação em lote: dados base compartilhados + lista de bens (multi_payload).
+
+    Valida todos os bens antes de persistir qualquer um — se qualquer número
+    patrimonial for inválido ou duplicado (no payload ou no banco), nenhum bem é criado.
+    """
+
+    unidade_administrativa = serializers.PrimaryKeyRelatedField(
+        queryset=UnidadeAdministrativa.objects.all()
+    )
+    nome = serializers.CharField()
+    descricao = serializers.CharField()
+    valor_unitario = serializers.CharField()
+    marca = serializers.CharField()
+    modelo = serializers.CharField()
+    numero_processo = serializers.CharField(required=False, allow_blank=True, default="")
+    multi_payload = BemItemCriacaoSerializer(many=True)
+
+    def validate(self, attrs):
+        attrs["valor_unitario"] = self._parse_valor_unitario(attrs.get("valor_unitario"))
+
+        multi_payload = attrs.get("multi_payload", [])
+        if not multi_payload:
+            raise serializers.ValidationError(
+                {"multi_payload": "Informe ao menos um bem."}
+            )
+        linhas_errors = {}
+        numeros_vistos = set()
+
+        for i, item in enumerate(multi_payload):
+            item_errors = {}
+            sem = bool(item.get("sem_numeracao"))
+            antigo = bool(item.get("numero_formato_antigo"))
+            numero = (item.get("numero_patrimonial") or "").strip() or None
+
+            if sem and antigo:
+                item_errors["numero_patrimonial"] = (
+                    "Selecione 'Formato antigo' OU 'Sem numeração' — não ambos."
+                )
+            elif not sem:
+                if not numero:
+                    item_errors["numero_patrimonial"] = (
+                        "Informe o Número Patrimonial ou marque 'Sem numeração'."
+                    )
+                elif not antigo and not re.fullmatch(self._NEW_FMT_RE, numero):
+                    item_errors["numero_patrimonial"] = (
+                        "Use o formato 000.000000000-0 ou marque 'Formato antigo'."
+                    )
+                elif numero in numeros_vistos:
+                    item_errors["numero_patrimonial"] = (
+                        "Número patrimonial duplicado neste cadastro."
+                    )
+                elif BemPatrimonial.objects.filter(
+                    numero_patrimonial=numero, excluido=False
+                ).exists():
+                    item_errors["numero_patrimonial"] = (
+                        "Número Patrimonial já está cadastrado no sistema."
+                    )
+                else:
+                    numeros_vistos.add(numero)
+
+            if item_errors:
+                linhas_errors[str(i)] = item_errors
+
+        if linhas_errors:
+            raise serializers.ValidationError({"linhas": linhas_errors})
+
+        return attrs

--- a/bem_patrimonial/tests/test_serializers.py
+++ b/bem_patrimonial/tests/test_serializers.py
@@ -6,6 +6,7 @@ from bem_patrimonial.models import BemPatrimonial
 from bem_patrimonial.serializers.bem_patrimonial_serializers import (
     BemPatrimonialDetailSerializer,
     BemPatrimonialListSerializer,
+    BemPatrimonialMultiCreateSerializer,
 )
 from bem_patrimonial import constants
 from dados_comuns.tests.factories import criar_ua, criar_uo
@@ -160,3 +161,281 @@ class BemPatrimonialSerializerTest(TestCase):
                 serializer.save()
         else:
             self.assertIn("numero_patrimonial", serializer.errors)
+
+
+class BemPatrimonialMultiCreateSerializerTest(TestCase):
+    def setUp(self):
+        user_model = get_user_model()
+        self.user = user_model.objects.create_superuser(
+            username="admin_multi",
+            email="admin_multi@example.com",
+            **auth_kwargs("admin123"),
+        )
+        self.uo = criar_uo(codigo="200", nome="UO 200")
+        self.ua = criar_ua(nome="UA Multi", uo=self.uo)
+
+        self.user.unidade_administrativa = self.ua
+        self.user.save()
+
+        self.factory = RequestFactory()
+
+    def _get_request(self):
+        request = self.factory.post("/fake/")
+        request.user = self.user
+        return request
+
+    def _payload_base(self, **kwargs):
+        data = {
+            "unidade_administrativa": self.ua.id,
+            "nome": "Mesa",
+            "descricao": "Mesa de escritório",
+            "valor_unitario": "1.500,00",
+            "marca": "Tokio",
+            "modelo": "T200",
+            "numero_processo": "PROC-99",
+        }
+        data.update(kwargs)
+        return data
+
+    def _item(self, **kwargs):
+        item = {
+            "numero_patrimonial": "000.000000001-0",
+            "numero_formato_antigo": False,
+            "sem_numeracao": False,
+            "localizacao": "Sala A",
+        }
+        item.update(kwargs)
+        return item
+
+    # ------------------------------------------------------------------
+    # Casos de sucesso
+    # ------------------------------------------------------------------
+
+    def test_cria_um_bem_com_numero_valido(self):
+        data = self._payload_base(multi_payload=[self._item()])
+        s = BemPatrimonialMultiCreateSerializer(
+            data=data, context={"request": self._get_request()}
+        )
+        self.assertTrue(s.is_valid(), s.errors)
+
+    def test_cria_multiplos_bens_com_numeros_distintos(self):
+        data = self._payload_base(
+            multi_payload=[
+                self._item(numero_patrimonial="000.000000011-0"),
+                self._item(numero_patrimonial="000.000000012-0"),
+            ]
+        )
+        s = BemPatrimonialMultiCreateSerializer(
+            data=data, context={"request": self._get_request()}
+        )
+        self.assertTrue(s.is_valid(), s.errors)
+
+    def test_cria_bem_sem_numeracao(self):
+        data = self._payload_base(
+            multi_payload=[
+                {
+                    "numero_patrimonial": "",
+                    "numero_formato_antigo": False,
+                    "sem_numeracao": True,
+                    "localizacao": "Sala B",
+                }
+            ]
+        )
+        s = BemPatrimonialMultiCreateSerializer(
+            data=data, context={"request": self._get_request()}
+        )
+        self.assertTrue(s.is_valid(), s.errors)
+
+    def test_cria_bem_com_formato_antigo(self):
+        data = self._payload_base(
+            multi_payload=[
+                self._item(
+                    numero_patrimonial="ANTIGO-123",
+                    numero_formato_antigo=True,
+                )
+            ]
+        )
+        s = BemPatrimonialMultiCreateSerializer(
+            data=data, context={"request": self._get_request()}
+        )
+        self.assertTrue(s.is_valid(), s.errors)
+
+    def test_valor_unitario_aceita_formato_brasileiro(self):
+        data = self._payload_base(
+            valor_unitario="2.500,99",
+            multi_payload=[self._item(numero_patrimonial="000.000000020-0")],
+        )
+        s = BemPatrimonialMultiCreateSerializer(
+            data=data, context={"request": self._get_request()}
+        )
+        self.assertTrue(s.is_valid(), s.errors)
+        from decimal import Decimal
+        self.assertEqual(s.validated_data["valor_unitario"], Decimal("2500.99"))
+
+    # ------------------------------------------------------------------
+    # Validação de campos base obrigatórios
+    # ------------------------------------------------------------------
+
+    def test_erro_sem_nome(self):
+        data = self._payload_base(
+            nome="", multi_payload=[self._item(numero_patrimonial="000.000000030-0")]
+        )
+        s = BemPatrimonialMultiCreateSerializer(
+            data=data, context={"request": self._get_request()}
+        )
+        self.assertFalse(s.is_valid())
+        self.assertIn("nome", s.errors)
+
+    def test_erro_sem_descricao(self):
+        data = self._payload_base(
+            descricao="",
+            multi_payload=[self._item(numero_patrimonial="000.000000031-0")],
+        )
+        s = BemPatrimonialMultiCreateSerializer(
+            data=data, context={"request": self._get_request()}
+        )
+        self.assertFalse(s.is_valid())
+        self.assertIn("descricao", s.errors)
+
+    def test_erro_sem_marca(self):
+        data = self._payload_base(
+            marca="", multi_payload=[self._item(numero_patrimonial="000.000000032-0")]
+        )
+        s = BemPatrimonialMultiCreateSerializer(
+            data=data, context={"request": self._get_request()}
+        )
+        self.assertFalse(s.is_valid())
+        self.assertIn("marca", s.errors)
+
+    def test_erro_sem_modelo(self):
+        data = self._payload_base(
+            modelo="", multi_payload=[self._item(numero_patrimonial="000.000000033-0")]
+        )
+        s = BemPatrimonialMultiCreateSerializer(
+            data=data, context={"request": self._get_request()}
+        )
+        self.assertFalse(s.is_valid())
+        self.assertIn("modelo", s.errors)
+
+    def test_erro_multi_payload_vazio(self):
+        data = self._payload_base(multi_payload=[])
+        s = BemPatrimonialMultiCreateSerializer(
+            data=data, context={"request": self._get_request()}
+        )
+        self.assertFalse(s.is_valid())
+        self.assertIn("multi_payload", s.errors)
+
+    # ------------------------------------------------------------------
+    # Validação por linha
+    # ------------------------------------------------------------------
+
+    def test_erro_numero_formato_invalido_retorna_erros_por_linha(self):
+        data = self._payload_base(
+            multi_payload=[
+                self._item(
+                    numero_patrimonial="INVALIDO",
+                    numero_formato_antigo=False,
+                )
+            ]
+        )
+        s = BemPatrimonialMultiCreateSerializer(
+            data=data, context={"request": self._get_request()}
+        )
+        self.assertFalse(s.is_valid())
+        self.assertIn("linhas", s.errors)
+        self.assertIn("0", s.errors["linhas"])
+        self.assertIn("numero_patrimonial", s.errors["linhas"]["0"])
+
+    def test_erro_sem_numero_e_sem_flag_sem_numeracao(self):
+        data = self._payload_base(
+            multi_payload=[
+                self._item(
+                    numero_patrimonial="",
+                    sem_numeracao=False,
+                )
+            ]
+        )
+        s = BemPatrimonialMultiCreateSerializer(
+            data=data, context={"request": self._get_request()}
+        )
+        self.assertFalse(s.is_valid())
+        self.assertIn("linhas", s.errors)
+
+    def test_erro_sem_numeracao_e_formato_antigo_juntos(self):
+        data = self._payload_base(
+            multi_payload=[
+                self._item(
+                    numero_patrimonial="",
+                    sem_numeracao=True,
+                    numero_formato_antigo=True,
+                )
+            ]
+        )
+        s = BemPatrimonialMultiCreateSerializer(
+            data=data, context={"request": self._get_request()}
+        )
+        self.assertFalse(s.is_valid())
+        self.assertIn("linhas", s.errors)
+
+    def test_erro_duplicata_no_payload(self):
+        numero = "000.000000050-0"
+        data = self._payload_base(
+            multi_payload=[
+                self._item(numero_patrimonial=numero),
+                self._item(numero_patrimonial=numero),
+            ]
+        )
+        s = BemPatrimonialMultiCreateSerializer(
+            data=data, context={"request": self._get_request()}
+        )
+        self.assertFalse(s.is_valid())
+        self.assertIn("linhas", s.errors)
+        # segundo item (índice 1) deve ter o erro de duplicata
+        self.assertIn("1", s.errors["linhas"])
+        self.assertIn(
+            "duplicado", s.errors["linhas"]["1"]["numero_patrimonial"].lower()
+        )
+
+    def test_erro_numero_ja_cadastrado_no_banco(self):
+        numero = "000.000000060-0"
+        BemPatrimonial.objects.create(
+            nome="Existente",
+            descricao="Desc",
+            valor_unitario=1,
+            marca="M",
+            modelo="X",
+            numero_patrimonial=numero,
+            numero_formato_antigo=False,
+            sem_numeracao=False,
+            unidade_administrativa=self.ua,
+            criado_por=self.user,
+            status=constants.AGUARDANDO_APROVACAO,
+        )
+
+        data = self._payload_base(
+            multi_payload=[self._item(numero_patrimonial=numero)]
+        )
+        s = BemPatrimonialMultiCreateSerializer(
+            data=data, context={"request": self._get_request()}
+        )
+        self.assertFalse(s.is_valid())
+        self.assertIn("linhas", s.errors)
+        self.assertIn("cadastrado", s.errors["linhas"]["0"]["numero_patrimonial"].lower())
+
+    def test_erro_em_linha_nao_impede_validacao_das_demais(self):
+        """Todos os erros por linha são coletados antes de retornar."""
+        data = self._payload_base(
+            multi_payload=[
+                self._item(numero_patrimonial="INVALIDO_1", numero_formato_antigo=False),
+                self._item(numero_patrimonial="000.000000070-0"),
+                self._item(numero_patrimonial="INVALIDO_2", numero_formato_antigo=False),
+            ]
+        )
+        s = BemPatrimonialMultiCreateSerializer(
+            data=data, context={"request": self._get_request()}
+        )
+        self.assertFalse(s.is_valid())
+        linhas = s.errors["linhas"]
+        self.assertIn("0", linhas)
+        self.assertNotIn("1", linhas)  # linha válida não tem erro
+        self.assertIn("2", linhas)

--- a/bem_patrimonial/tests/test_viewset.py
+++ b/bem_patrimonial/tests/test_viewset.py
@@ -131,3 +131,208 @@ class BemPatrimonialViewSetTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["reprovados"], 0)
         self.assertEqual(response.data["ignorados"], 1)
+
+
+class CreateMultiViewSetTest(TestCase):
+    def setUp(self):
+        user_model = get_user_model()
+        self.user = user_model.objects.create_superuser(
+            username="admin_multi_vs",
+            email="admin_multi_vs@example.com",
+            **auth_kwargs("admin123"),
+        )
+        self.client = APIClient()
+        self.client.force_authenticate(self.user)
+
+        self.uo = criar_uo(codigo="300", nome="UO 300")
+        self.ua = criar_ua(nome="UA Multi VS", uo=self.uo)
+
+        self.user.unidade_administrativa = self.ua
+        self.user.save()
+
+    def _url(self):
+        return reverse("bens-create-multi")
+
+    def _payload(self, multi_payload=None):
+        return {
+            "unidade_administrativa": self.ua.id,
+            "nome": "Cadeira",
+            "descricao": "Cadeira ergonômica",
+            "valor_unitario": "500,00",
+            "marca": "Flexform",
+            "modelo": "Ergo500",
+            "numero_processo": "PROC-01",
+            "multi_payload": multi_payload if multi_payload is not None else [
+                {
+                    "numero_patrimonial": "000.000000100-0",
+                    "numero_formato_antigo": False,
+                    "sem_numeracao": False,
+                    "localizacao": "Sala 1",
+                }
+            ],
+        }
+
+    def test_create_multi_retorna_201(self):
+        response = self.client.post(self._url(), self._payload(), format="json")
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.data["count"], 1)
+
+    def test_create_multi_cria_bens_no_banco(self):
+        self.client.post(self._url(), self._payload(), format="json")
+        self.assertEqual(
+            BemPatrimonial.objects.filter(numero_patrimonial="000.000000100-0").count(),
+            1,
+        )
+
+    def test_create_multi_status_aguardando_aprovacao(self):
+        self.client.post(self._url(), self._payload(), format="json")
+        bem = BemPatrimonial.objects.get(numero_patrimonial="000.000000100-0")
+        self.assertEqual(bem.status, constants.AGUARDANDO_APROVACAO)
+
+    def test_create_multi_criado_por_e_ua_corretos(self):
+        self.client.post(self._url(), self._payload(), format="json")
+        bem = BemPatrimonial.objects.get(numero_patrimonial="000.000000100-0")
+        self.assertEqual(bem.criado_por, self.user)
+        self.assertEqual(bem.unidade_administrativa, self.ua)
+
+    def test_create_multi_multiplos_bens(self):
+        payload = self._payload(
+            multi_payload=[
+                {
+                    "numero_patrimonial": "000.000000101-0",
+                    "numero_formato_antigo": False,
+                    "sem_numeracao": False,
+                    "localizacao": "Sala 1",
+                },
+                {
+                    "numero_patrimonial": "000.000000102-0",
+                    "numero_formato_antigo": False,
+                    "sem_numeracao": False,
+                    "localizacao": "Sala 2",
+                },
+            ]
+        )
+        response = self.client.post(self._url(), payload, format="json")
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.data["count"], 2)
+        self.assertEqual(
+            BemPatrimonial.objects.filter(
+                numero_patrimonial__in=["000.000000101-0", "000.000000102-0"]
+            ).count(),
+            2,
+        )
+
+    def test_create_multi_sem_numeracao(self):
+        payload = self._payload(
+            multi_payload=[
+                {
+                    "numero_patrimonial": "",
+                    "numero_formato_antigo": False,
+                    "sem_numeracao": True,
+                    "localizacao": "",
+                }
+            ]
+        )
+        response = self.client.post(self._url(), payload, format="json")
+        self.assertEqual(response.status_code, 201)
+
+    def test_create_multi_numero_invalido_retorna_400_com_erros_por_linha(self):
+        payload = self._payload(
+            multi_payload=[
+                {
+                    "numero_patrimonial": "INVALIDO",
+                    "numero_formato_antigo": False,
+                    "sem_numeracao": False,
+                    "localizacao": "",
+                }
+            ]
+        )
+        response = self.client.post(self._url(), payload, format="json")
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("linhas", response.data)
+        self.assertIn("0", response.data["linhas"])
+
+    def test_create_multi_duplicata_no_banco_retorna_400(self):
+        BemPatrimonial.objects.create(
+            nome="Existente",
+            descricao="Desc",
+            valor_unitario=1,
+            marca="M",
+            modelo="X",
+            numero_patrimonial="000.000000110-0",
+            numero_formato_antigo=False,
+            sem_numeracao=False,
+            unidade_administrativa=self.ua,
+            criado_por=self.user,
+            status=constants.AGUARDANDO_APROVACAO,
+        )
+        payload = self._payload(
+            multi_payload=[
+                {
+                    "numero_patrimonial": "000.000000110-0",
+                    "numero_formato_antigo": False,
+                    "sem_numeracao": False,
+                    "localizacao": "",
+                }
+            ]
+        )
+        response = self.client.post(self._url(), payload, format="json")
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("linhas", response.data)
+
+    def test_create_multi_duplicata_no_payload_retorna_400(self):
+        numero = "000.000000120-0"
+        payload = self._payload(
+            multi_payload=[
+                {
+                    "numero_patrimonial": numero,
+                    "numero_formato_antigo": False,
+                    "sem_numeracao": False,
+                    "localizacao": "",
+                },
+                {
+                    "numero_patrimonial": numero,
+                    "numero_formato_antigo": False,
+                    "sem_numeracao": False,
+                    "localizacao": "",
+                },
+            ]
+        )
+        response = self.client.post(self._url(), payload, format="json")
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("linhas", response.data)
+
+    def test_create_multi_rollback_se_algum_invalido(self):
+        """Nenhum bem é persistido se qualquer linha for inválida."""
+        count_antes = BemPatrimonial.objects.count()
+        payload = self._payload(
+            multi_payload=[
+                {
+                    "numero_patrimonial": "000.000000130-0",
+                    "numero_formato_antigo": False,
+                    "sem_numeracao": False,
+                    "localizacao": "",
+                },
+                {
+                    "numero_patrimonial": "INVALIDO",
+                    "numero_formato_antigo": False,
+                    "sem_numeracao": False,
+                    "localizacao": "",
+                },
+            ]
+        )
+        response = self.client.post(self._url(), payload, format="json")
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(BemPatrimonial.objects.count(), count_antes)
+
+    def test_create_multi_payload_vazio_retorna_400(self):
+        payload = self._payload(multi_payload=[])
+        response = self.client.post(self._url(), payload, format="json")
+        self.assertEqual(response.status_code, 400)
+
+    def test_create_multi_campo_base_obrigatorio_faltando_retorna_400(self):
+        payload = self._payload()
+        del payload["nome"]
+        response = self.client.post(self._url(), payload, format="json")
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("nome", response.data)

--- a/bem_patrimonial/views.py
+++ b/bem_patrimonial/views.py
@@ -23,6 +23,7 @@ from bem_patrimonial import constants
 from bem_patrimonial.serializers.bem_patrimonial_serializers import (
     BemPatrimonialListSerializer,
     BemPatrimonialDetailSerializer,
+    BemPatrimonialMultiCreateSerializer,
 )
 from bem_patrimonial.serializers.historico_serializers import HistoricoGrupoSerializer
 
@@ -210,6 +211,45 @@ class BemPatrimonialViewSet(viewsets.ModelViewSet):
             usuario=request.user,
             queryset=BemPatrimonial.objects.all(),
             campo_ua="unidade_administrativa",
+        )
+
+    @action(detail=False, methods=["post"], url_path="multi")
+    def create_multi(self, request):
+        serializer = BemPatrimonialMultiCreateSerializer(
+            data=request.data,
+            context={"request": request},
+        )
+        serializer.is_valid(raise_exception=True)
+
+        vdata = dict(serializer.validated_data)
+        multi_payload = vdata.pop("multi_payload")
+        base = vdata
+
+        with transaction.atomic():
+            with audit_as(request.user):
+                bens = []
+                for item in multi_payload:
+                    sem = item.get("sem_numeracao", False)
+                    bem = BemPatrimonial(
+                        **base,
+                        numero_patrimonial=(
+                            None if sem else (item.get("numero_patrimonial") or None)
+                        ),
+                        numero_formato_antigo=item.get("numero_formato_antigo", False),
+                        sem_numeracao=sem,
+                        localizacao=item.get("localizacao", ""),
+                        criado_por=request.user,
+                        status=constants.AGUARDANDO_APROVACAO,
+                    )
+                    bem.save()
+                    bens.append(bem)
+
+        return Response(
+            {
+                "detail": f"{len(bens)} bem(ns) criado(s) com sucesso.",
+                "count": len(bens),
+            },
+            status=http_status.HTTP_201_CREATED,
         )
 
     @action(detail=False, methods=["post"], url_path="aprovar")


### PR DESCRIPTION
# PR – Backend: Criação de Bens Patrimoniais

## O que foi feito

Implementação do endpoint `POST /bens/multi/` para criação atômica de um ou mais bens patrimoniais, com validação completa antes de persistir qualquer registro.

---

## Arquivos alterados

### `bem_patrimonial/serializers/bem_patrimonial_serializers.py`

**Duas novas classes adicionadas ao final do arquivo.**

#### `BemItemCriacaoSerializer`

Serializa os dados únicos de cada bem na criação em lote:

| Campo | Tipo | Obrigatório |
|---|---|---|
| `numero_patrimonial` | `CharField` | Não (padrão `""`) |
| `numero_formato_antigo` | `BooleanField` | Não (padrão `False`) |
| `sem_numeracao` | `BooleanField` | Não (padrão `False`) |
| `localizacao` | `CharField` | Não (padrão `""`) |

#### `BemPatrimonialMultiCreateSerializer`

Serializa a criação em lote: dados base compartilhados por todos os bens + lista `multi_payload`.

**Campos base:**

| Campo | Tipo | Obrigatório |
|---|---|---|
| `unidade_administrativa` | `PrimaryKeyRelatedField` | Sim |
| `nome` | `CharField` | Sim |
| `descricao` | `CharField` | Sim |
| `valor_unitario` | `CharField` | Sim |
| `marca` | `CharField` | Sim |
| `modelo` | `CharField` | Sim |
| `numero_processo` | `CharField` | Não (padrão `""`) |
| `multi_payload` | `BemItemCriacaoSerializer(many=True)` | Sim |

**Lógica de validação em `validate()`:**

1. Converte `valor_unitario` com o helper `_parse_valor_unitario` (aceita formatos `1.500,00` e `1500.00`).
2. Rejeita `multi_payload` vazio com `ValidationError`.
3. Para cada item da lista, valida:
   - `sem_numeracao` e `numero_formato_antigo` não podem ser `True` simultaneamente.
   - Se `sem_numeracao=False`, o número patrimonial é obrigatório.
   - Se `numero_formato_antigo=False`, valida o formato `000.000000000-0` com regex.
   - Detecta duplicatas dentro do próprio payload.
   - Detecta duplicatas já existentes no banco (`BemPatrimonial.objects.filter`).
4. Coleta todos os erros por linha e os retorna de uma vez no formato `{"linhas": {"0": {...}, "2": {...}}}` — nenhuma linha é bloqueada individualmente; todos os erros são retornados juntos.

---

### `bem_patrimonial/views.py`

**Nova action `create_multi` adicionada ao `BemPatrimonialViewSet`.**

```
POST /bens/multi/
```

- Valida o payload com `BemPatrimonialMultiCreateSerializer`.
- Cria todos os bens dentro de `transaction.atomic()` + `audit_as(request.user)` — se qualquer `bem.save()` falhar, nenhum é persistido.
- Cada bem é criado com `status=AGUARDANDO_APROVACAO` e `criado_por=request.user`.
- Retorna `201` com `{ "detail": "N bem(ns) criado(s) com sucesso.", "count": N }`.

---

### `bem_patrimonial/tests/test_serializers.py`

**Nova classe `BemPatrimonialMultiCreateSerializerTest`** com 14 testes unitários cobrindo o serializer diretamente (sem HTTP):

| Grupo | Casos |
|---|---|
| Sucesso | número válido, múltiplos números distintos, `sem_numeracao`, `formato_antigo`, valor em formato brasileiro |
| Campos base obrigatórios | ausência de `nome`, `descricao`, `marca`, `modelo` |
| Payload | lista vazia |
| Erros por linha | formato inválido, número ausente sem `sem_numeracao`, `sem_numeracao` + `formato_antigo` juntos, duplicata no payload, duplicata no banco, erros coletados em múltiplas linhas simultaneamente |

**Correção no `setUp`:** parâmetro `unidade_orcamentaria` corrigido para `uo` na chamada de `criar_ua()` — o nome errado fazia a factory ignorar o argumento e chamar `criar_uo()` internamente com código padrão já existente, causando `IntegrityError: duplicate key`.

---

### `bem_patrimonial/tests/test_viewset.py`

**Nova classe `CreateMultiViewSetTest`** com 11 testes de integração via HTTP:

| Caso | Resultado esperado |
|---|---|
| Payload válido com 1 bem | `201`, `count=1` |
| Bem criado no banco | registro encontrado por `numero_patrimonial` |
| Status após criação | `AGUARDANDO_APROVACAO` |
| `criado_por` e `unidade_administrativa` | valores corretos |
| Múltiplos bens válidos | `201`, `count=2`, registros no banco |
| `sem_numeracao=True` | `201` |
| `numero_patrimonial` inválido | `400`, corpo contém `linhas` |
| Duplicata no banco | `400`, corpo contém `linhas` |
| Duplicata no payload | `400`, corpo contém `linhas` |
| Rollback: lista com item inválido | `400`, nenhum bem persistido |
| `multi_payload` vazio | `400` |
| Campo base faltando (`nome`) | `400`, `nome` no corpo de erro |

**Correção no helper `_payload`:** `multi_payload or [default]` substituído por `multi_payload if multi_payload is not None else [default]` — o operador `or` avaliava `[]` como falsy e substituía pelo default, impedindo que o teste de payload vazio chegasse ao serializer com lista vazia de fato.
