### PR TITLE
Feature: Alinha Escopo Ativo do Superusuário e Bloqueia Código Duplicado (POST/PUT/PATCH)

### DIFF
--- a/dados_comuns/api_serializers.py
+++ b/dados_comuns/api_serializers.py
@@ -61,6 +61,16 @@ class UnidadeAdministrativaDetailSerializer(UnidadeAdministrativaListSerializer)
 
         return None
 
+    def _validar_codigo_unico(self, codigo):
+        queryset = UnidadeAdministrativa.objects.filter(codigo=codigo)
+        if self.instance:
+            queryset = queryset.exclude(pk=self.instance.pk)
+
+        if queryset.exists():
+            raise serializers.ValidationError(
+                {"codigo": "Já existe uma unidade administrativa com este código."}
+            )
+
     def validate(self, attrs):
         uo = attrs.get("unidade_orcamentaria")
         if self.instance and uo is None:
@@ -84,6 +94,7 @@ class UnidadeAdministrativaDetailSerializer(UnidadeAdministrativaListSerializer)
                         }
                     )
                 attrs["codigo"] = f"{uo.codigo}.{sufixo}"
+                self._validar_codigo_unico(attrs["codigo"])
             return attrs
 
         if codigo_informado is None:
@@ -102,6 +113,7 @@ class UnidadeAdministrativaDetailSerializer(UnidadeAdministrativaListSerializer)
             )
 
         attrs["codigo"] = f"{uo.codigo}.{sufixo}"
+        self._validar_codigo_unico(attrs["codigo"])
         return attrs
 
 

--- a/dados_comuns/api_views.py
+++ b/dados_comuns/api_views.py
@@ -197,9 +197,6 @@ class UnidadeAdministrativaViewSet(viewsets.ModelViewSet):
         qs = UnidadeAdministrativa.objects.select_related("unidade_orcamentaria")
 
         user = self.request.user
-        if getattr(user, "is_superuser", False):
-            return qs
-
         uo_id = getattr(user, "unidade_orcamentaria_id", None)
         if uo_id:
             return qs.filter(unidade_orcamentaria_id=uo_id)
@@ -232,9 +229,6 @@ class UnidadeAdministrativaViewSet(viewsets.ModelViewSet):
         return False
 
     def _uo_ids_permitidos(self, user):
-        if getattr(user, "is_superuser", False):
-            return None
-
         if getattr(user, "unidade_orcamentaria_id", None):
             return {user.unidade_orcamentaria_id}
 
@@ -259,9 +253,6 @@ class UnidadeAdministrativaViewSet(viewsets.ModelViewSet):
             return
 
         uo_ids_permitidos = self._uo_ids_permitidos(self.request.user)
