### PR TITLE
Feature(145658): Padronizar Assinaturas dos Documentos de Nome para RF

### DIFF
--- a/bem_patrimonial/cimbpm.py
+++ b/bem_patrimonial/cimbpm.py
@@ -21,6 +21,7 @@ from bem_patrimonial.pdf_utils import (
     criar_estilo_base,
     formatar_moeda_brasileira,
     obter_nome_usuario,
+    obter_rf_usuario,
     formatar_data,
 )
 from bem_patrimonial.documentos_pdf_utils import (
@@ -245,18 +246,12 @@ def _criar_total_bens(movimentacao):
 
 def _criar_rodape_cimbpm(movimentacao, data_aceite):
     responsavel_entrega_obj = movimentacao.solicitado_por
-    nome_entrega = obter_nome_usuario(responsavel_entrega_obj).upper()
-    rf_entrega = (
-        responsavel_entrega_obj.rf if responsavel_entrega_obj.rf else "-"
-    )
-    responsavel_entrega = f"{nome_entrega} - RF: {rf_entrega}"
+    responsavel_entrega = obter_rf_usuario(responsavel_entrega_obj)
 
     responsavel_recebimento = ""
     if data_aceite and movimentacao.aprovado_por:
         responsavel_rec = movimentacao.aprovado_por
-        nome_recebimento = obter_nome_usuario(responsavel_rec).upper()
-        rf_recebimento = responsavel_rec.rf if responsavel_rec.rf else "-"
-        responsavel_recebimento = f"{nome_recebimento} - RF: {rf_recebimento}"
+        responsavel_recebimento = obter_rf_usuario(responsavel_rec)
 
     return criar_tabela_rodape_responsaveis(
         label_esquerda="RESPONSÁVEL PELA ENTREGA",

--- a/bem_patrimonial/documentos_pdf_utils.py
+++ b/bem_patrimonial/documentos_pdf_utils.py
@@ -12,8 +12,8 @@ from bem_patrimonial.pdf_utils import (
     criar_estilo_base,
     carregar_logo,
     formatar_moeda_brasileira,
-    obter_nome_usuario,
     criar_info_geracao_paragraph,
+    obter_rf_usuario,
 )
 
 
@@ -416,9 +416,7 @@ def formatar_responsavel(usuario):
     if not usuario:
         return ""
 
-    nome = obter_nome_usuario(usuario).upper()
-    rf = getattr(usuario, "rf", None) or "-"
-    return f"{nome} - RF: {rf}"
+    return obter_rf_usuario(usuario)
 
 
 def criar_tabela_rodape_responsaveis(

--- a/bem_patrimonial/formats.py
+++ b/bem_patrimonial/formats.py
@@ -19,6 +19,8 @@ from reportlab.platypus import (
     KeepTogether,
 )
 
+from bem_patrimonial.pdf_utils import obter_rf_usuario
+
 
 class PDFFormat(Format):
 
@@ -51,7 +53,7 @@ class PDFFormat(Format):
             bottomMargin=0.9 * cm,
             title="Relatório de Bens Patrimoniais",
             author=(
-                request.user.get_full_name() or request.user.username
+                obter_rf_usuario(request.user)
                 if request
                 else "Sistema Bens Físicos"
             ),
@@ -148,10 +150,7 @@ class PDFFormat(Format):
         user = request.user
         if not user.is_authenticated:
             return "Sistema"
-        if hasattr(user, "nome") and user.nome:
-            return user.nome
-        full_name = user.get_full_name() if hasattr(user, "get_full_name") else ""
-        return full_name.strip() if full_name and full_name.strip() else user.username
+        return obter_rf_usuario(user)
 
     def _criar_info_relatorio(self, request, total_registros):
         elements = []

--- a/bem_patrimonial/nbbpm.py
+++ b/bem_patrimonial/nbbpm.py
@@ -19,7 +19,7 @@ from bem_patrimonial.pdf_utils import (
     PDFConfigBase as PDFConfig,
     extrair_codigo_ua,
     criar_estilo_base,
-    obter_nome_usuario,
+    obter_rf_usuario,
     formatar_data,
 )
 from bem_patrimonial.documentos_pdf_utils import (
@@ -260,15 +260,11 @@ def _criar_total_bens(baixa):
 
 def _criar_rodape_nbbpm(baixa):
     resp_baixa = getattr(baixa, "criado_por", None)
-    nome_baixa = obter_nome_usuario(resp_baixa).upper()
-    rf_baixa = getattr(resp_baixa, "rf", None) or "-"
-    responsavel_baixa = f"{nome_baixa} - RF: {rf_baixa}"
+    responsavel_baixa = obter_rf_usuario(resp_baixa)
 
     resp_aprov = getattr(baixa, "aprovado_por", None)
     if resp_aprov:
-        nome_aprov = obter_nome_usuario(resp_aprov).upper()
-        rf_aprov = getattr(resp_aprov, "rf", None) or "-"
-        responsavel_aprov = f"{nome_aprov} - RF: {rf_aprov}"
+        responsavel_aprov = obter_rf_usuario(resp_aprov)
     else:
         responsavel_aprov = ""
 

--- a/bem_patrimonial/pdf_utils.py
+++ b/bem_patrimonial/pdf_utils.py
@@ -66,6 +66,12 @@ def obter_nome_usuario(usuario):
     return usuario.nome if getattr(usuario, "nome", None) else usuario.username
 
 
+def obter_rf_usuario(usuario):
+    if not usuario:
+        return "-"
+    return getattr(usuario, "rf", None) or "-"
+
+
 def criar_estilo_base(nome, parent_styles, config_cls=PDFConfigBase, **kwargs):
     if config_cls is None:
         config_cls = PDFConfigBase
@@ -130,10 +136,10 @@ def criar_info_geracao_paragraph(
         textColor=colors.grey,
     )
 
-    nome = obter_nome_usuario(usuario)
+    rf = obter_rf_usuario(usuario)
     quando = formatar_datahora_geracao(data_geracao, config_cls=config_cls)
 
     return [
         Spacer(1, 0.2 * cm),
-        Paragraph(f"Gerado por {nome} em {quando}", info_style),
+        Paragraph(f"Gerado por {rf} em {quando}", info_style),
     ]

--- a/bem_patrimonial/tests/test_nbbpm.py
+++ b/bem_patrimonial/tests/test_nbbpm.py
@@ -22,6 +22,7 @@ from bem_patrimonial.models import (
 from bem_patrimonial.nbbpm import (
     obter_bens_baixa,
     gerar_numero_nbbpm,
+    _criar_rodape_nbbpm,
     gerar_pdf_nbbpm,
     http_response_nbbpm,
 )
@@ -183,6 +184,19 @@ class TestGeracaoNumeroNBBPM(NBBPMTestBase):
 
 
 class TestGeracaoPDFNBBPM(NBBPMTestBase):
+    def test_rodape_nbbpm_exibe_apenas_rf_nos_responsaveis(self):
+        baixa = self.criar_baixa(status=constants.ACEITA)
+
+        rodape_table = _criar_rodape_nbbpm(baixa)[0]
+
+        responsavel_baixa = rodape_table._cellvalues[1][0].getPlainText()
+        responsavel_aprovacao = rodape_table._cellvalues[1][1].getPlainText()
+
+        self.assertEqual(responsavel_baixa, "1234567")
+        self.assertEqual(responsavel_aprovacao, "7654321")
+        self.assertNotIn("João Silva", responsavel_baixa)
+        self.assertNotIn("Maria Santos", responsavel_aprovacao)
+
     def test_gera_pdf_quando_aceita(self):
         baixa = self.criar_baixa(status=constants.ACEITA)
         bem = self.criar_bem()

--- a/bem_patrimonial/tests/tests_cimbpm.py
+++ b/bem_patrimonial/tests/tests_cimbpm.py
@@ -15,8 +15,10 @@ from bem_patrimonial.cimbpm import (
     formatar_moeda_brasileira,
     obter_bens_movimentacao,
     obter_nome_usuario,
+    _criar_rodape_cimbpm,
     gerar_pdf_cimbpm,
 )
+from bem_patrimonial.pdf_utils import criar_info_geracao_paragraph
 from bem_patrimonial import constants
 from dados_comuns.models import UnidadeAdministrativa
 from dados_comuns.tests.factories import criar_ua
@@ -139,6 +141,23 @@ class TestFuncoesAuxiliares(TestCase):
         u3.nome = None
         u3.save()
         self.assertEqual(obter_nome_usuario(u3), "user3")
+
+    def test_info_geracao_exibe_apenas_rf(self):
+        ua = criar_ua(codigo=codigo_ua(1, 16, 10, 2), sigla="T2", nome="Teste 2", status="A")
+
+        usuario = Usuario.objects.create_user(
+            username="rf_user",
+            nome="Nome Completo",
+            rf="1234567",
+            unidade_administrativa=ua,
+            unidade_orcamentaria=ua.unidade_orcamentaria,
+        )
+
+        info_paragraph = criar_info_geracao_paragraph(usuario=usuario)[1]
+        info_texto = info_paragraph.getPlainText()
+
+        self.assertIn("Gerado por 1234567 em ", info_texto)
+        self.assertNotIn("Nome Completo", info_texto)
 
 
 class TestObterBensMovimentacao(CIMBPMTestBase):
@@ -415,6 +434,26 @@ class TestConteudoDownload(CIMBPMTestBase):
 
 
 class TestEdgeCasesPDF(CIMBPMTestBase):
+    def test_rodape_cimbpm_exibe_apenas_rf_nos_responsaveis(self):
+        mov = MovimentacaoBemPatrimonial.objects.create(
+            bem_patrimonial=self.criar_bem(),
+            unidade_administrativa_origem=self.ua_origem,
+            unidade_administrativa_destino=self.ua_destino,
+            solicitado_por=self.operador,
+            aprovado_por=self.gestor,
+            status=constants.ACEITA,
+        )
+
+        rodape_table = _criar_rodape_cimbpm(mov, timezone.now())[0]
+
+        responsavel_entrega = rodape_table._cellvalues[1][0].getPlainText()
+        responsavel_recebimento = rodape_table._cellvalues[1][1].getPlainText()
+
+        self.assertEqual(responsavel_entrega, "1234567")
+        self.assertEqual(responsavel_recebimento, "7654321")
+        self.assertNotIn("João Silva", responsavel_entrega)
+        self.assertNotIn("Maria Santos", responsavel_recebimento)
+
     def test_geracao_com_campos_vazios(self):
         bem = self.criar_bem(
             descricao="",

--- a/bem_patrimonial/tests/tests_export_pdf.py
+++ b/bem_patrimonial/tests/tests_export_pdf.py
@@ -25,7 +25,11 @@ class SetupExportData:
         return criar_ua(uo=self.uo, codigo=codigo, nome=nome)
 
     def create_usuario(
-        self, username="testuser", unidade=None, grupo=GRUPO_GESTOR_PATRIMONIO
+        self,
+        username="testuser",
+        unidade=None,
+        grupo=GRUPO_GESTOR_PATRIMONIO,
+        rf=None,
     ):
         if not unidade:
             unidade = self.create_unidade_administrativa()
@@ -35,6 +39,7 @@ class SetupExportData:
             **auth_kwargs("testpass123"),
             nome=f"Usuario {username}",
             email=f"{username}@teste.com",
+            rf=rf,
             unidade_administrativa=unidade,
             unidade_orcamentaria=unidade.unidade_orcamentaria,
             is_staff=True,
@@ -388,7 +393,7 @@ class PDFUserContextTestCase(TestCase):
         self.factory = RequestFactory()
 
     def test_pdf_uses_nome_field_when_available(self):
-        usuario = self.test_data.create_usuario()
+        usuario = self.test_data.create_usuario(rf="4444444")
         usuario.nome = "Maria Silva"
         usuario.first_name = "Maria"
         usuario.last_name = "Santos"
@@ -406,7 +411,7 @@ class PDFUserContextTestCase(TestCase):
         self.assertTrue(pdf_bytes.startswith(b"%PDF"))
 
     def test_pdf_uses_username_as_fallback(self):
-        usuario = self.test_data.create_usuario()
+        usuario = self.test_data.create_usuario(rf="5555555")
         usuario.nome = None
         usuario.first_name = ""
         usuario.last_name = ""
@@ -434,3 +439,16 @@ class PDFUserContextTestCase(TestCase):
         pdf_bytes = pdf_format.export_data(None)
 
         self.assertTrue(pdf_bytes.startswith(b"%PDF"))
+
+    def test_info_relatorio_exibe_apenas_rf(self):
+        usuario = self.test_data.create_usuario(rf="6666666")
+        request = self.factory.get("/admin/")
+        request.user = usuario
+
+        pdf_format = PDFFormat()
+
+        info_table = pdf_format._criar_info_relatorio(request, total_registros=3)[0]
+
+        self.assertEqual(pdf_format._obter_usuario_geracao(request), "6666666")
+        self.assertEqual(info_table._cellvalues[0][2], "Gerado por:")
+        self.assertEqual(info_table._cellvalues[0][3], "6666666")

--- a/dados_comuns/formats.py
+++ b/dados_comuns/formats.py
@@ -18,6 +18,8 @@ from reportlab.platypus import (
     Image,
 )
 
+from bem_patrimonial.pdf_utils import obter_rf_usuario
+
 
 class UnidadeAdministrativaPDFFormat(Format):
 
@@ -46,7 +48,7 @@ class UnidadeAdministrativaPDFFormat(Format):
             bottomMargin=0.9 * cm,
             title="Relatório de Unidades Administrativas",
             author=(
-                request.user.get_full_name() or request.user.username
+                obter_rf_usuario(request.user)
                 if request
                 else "Sistema Bens Físicos"
             ),
@@ -83,19 +85,9 @@ class UnidadeAdministrativaPDFFormat(Format):
 
     def _resolver_usuario_exportacao(self, request):
         if not request or not hasattr(request, "user") or not request.user.is_authenticated:
-            return "Sistema", ""
+            return "Sistema"
 
-        user = request.user
-
-        if hasattr(user, "nome") and user.nome:
-            usuario = user.nome
-        elif user.get_full_name():
-            usuario = user.get_full_name().strip()
-        else:
-            usuario = user.username
-
-        rf_text = f" - RF: {user.rf}" if hasattr(user, "rf") and user.rf else ""
-        return usuario, rf_text
+        return obter_rf_usuario(request.user)
 
     def _criar_estilos_celula(self, styles):
         base_kwargs = {
@@ -224,10 +216,10 @@ class UnidadeAdministrativaPDFFormat(Format):
         canvas.saveState()
 
         request = getattr(self, "_export_request", None)
-        data_emissao = localtime(timezone.now()).strftime("%d/%m/%Y %H:%M")
-        usuario, rf_text = self._resolver_usuario_exportacao(request)
+        data_emissao = localtime(timezone.now()).strftime("%d/%m/%Y às %H:%M")
+        usuario = self._resolver_usuario_exportacao(request)
 
-        footer_text = f"Emitido em: {data_emissao} | Por: {usuario}{rf_text}"
+        footer_text = f"Gerado por {usuario} em {data_emissao}"
         canvas.setFont("Helvetica", 8)
         canvas.setFillColor(colors.grey)
         canvas.drawString(0.5 * cm, 0.5 * cm, footer_text)

--- a/dados_comuns/tests/tests_exportacao_unidades.py
+++ b/dados_comuns/tests/tests_exportacao_unidades.py
@@ -2,6 +2,7 @@ from dados_comuns.tests.auth_test_utils import auth_kwargs
 from django.test import TestCase, RequestFactory
 from django.contrib.admin.sites import AdminSite
 from django.contrib.auth.models import Group
+from unittest.mock import Mock
 from dados_comuns.models import UnidadeAdministrativa
 from dados_comuns.admin import UnidadeAdministrativaAdmin
 from dados_comuns.formats import UnidadeAdministrativaPDFFormat
@@ -87,7 +88,7 @@ class ExportacaoUnidadeAdministrativaTestCase(TestCase):
         self.assertTrue(pdf_bytes.startswith(b"%PDF"))
         self.assertIn(b"%%EOF", pdf_bytes)
         self.assertGreater(len(pdf_bytes), 1000)
-        self.assertIn(b"/Author (gestor_rf)", pdf_bytes)
+        self.assertIn(b"/Author (123456)", pdf_bytes)
 
     def test_pdf_gerado_sem_rf_cadastrado(self):
         pdf_bytes = self._gerar_pdf(self.gestor_sem_rf)
@@ -96,7 +97,32 @@ class ExportacaoUnidadeAdministrativaTestCase(TestCase):
         self.assertTrue(pdf_bytes.startswith(b"%PDF"))
         self.assertIn(b"%%EOF", pdf_bytes)
         self.assertGreater(len(pdf_bytes), 1000)
-        self.assertIn(b"/Author (gestor_sem_rf)", pdf_bytes)
+        self.assertIn(b"/Author (-)", pdf_bytes)
+
+    def test_resolve_usuario_exportacao_retorna_apenas_rf(self):
+        request = self.factory.get("/admin/dados_comuns/unidadeadministrativa/")
+        request.user = self.gestor_com_rf
+
+        pdf_format = UnidadeAdministrativaPDFFormat()
+
+        self.assertEqual(pdf_format._resolver_usuario_exportacao(request), "123456")
+
+    def test_rodape_pdf_exibe_apenas_rf(self):
+        request = self.factory.get("/admin/dados_comuns/unidadeadministrativa/")
+        request.user = self.gestor_com_rf
+
+        pdf_format = UnidadeAdministrativaPDFFormat()
+        pdf_format._export_request = request
+
+        canvas = Mock()
+        canvas.getPageNumber.return_value = 1
+        doc = Mock()
+
+        pdf_format._adicionar_numero_pagina(canvas, doc)
+
+        footer_text = canvas.drawString.call_args.args[2]
+        self.assertIn("Gerado por 123456 em ", footer_text)
+        self.assertNotIn("José da Silva", footer_text)
 
     def test_exportacao_excel_com_status_legivel(self):
         resource = UnidadeAdministrativaResource()

--- a/inventario/relatorio_conciliacao_pdf.py
+++ b/inventario/relatorio_conciliacao_pdf.py
@@ -25,6 +25,7 @@ from reportlab.platypus import (
 import pytz
 
 from inventario import constants as inv_constants
+from bem_patrimonial.pdf_utils import obter_rf_usuario
 
 
 class PDFConfig:
@@ -142,9 +143,9 @@ def _criar_info_geracao(usuario_gerador=None, data_geracao=None):
         data_ref = timezone.make_aware(data_ref)
 
     data_geracao_str = data_ref.astimezone(tz_sp).strftime("%d/%m/%Y às %H:%M")
-    nome_usuario = obter_nome_usuario(usuario_gerador) if usuario_gerador else "-"
+    rf_usuario = obter_rf_usuario(usuario_gerador)
 
-    info_text = f"Gerado por {nome_usuario} em {data_geracao_str}"
+    info_text = f"Gerado por {rf_usuario} em {data_geracao_str}"
     elements.append(Paragraph(info_text, info_style))
     return elements
 
@@ -319,21 +320,14 @@ def _criar_rodape_conciliacao(conciliacao, usuario_gerador=None):
     fechado_por = conciliacao.fechado_por
 
     responsavel_operacao = usuario_gerador or criado_por
-    nome_operacao = (
-        obter_nome_usuario(responsavel_operacao).upper()
-        if responsavel_operacao
-        else "-"
-    )
-    rf_operacao = getattr(responsavel_operacao, "rf", None) or "-"
+    rf_operacao = obter_rf_usuario(responsavel_operacao)
 
     status_display = conciliacao.get_status_display()
 
     if STATUS_NAO_CONCILIADO in status_display:
         nome_fechamento = status_display
     elif fechado_por:
-        nome = obter_nome_usuario(fechado_por).upper()
-        rf = getattr(fechado_por, "rf", None) or "-"
-        nome_fechamento = f"{nome} - RF: {rf}"
+        nome_fechamento = obter_rf_usuario(fechado_por)
     else:
         nome_fechamento = ""
 
@@ -343,7 +337,7 @@ def _criar_rodape_conciliacao(conciliacao, usuario_gerador=None):
             Paragraph("<b>RESPONSÁVEL (FECHAMENTO)</b>", label_style),
         ],
         [
-            Paragraph(f"{nome_operacao} - RF: {rf_operacao}", value_style),
+            Paragraph(rf_operacao, value_style),
             Paragraph(nome_fechamento, value_style),
         ],
         [
@@ -575,7 +569,7 @@ def _linhas_tabela_item(item, txt, txt_center):
     rows = [linha_topo, linha_desc, linha_situacao]
     oc = item.ocorrencias.first() if item.tem_ocorrencia else None
     if oc:
-        registrado_por = obter_nome_usuario(getattr(oc, "registrado_por", None))
+        registrado_por = obter_rf_usuario(getattr(oc, "registrado_por", None))
         registrado_em = _fmt_date(getattr(oc, "registrado_em", None))
         obs = (getattr(oc, "observacao", "") or "").strip() or "-"
         div = (getattr(oc, "divergencia", "") or "").strip() or "-"

--- a/inventario/tests/test_exportar_conciliacao_pdf.py
+++ b/inventario/tests/test_exportar_conciliacao_pdf.py
@@ -7,6 +7,7 @@ from django.test import TestCase, Client
 from django.urls import reverse
 from django.contrib.auth.models import Group
 from django.utils import timezone
+from reportlab.lib.styles import getSampleStyleSheet
 
 from dados_comuns.models import UnidadeAdministrativa
 from dados_comuns.tests.factories import criar_ua
@@ -250,6 +251,31 @@ class TestHelpersRelatorioConciliacao(TestCase):
 
         self.assertEqual(formatar_status_para_header(Dummy()), "Fechado")
 
+    def test_info_geracao_exibe_apenas_rf(self):
+        ua = criar_ua(
+            codigo="01.16.10.501",
+            sigla="UA",
+            nome="Unidade",
+            status=UnidadeAdministrativa.ATIVA,
+        )
+        usuario = Usuario.objects.create_user(
+            username="operador_rf",
+            nome="Operador Nome Completo",
+            rf="3333333",
+            email="operador_rf@exemplo.com",
+            **auth_kwargs("senha123"),
+            unidade_administrativa=ua,
+            unidade_orcamentaria=ua.unidade_orcamentaria,
+        )
+
+        from inventario.relatorio_conciliacao_pdf import _criar_info_geracao
+
+        info_paragraph = _criar_info_geracao(usuario)[0]
+        info_texto = info_paragraph.getPlainText()
+
+        self.assertIn("Gerado por 3333333 em ", info_texto)
+        self.assertNotIn("Operador Nome Completo", info_texto)
+
 
 class TestGerarPDFConciliacao(ConciliacaoPDFTestBase):
     def setUp(self):
@@ -306,3 +332,35 @@ class TestGerarPDFConciliacao(ConciliacaoPDFTestBase):
             )
 
         self.assertTrue(buf.getvalue().startswith(b"%PDF"))
+
+    def test_rodape_e_ocorrencia_exibem_apenas_rf(self):
+        from inventario.relatorio_conciliacao_pdf import (
+            _criar_rodape_conciliacao,
+            _linhas_tabela_item,
+            _estilos_blocos_itens,
+        )
+
+        self.conciliacao.fechado_por = self.gestor
+
+        rodape_table = _criar_rodape_conciliacao(
+            self.conciliacao, usuario_gerador=self.operador_a
+        )[0]
+        responsavel_exportacao = rodape_table._cellvalues[1][0].getPlainText()
+        responsavel_fechamento = rodape_table._cellvalues[1][1].getPlainText()
+
+        self.assertEqual(responsavel_exportacao, "1111111")
+        self.assertEqual(responsavel_fechamento, "9999999")
+        self.assertNotIn("Operador A", responsavel_exportacao)
+        self.assertNotIn("Gestor", responsavel_fechamento)
+
+        item_com_ocorrencia = self.conciliacao.itens.get(situacao=constants.DIVERGENTE)
+        estilos = _estilos_blocos_itens(getSampleStyleSheet())
+        rows, _ = _linhas_tabela_item(
+            item_com_ocorrencia,
+            estilos["txt"],
+            estilos["txt_center"],
+        )
+        registrado_por = rows[-1][1].getPlainText()
+
+        self.assertEqual(registrado_por, "Registrado por: 1111111")
+        self.assertNotIn("Operador A", registrado_por)


### PR DESCRIPTION
## 🎯 Objetivo
Padronizar a identificação do usuário em documentos oficiais e relatórios PDF para exibir apenas o RF, removendo o nome completo de assinaturas, rodapés e campos equivalentes. Além do escopo inicial, a mesma regra foi aplicada à exportação PDF de Unidades Administrativas.

## 📦 Escopo entregue
- Padronização do texto de geração para `Gerado por [RF] em [DATA E HORA]`.
- Exibição apenas do RF em responsáveis do CIMBPM e da NBBPM.
- Exibição apenas do RF em `Registrado por` e nos responsáveis do relatório de conciliação.
- Exibição apenas do RF em `Gerado por:` no relatório de bens patrimoniais.
- Exibição apenas do RF no rodapé e na metadata `Author` da exportação PDF de Unidades Administrativas.

## 🛠️ Implementação
- Foi centralizada a resolução do RF do usuário em um helper compartilhado, com fallback `-` para ausência de RF.
- O rodapé padrão e os blocos de geração dos documentos passaram a reutilizar essa regra.
- A padronização foi aplicada aos documentos oficiais, relatórios patrimoniais, relatório de conciliação e exportação PDF de unidades administrativas.

## 🧯 Fallbacks e comportamento
- Usuário com RF ausente: exibe `-`.
- Export sem usuário autenticado em fluxos administrativos: mantém fallback `Sistema` no texto exibido e `Sistema Bens Físicos` na metadata onde já era o comportamento existente.
- Campos de responsável ainda sem usuário associado permanecem vazios quando essa já era a regra de negócio do documento.

## 🧪 Testes criados e alterados
- Testes criados do zero:
  - "bem_patrimonial/tests/tests_cimbpm.py": "test_info_geracao_exibe_apenas_rf", "test_rodape_cimbpm_exibe_apenas_rf_nos_responsaveis".
  - "bem_patrimonial/tests/test_nbbpm.py": "test_rodape_nbbpm_exibe_apenas_rf_nos_responsaveis".
  - "inventario/tests/test_exportar_conciliacao_pdf.py": "test_info_geracao_exibe_apenas_rf", "test_rodape_e_ocorrencia_exibem_apenas_rf".
  - "bem_patrimonial/tests/tests_export_pdf.py": "test_info_relatorio_exibe_apenas_rf".
  - "dados_comuns/tests/tests_exportacao_unidades.py": "test_resolve_usuario_exportacao_retorna_apenas_rf", "test_rodape_pdf_exibe_apenas_rf".
- Testes existentes que foram modificados para a nova regra:
  - "bem_patrimonial/tests/tests_export_pdf.py": "test_pdf_uses_nome_field_when_available", "test_pdf_uses_username_as_fallback".
  - "dados_comuns/tests/tests_exportacao_unidades.py": "test_pdf_gerado_com_estrutura_valida", "test_pdf_gerado_sem_rf_cadastrado".
- Ajustes auxiliares de setup para suportar os cenários:
  - "bem_patrimonial/tests/tests_export_pdf.py": helper "SetupExportData.create_usuario" passou a aceitar RF para montar cenários determinísticos.

## ✅ Comandos de validação
- Relatórios e documentos PDF:

```bash
docker compose -f docker-compose-dev.yml exec -T web python manage.py test \
  bem_patrimonial.tests.tests_cimbpm \
  bem_patrimonial.tests.test_nbbpm \
  inventario.tests.test_exportar_conciliacao_pdf \
  bem_patrimonial.tests.tests_export_pdf \
  dados_comuns.tests.tests_exportacao_unidades
```

- Regressão geral do sistema:

```bash
docker compose -f docker-compose-dev.yml exec -T web python manage.py test
```

- Validação já executada nesta branch: 85 testes direcionados relacionados aos PDFs, todos OK.

## ⚠️ Pontos de atenção
- A mudança é exclusivamente de apresentação dos PDFs; não altera regras de negócio, permissões, modelos ou fluxos de aprovação.
- O fallback principal para RF ausente é `-`.
- Há casos em que a ausência do responsável continua resultando em campo vazio, por regra já existente do documento.
