### PR TITLE
Fix: Corrige Falha Sazonal nos Testes de Conciliação Anual

### DIFF
--- a/inventario/tests/test_conciliacao_anual.py
+++ b/inventario/tests/test_conciliacao_anual.py
@@ -32,8 +32,19 @@ class ConciliacaoAnualModelTest(TestCase):
             criado_por=self.usuario,
         )
 
+    def criar_parametro_anual_vigente(self):
+        hoje = timezone.localdate()
+        return ParametroConciliacaoAnual.objects.create(
+            ano_referencia=hoje.year - 1,
+            periodo_inicial=hoje - timezone.timedelta(days=1),
+            periodo_final=hoje + timezone.timedelta(days=1),
+            ativo=True,
+            unidade_orcamentaria=self.ua.unidade_orcamentaria,
+        )
+
     def test_define_periodo_final_automaticamente(self):
         self.criar_bem()
+        self.criar_parametro_anual_vigente()
 
         conciliacao = ConciliacaoUA.objects.create(
             unidade_administrativa=self.ua,
@@ -46,6 +57,7 @@ class ConciliacaoAnualModelTest(TestCase):
 
     def test_nao_permite_duas_anuais_mesmo_ano(self):
         self.criar_bem()
+        self.criar_parametro_anual_vigente()
 
         ConciliacaoUA.objects.create(
             unidade_administrativa=self.ua,


### PR DESCRIPTION
## Objetivo

Corrigir a falha sazonal nos testes de conciliação anual, removendo a dependência da data real do ambiente de execução.

## Problema

Os testes de conciliação anual estavam criando registros sem garantir explicitamente que a data atual estivesse dentro da janela válida de criação.

Como a validação do modelo permite a criação da conciliação anual apenas dentro do período configurado, ou, na ausência de parâmetro, entre `01/01` e `31/03`, os testes passaram a falhar fora dessa janela, mesmo sem alteração na regra de negócio.

## O que foi feito

- Adicionado um helper de teste para criar um `ParametroConciliacaoAnual` vigente.
- Ajustados os testes que precisam criar uma conciliação anual com sucesso para usar esse parâmetro.
- Mantida a regra de negócio original do modelo, sem alteração funcional na aplicação.

## Resultado

- Os testes deixaram de depender do calendário real do ambiente.
- A suíte ficou determinística.
- A falha sazonal foi eliminada sem impactar o comportamento do domínio.

## Testes executados

```bash
docker compose -f docker-compose-dev.yml exec web python manage.py test inventario.tests.test_conciliacao_anual
docker compose -f docker-compose-dev.yml exec web python ma nage.py test inventario.tests
```

## Resultado dos testes

- inventario.tests.test_conciliacao_anual: 3 testes executados com sucesso
- inventario.tests: 62 testes executados com sucesso