-        if uo_ids_permitidos is None:
-            return
-
         if requested_uo_id not in uo_ids_permitidos:
             raise PermissionDenied(
                 "Você não tem acesso à Unidade Orçamentária informada no filtro."

--- a/dados_comuns/api_views.py
+++ b/dados_comuns/api_views.py
@@ -18,7 +18,6 @@ from rest_framework import viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import (
     NotFound,
-    PermissionDenied,
     ValidationError as DRFValidationError,
 )
 from rest_framework.filters import OrderingFilter, SearchFilter
@@ -70,12 +69,6 @@ UA_ID_PATH_PARAM = OpenApiParameter(
                 type=OpenApiTypes.STR,
                 location=OpenApiParameter.QUERY,
                 description="Filtra por status da unidade administrativa (ativa/inativa).",
-            ),
-            OpenApiParameter(
-                name="unidade_orcamentaria",
-                type=OpenApiTypes.INT,
-                location=OpenApiParameter.QUERY,
-                description="Filtra por ID da Unidade Orçamentária. Retorna 403 quando o usuário não possui acesso ao escopo solicitado.",
             ),
             OpenApiParameter(
                 name="page",
@@ -160,7 +153,7 @@ class UnidadeAdministrativaViewSet(viewsets.ModelViewSet):
     permission_classes = [UnidadeAdministrativaPermission]
 
     filter_backends = [DjangoFilterBackend, SearchFilter, OrderingFilter]
-    filterset_fields = ["status", "unidade_orcamentaria"]
+    filterset_fields = ["status"]
     search_fields = [
         "codigo",
         "sigla",
@@ -215,9 +208,6 @@ class UnidadeAdministrativaViewSet(viewsets.ModelViewSet):
         return obj
 
     def _pode_acessar_objeto(self, user, obj):
-        if getattr(user, "is_superuser", False):
-            return True
-
         user_uo_id = getattr(user, "unidade_orcamentaria_id", None)
         if user_uo_id:
             return obj.unidade_orcamentaria_id == user_uo_id
@@ -227,40 +217,6 @@ class UnidadeAdministrativaViewSet(viewsets.ModelViewSet):
             return obj.pk == user_ua_id
 
         return False
-
-    def _uo_ids_permitidos(self, user):
-        if getattr(user, "unidade_orcamentaria_id", None):
-            return {user.unidade_orcamentaria_id}
-
-        if getattr(user, "unidade_administrativa_id", None):
-            uo_id = (
-                UnidadeAdministrativa.objects.filter(pk=user.unidade_administrativa_id)
-                .values_list("unidade_orcamentaria_id", flat=True)
-                .first()
-            )
-            return {uo_id} if uo_id else set()
-
-        return set()
-
-    def _validar_filtro_unidade_orcamentaria(self):
-        raw_uo = self.request.query_params.get("unidade_orcamentaria")
-        if raw_uo in (None, ""):
-            return
-
-        try:
-            requested_uo_id = int(raw_uo)
-        except (TypeError, ValueError):
-            return
-
-        uo_ids_permitidos = self._uo_ids_permitidos(self.request.user)
-        if requested_uo_id not in uo_ids_permitidos:
-            raise PermissionDenied(
-                "Você não tem acesso à Unidade Orçamentária informada no filtro."
-            )
-
-    def list(self, request, *args, **kwargs):
-        self._validar_filtro_unidade_orcamentaria()
-        return super().list(request, *args, **kwargs)
 
     def _validate_uo_scope(self, validated_data, instance=None):
         user = self.request.user
@@ -458,7 +414,6 @@ class UnidadeAdministrativaViewSet(viewsets.ModelViewSet):
         )
         serializer.is_valid(raise_exception=True)
         formato = serializer.validated_data["formato"]
-        self._validar_filtro_unidade_orcamentaria()
 
         queryset = self.filter_queryset(self.get_queryset())
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")

--- a/dados_comuns/tests/tests_unidade_administrativa_api.py
+++ b/dados_comuns/tests/tests_unidade_administrativa_api.py
@@ -165,11 +165,19 @@ class UnidadeAdministrativaAPITestCase(APITestCase):
         fora_escopo = self.client.get(self._get_detail_url(self.ua3.id))
         self.assertEqual(fora_escopo.status_code, status.HTTP_404_NOT_FOUND)
 
-    def test_filtro_unidade_orcamentaria_fora_escopo_retorna_403(self):
+        self._auth(self.superuser)
+        ok_super = self.client.get(self._get_detail_url(self.ua1.id))
+        self.assertEqual(ok_super.status_code, status.HTTP_200_OK)
+
+        fora_escopo_super = self.client.get(self._get_detail_url(self.ua3.id))
+        self.assertEqual(fora_escopo_super.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_parametro_unidade_orcamentaria_nao_altera_escopo(self):
         self._auth(self.gestor)
         response = self.client.get(self.list_url, {"unidade_orcamentaria": self.uo2.id})
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-        self.assertIn("detail", response.data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = {row["id"] for row in response.data["results"]}
+        self.assertEqual(ids, {self.ua1.id, self.ua2.id})
 
     def test_criacao_codigo_valido_em_varios_formatos(self):
         self._auth(self.gestor)
@@ -291,6 +299,12 @@ class UnidadeAdministrativaAPITestCase(APITestCase):
         self.assertIsInstance(response.data, list)
         self.assertGreaterEqual(len(response.data), 1)
         self.assertIn("acoes", response.data[0])
+
+        self._auth(self.superuser)
+        historico_fora_escopo = self.client.get(
+            reverse("unidades-administrativas-historico", args=[self.ua3.id])
+        )
+        self.assertEqual(historico_fora_escopo.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_exportacao_por_formato_permitido(self):
         self._auth(self.gestor)

--- a/dados_comuns/tests/tests_unidade_administrativa_api.py
+++ b/dados_comuns/tests/tests_unidade_administrativa_api.py
@@ -220,6 +220,53 @@ class UnidadeAdministrativaAPITestCase(APITestCase):
                 self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
                 self.assertIn(campo_esperado, response.data)
 
+    def test_post_nao_permite_codigo_duplicado(self):
+        self._auth(self.gestor)
+
+        response = self.client.post(
+            self.list_url,
+            self._payload_ua(
+                uo_id=self.uo1.id,
+                codigo="001",
+                sigla="UA DUP",
+                nome="Unidade Duplicada",
+            ),
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("codigo", response.data)
+
+    def test_patch_nao_permite_codigo_duplicado(self):
+        self._auth(self.gestor)
+
+        response = self.client.patch(
+            self._get_detail_url(self.ua2.id),
+            {"codigo": "001"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("codigo", response.data)
+
+    def test_put_nao_permite_codigo_duplicado(self):
+        self._auth(self.gestor)
+
+        response = self.client.put(
+            self._get_detail_url(self.ua2.id),
+            self._payload_ua(
+                uo_id=self.uo1.id,
+                codigo="001",
+                sigla="UA2",
+                nome="Unidade 2",
+                status_=UnidadeAdministrativa.INATIVA,
+            ),
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("codigo", response.data)
+
     def test_superuser_pode_criar_em_qualquer_uo(self):
         self._auth(self.superuser)
         response = self.client.post(

--- a/dados_comuns/tests/tests_unidade_administrativa_api.py
+++ b/dados_comuns/tests/tests_unidade_administrativa_api.py
@@ -86,6 +86,7 @@ class UnidadeAdministrativaAPITestCase(APITestCase):
             nome="Super UA",
             is_staff=True,
             is_superuser=True,
+            unidade_orcamentaria=self.uo1,
         )
 
         self.list_url = reverse("unidades-administrativas-list")
@@ -118,7 +119,7 @@ class UnidadeAdministrativaAPITestCase(APITestCase):
         cenarios = [
             (self.gestor, {self.ua1.id, self.ua2.id}, {self.ua3.id}),
             (self.operador, {self.ua1.id, self.ua2.id}, {self.ua3.id}),
-            (self.superuser, {self.ua1.id, self.ua2.id, self.ua3.id}, set()),
+            (self.superuser, {self.ua1.id, self.ua2.id}, {self.ua3.id}),
         ]
 
         for user, deve_ter, nao_deve_ter in cenarios:
@@ -309,6 +310,20 @@ class UnidadeAdministrativaAPITestCase(APITestCase):
                 self.assertEqual(response.status_code, status.HTTP_200_OK)
                 self.assertEqual(response["Content-Type"], content_type)
                 self.assertIn("attachment;", response["Content-Disposition"])
+
+    def test_exportacao_superuser_respeita_escopo_ativo(self):
+        self._auth(self.superuser)
+
+        response = self.client.get(
+            reverse("unidades-administrativas-exportar"),
+            {"formato": "csv"},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        conteudo = response.content.decode("utf-8-sig")
+        self.assertIn(self.ua1.codigo, conteudo)
+        self.assertIn(self.ua2.codigo, conteudo)
+        self.assertNotIn(self.ua3.codigo, conteudo)
 
     def test_exportacao_validacoes_e_permissoes(self):
         self._auth(self.operador)


### PR DESCRIPTION
## Descrição:
Este ajuste padroniza o comportamento de escopo da API de Unidades Administrativas para superusuário.
Antes, superuser recebia todas as UAs na listagem, exportação, detalhe e histórico.
Agora, superuser também respeita o escopo ativo (UO/UA), igual aos demais perfis.

## Mudanças principais:

- Remoção do bypass de superuser na construção do queryset da API de UAs.
- Remoção do parâmetro unidade_orcamentaria como filtro funcional da listagem.
- Remoção da validação específica desse parâmetro na exportação.
- Aplicação da mesma regra de escopo ativo no acesso por objeto, alinhando detalhe e histórico.
- Validação de unicidade do campo código na API de Unidade Administrativa, impedindo duplicidade em criação e atualização.
- Atualização da documentação OpenAPI para refletir o comportamento simplificado.
- Ajuste e ampliação dos testes cobrindo os novos cenários de escopo para superuser.
- Inclusão de testes específicos para bloquear código duplicado em POST, PATCH e PUT.

## Resultado:

- O parâmetro unidade_orcamentaria deixa de ser filtro funcional da listagem/exportação.
- Listagem, exportação, detalhe e histórico passam a seguir a mesma regra de escopo ativo do usuário (UO/UA), inclusive para superuser.
- Não é mais possível criar ou atualizar Unidade Administrativa com código já existente.
- Comportamento mais previsível e alinhado ao padrão de escopo do sistema.

## Testes:

Execução da suíte de API de UAs: 18 testes passando.

Cenários validados:

1. Listagem escopada por perfil, incluindo superuser com UO ativa.
2. Exportação respeitando escopo ativo para superuser.
3. Detalhe com bloqueio fora de escopo para superuser.
4. Histórico com bloqueio fora de escopo para superuser.
5. Bloqueio de código duplicado em criação (POST).
6. Bloqueio de código duplicado em edição parcial (PATCH).
7. Bloqueio de código duplicado em edição completa (PUT).
8. Regras de criação/edição/exclusão e validações já existentes sem regressão.

### Testes Geral

<img width="643" height="355" alt="image" src="https://github.com/user-attachments/assets/b1ae6256-1c76-45ed-bf89-70b2692d6adf" />
