### PR TITLE
Feature(142268): Movimentação Entre UOs

### DIFF
--- a/bem_patrimonial/admins/forms/movimentacao_bem_patrimonial_form.py
+++ b/bem_patrimonial/admins/forms/movimentacao_bem_patrimonial_form.py
@@ -392,7 +392,6 @@ class MovimentacaoBemPatrimonialForm(forms.ModelForm):
 
     def clean(self):
         cleaned_data = super().clean()
-        self.is_cleaned = True
         user = self._get_user()
         is_editing = self.instance.pk is not None
         if not is_editing:

--- a/bem_patrimonial/admins/forms/movimentacao_bem_patrimonial_form.py
+++ b/bem_patrimonial/admins/forms/movimentacao_bem_patrimonial_form.py
@@ -1,61 +1,324 @@
+import json
+
 from django import forms
 from django.core.exceptions import ValidationError
+from django.db.models import Q
 
 from bem_patrimonial.models import MovimentacaoBemPatrimonial
-from dados_comuns.models import UnidadeAdministrativa
+from dados_comuns.models import UnidadeAdministrativa, UnidadeOrcamentaria
 
 from dados_comuns.escopo import (
     filtrar_ua_origem_por_escopo,
-    filtrar_ua_destino_por_uo_do_usuario,
 )
 
 
+CODIGO_UA_PONTO_CENTRAL = "001"
+MENSAGEM_SEM_PONTO_CENTRAL = (
+    "Não há ponto central cadastrado na Unidade Orçamentária de destino. "
+    "Por favor, entrar em contato com o gestor"
+)
+
+
+def q_codigo_ponto_central():
+    return Q(codigo=CODIGO_UA_PONTO_CENTRAL) | Q(
+        codigo__endswith=f".{CODIGO_UA_PONTO_CENTRAL}"
+    )
+
+
+def serializar_ua_para_opcao(ua):
+    return {"id": str(ua.pk), "label": str(ua)}
+
+
+def obter_uo_referencia_do_usuario(usuario):
+    if not usuario:
+        return None
+
+    unidade_orcamentaria = getattr(usuario, "unidade_orcamentaria", None)
+    if unidade_orcamentaria:
+        return unidade_orcamentaria
+
+    unidade_administrativa = getattr(usuario, "unidade_administrativa", None)
+    return getattr(unidade_administrativa, "unidade_orcamentaria", None)
+
+
+def queryset_uos_destino():
+    return UnidadeOrcamentaria.objects.filter(ativa=True).order_by("codigo", "nome")
+
+
+def queryset_uas_ativas():
+    return (
+        UnidadeAdministrativa.objects.filter(status=UnidadeAdministrativa.ATIVA)
+        .select_related("unidade_orcamentaria")
+        .order_by("unidade_orcamentaria__codigo", "codigo", "sigla", "nome")
+    )
+
+
+def queryset_uas_da_uo(unidade_orcamentaria):
+    qs = queryset_uas_ativas()
+    if not unidade_orcamentaria:
+        return qs.none()
+    return qs.filter(unidade_orcamentaria=unidade_orcamentaria)
+
+
+def obter_ua_ponto_central(unidade_orcamentaria):
+    if not unidade_orcamentaria:
+        return None
+
+    return (
+        queryset_uas_da_uo(unidade_orcamentaria)
+        .filter(q_codigo_ponto_central())
+        .order_by("id")
+        .first()
+    )
+
+
+def montar_configuracao_destino_widget(usuario):
+    uo_referencia = obter_uo_referencia_do_usuario(usuario)
+
+    centrais_por_uo = {}
+    uas_ponto_central = queryset_uas_ativas().filter(q_codigo_ponto_central())
+    for ua in uas_ponto_central:
+        centrais_por_uo[str(ua.unidade_orcamentaria_id)] = serializar_ua_para_opcao(ua)
+
+    opcoes_mesma_uo = []
+    if uo_referencia:
+        opcoes_mesma_uo = [
+            serializar_ua_para_opcao(ua) for ua in queryset_uas_da_uo(uo_referencia)
+        ]
+
+    return json.dumps(
+        {
+            "uoReferenciaId": str(uo_referencia.pk) if uo_referencia else "",
+            "centraisPorUo": centrais_por_uo,
+            "opcoesMesmaUo": opcoes_mesma_uo,
+            "mensagemSemPontoCentral": MENSAGEM_SEM_PONTO_CENTRAL,
+        }
+    )
+
+
 class MovimentacaoBemPatrimonialForm(forms.ModelForm):
+    unidade_orcamentaria_destino = forms.ModelChoiceField(
+        label="Unidade orçamentária de destino",
+        queryset=queryset_uos_destino().none(),
+        required=False,
+    )
+
     class Meta:
         model = MovimentacaoBemPatrimonial
         fields = (
             "unidade_administrativa_origem",
+            "unidade_orcamentaria_destino",
             "unidade_administrativa_destino",
             "observacao",
         )
 
     def __init__(self, *args, **kwargs):
+        self.request = kwargs.pop("request", None)
         super().__init__(*args, **kwargs)
 
-        user = None
-        if hasattr(self, "request") and getattr(self.request, "user", None):
-            user = self.request.user
+        if "unidade_administrativa_destino" in self.fields:
+            self.fields["unidade_administrativa_destino"].required = False
+            self.fields["unidade_administrativa_destino"].widget = forms.Select()
+        self._configure_dynamic_fields()
 
-        qs_ativas = UnidadeAdministrativa.objects.filter(
-            status=UnidadeAdministrativa.ATIVA
+    def _get_user(self):
+        if getattr(self, "request", None) and getattr(self.request, "user", None):
+            return self.request.user
+        return None
+
+    def _get_uo_referencia(self, user, ua_origem=None):
+        uo_referencia = obter_uo_referencia_do_usuario(user)
+        if uo_referencia:
+            return uo_referencia
+        return getattr(ua_origem, "unidade_orcamentaria", None)
+
+    def _get_selected_ua_origem(self, queryset_ativas):
+        if self.is_bound:
+            ua_origem_id = self.data.get(self.add_prefix("unidade_administrativa_origem"))
+            if ua_origem_id:
+                return queryset_ativas.filter(pk=ua_origem_id).first()
+
+        if self.instance.pk:
+            return self.instance.unidade_administrativa_origem
+
+        initial_value = self.fields["unidade_administrativa_origem"].initial
+        if initial_value:
+            return queryset_ativas.filter(pk=initial_value).first()
+
+        return None
+
+    def _get_selected_uo_destino(self, queryset_uos, uo_referencia):
+        if self.is_bound:
+            uo_destino_id = self.data.get(self.add_prefix("unidade_orcamentaria_destino"))
+            if uo_destino_id:
+                return queryset_uos.filter(pk=uo_destino_id).first()
+
+        if self.instance.pk and self.instance.unidade_administrativa_destino_id:
+            return self.instance.unidade_administrativa_destino.unidade_orcamentaria
+
+        initial_value = self.fields["unidade_orcamentaria_destino"].initial
+        if initial_value:
+            return queryset_uos.filter(pk=initial_value).first()
+
+        return uo_referencia
+
+    def _set_initial_origem_para_usuario(self, user):
+        ua_user = getattr(user, "unidade_administrativa", None)
+        if (
+            not self.instance.pk
+            and "unidade_administrativa_origem" in self.fields
+            and ua_user
+            and ua_user.is_ativa
+            and not self.fields["unidade_administrativa_origem"].initial
+        ):
+            self.fields["unidade_administrativa_origem"].initial = ua_user.pk
+
+    def _set_initial_uo_destino(self, uo_referencia):
+        if (
+            not self.instance.pk
+            and "unidade_orcamentaria_destino" in self.fields
+            and uo_referencia
+            and not self.fields["unidade_orcamentaria_destino"].initial
+        ):
+            self.fields["unidade_orcamentaria_destino"].initial = uo_referencia.pk
+
+    def _configure_destino_field_for_change(self, campo_destino, qs_ativas):
+        campo_destino.queryset = qs_ativas.filter(
+            pk=self.instance.unidade_administrativa_destino_id
         )
+        campo_destino.initial = self.instance.unidade_administrativa_destino_id
+        campo_destino.disabled = True
+        if "unidade_orcamentaria_destino" in self.fields:
+            self.fields["unidade_orcamentaria_destino"].disabled = True
 
-        if user:
-            if "unidade_administrativa_origem" in self.fields:
+    def _configure_destino_field_for_create(
+        self,
+        campo_destino,
+        qs_ativas,
+        uo_destino,
+        destino_mesma_uo,
+    ):
+        if uo_destino is None:
+            campo_destino.queryset = qs_ativas
+            campo_destino.disabled = False
+            return
+
+        if destino_mesma_uo:
+            campo_destino.queryset = queryset_uas_da_uo(uo_destino)
+            campo_destino.disabled = False
+            return
+
+        ua_ponto_central = obter_ua_ponto_central(uo_destino)
+        if ua_ponto_central:
+            campo_destino.queryset = qs_ativas.filter(pk=ua_ponto_central.pk)
+            campo_destino.initial = ua_ponto_central.pk
+        else:
+            campo_destino.queryset = qs_ativas.none()
+            campo_destino.initial = None
+
+        campo_destino.disabled = True
+
+    def _configure_dynamic_fields(self):
+        user = self._get_user()
+        qs_ativas = queryset_uas_ativas()
+        qs_uos = queryset_uos_destino()
+        possui_campo_origem = "unidade_administrativa_origem" in self.fields
+        possui_campo_uo_destino = "unidade_orcamentaria_destino" in self.fields
+        possui_campo_ua_destino = "unidade_administrativa_destino" in self.fields
+
+        if possui_campo_uo_destino:
+            self.fields["unidade_orcamentaria_destino"].queryset = qs_uos
+            self.fields["unidade_orcamentaria_destino"].widget.attrs[
+                "data-movimentacao-destino-config"
+            ] = montar_configuracao_destino_widget(user)
+
+        if possui_campo_origem:
+            if user:
                 self.fields["unidade_administrativa_origem"].queryset = (
                     filtrar_ua_origem_por_escopo(user, qs_ativas)
                 )
-
-            if "unidade_administrativa_destino" in self.fields:
-                self.fields["unidade_administrativa_destino"].queryset = (
-                    filtrar_ua_destino_por_uo_do_usuario(user, qs_ativas)
-                )
-        else:
-
-            if "unidade_administrativa_origem" in self.fields:
+            else:
                 self.fields["unidade_administrativa_origem"].queryset = qs_ativas
-            if "unidade_administrativa_destino" in self.fields:
-                self.fields["unidade_administrativa_destino"].queryset = qs_ativas
+
+        if possui_campo_origem:
+            self._set_initial_origem_para_usuario(user)
+
+        ua_origem = self._get_selected_ua_origem(qs_ativas)
+        uo_referencia = self._get_uo_referencia(user, ua_origem)
+
+        if possui_campo_uo_destino:
+            self._set_initial_uo_destino(uo_referencia)
+
+        uo_destino = self._get_selected_uo_destino(qs_uos, uo_referencia)
+        destino_mesma_uo = (
+            uo_destino is not None
+            and uo_referencia is not None
+            and uo_destino.pk == uo_referencia.pk
+        )
+
+        if not possui_campo_ua_destino:
+            if self.instance.pk and possui_campo_uo_destino:
+                self.fields["unidade_orcamentaria_destino"].disabled = True
+            return
+
+        campo_destino = self.fields["unidade_administrativa_destino"]
+
+        if self.instance.pk:
+            self._configure_destino_field_for_change(campo_destino, qs_ativas)
+            return
+
+        self._configure_destino_field_for_create(
+            campo_destino,
+            qs_ativas,
+            uo_destino,
+            destino_mesma_uo,
+        )
 
     def _validate_ua_origem_destino_new(self, cleaned_data, user):
         ua_origem = cleaned_data.get("unidade_administrativa_origem")
-        ua_destino = cleaned_data.get("unidade_administrativa_destino")
+        uo_destino = cleaned_data.get("unidade_orcamentaria_destino")
+
         if not ua_origem:
             raise ValidationError(
                 {
                     "unidade_administrativa_origem": "Unidade administrativa de origem é obrigatória."
                 }
             )
+
+        uo_referencia = self._get_uo_referencia(user, ua_origem)
+        if not uo_destino:
+            uo_destino = uo_referencia
+            cleaned_data["unidade_orcamentaria_destino"] = uo_destino
+
+        if not uo_destino:
+            raise ValidationError(
+                {
+                    "unidade_orcamentaria_destino": "Unidade Orçamentária de destino é obrigatória."
+                }
+            )
+
+        if not getattr(uo_destino, "ativa", False):
+            raise ValidationError(
+                {
+                    "unidade_orcamentaria_destino": "Unidade Orçamentária de destino está inativa."
+                }
+            )
+
+        destino_mesma_uo = (
+            uo_referencia is not None and uo_destino.pk == uo_referencia.pk
+        )
+
+        ua_destino = cleaned_data.get("unidade_administrativa_destino")
+        if not destino_mesma_uo:
+            ua_destino = obter_ua_ponto_central(uo_destino)
+            if not ua_destino:
+                raise ValidationError(
+                    {
+                        "unidade_orcamentaria_destino": MENSAGEM_SEM_PONTO_CENTRAL
+                    }
+                )
+            cleaned_data["unidade_administrativa_destino"] = ua_destino
+
         if not ua_destino:
             raise ValidationError(
                 {
@@ -84,8 +347,20 @@ class MovimentacaoBemPatrimonialForm(forms.ModelForm):
             raise ValidationError(
                 "Operação não permitida: origem e destino são iguais."
             )
+
+        if ua_destino.unidade_orcamentaria_id != uo_destino.id:
+            raise ValidationError(
+                {
+                    "unidade_administrativa_destino": (
+                        "A Unidade Administrativa de destino não pertence à Unidade "
+                        "Orçamentária selecionada."
+                    )
+                }
+            )
+
         if not user:
             return
+
         qs_origem = filtrar_ua_origem_por_escopo(
             user, UnidadeAdministrativa.objects.all()
         )
@@ -95,23 +370,37 @@ class MovimentacaoBemPatrimonialForm(forms.ModelForm):
                     "unidade_administrativa_origem": "UA de origem fora do seu escopo de acesso."
                 }
             )
-        qs_destino = filtrar_ua_destino_por_uo_do_usuario(
-            user, UnidadeAdministrativa.objects.all()
-        )
-        if not qs_destino.filter(pk=ua_destino.pk).exists():
+
+        if destino_mesma_uo:
+            qs_destino = queryset_uas_da_uo(uo_referencia)
+            if not qs_destino.filter(pk=ua_destino.pk).exists():
+                raise ValidationError(
+                    {
+                        "unidade_administrativa_destino": (
+                            "UA de destino fora das UAs permitidas para sua UO."
+                        )
+                    }
+                )
+
+        qs_uos = queryset_uos_destino()
+        if not qs_uos.filter(pk=uo_destino.pk).exists():
             raise ValidationError(
                 {
-                    "unidade_administrativa_destino": "UA de destino fora das UAs permitidas para sua UO."
+                    "unidade_orcamentaria_destino": "UO de destino fora das opções disponíveis."
                 }
             )
 
     def clean(self):
         cleaned_data = super().clean()
         self.is_cleaned = True
-        user = getattr(self, "request", None).user if hasattr(self, "request") else None
+        user = self._get_user()
         is_editing = self.instance.pk is not None
         if not is_editing:
             self._validate_ua_origem_destino_new(cleaned_data, user)
+        elif self.instance.unidade_administrativa_destino_id:
+            cleaned_data["unidade_orcamentaria_destino"] = (
+                self.instance.unidade_administrativa_destino.unidade_orcamentaria
+            )
         if is_editing and user and getattr(user, "is_operador_inventario", False):
             if self.instance.solicitado_por_id != user.id:
                 raise ValidationError(

--- a/bem_patrimonial/admins/forms/movimentacao_bem_patrimonial_form.py
+++ b/bem_patrimonial/admins/forms/movimentacao_bem_patrimonial_form.py
@@ -274,18 +274,10 @@ class MovimentacaoBemPatrimonialForm(forms.ModelForm):
             destino_mesma_uo,
         )
 
-    def _validate_ua_origem_destino_new(self, cleaned_data, user):
-        ua_origem = cleaned_data.get("unidade_administrativa_origem")
+    def _obter_uo_destino(self, cleaned_data, user, ua_origem):
         uo_destino = cleaned_data.get("unidade_orcamentaria_destino")
-
-        if not ua_origem:
-            raise ValidationError(
-                {
-                    "unidade_administrativa_origem": "Unidade administrativa de origem é obrigatória."
-                }
-            )
-
         uo_referencia = self._get_uo_referencia(user, ua_origem)
+
         if not uo_destino:
             uo_destino = uo_referencia
             cleaned_data["unidade_orcamentaria_destino"] = uo_destino
@@ -307,24 +299,30 @@ class MovimentacaoBemPatrimonialForm(forms.ModelForm):
         destino_mesma_uo = (
             uo_referencia is not None and uo_destino.pk == uo_referencia.pk
         )
+        return uo_destino, uo_referencia, destino_mesma_uo
 
+    def _obter_ua_destino(self, cleaned_data, uo_destino, destino_mesma_uo):
         ua_destino = cleaned_data.get("unidade_administrativa_destino")
-        if not destino_mesma_uo:
-            ua_destino = obter_ua_ponto_central(uo_destino)
+        if destino_mesma_uo:
             if not ua_destino:
                 raise ValidationError(
                     {
-                        "unidade_orcamentaria_destino": MENSAGEM_SEM_PONTO_CENTRAL
+                        "unidade_administrativa_destino": "Unidade administrativa de destino é obrigatória."
                     }
                 )
-            cleaned_data["unidade_administrativa_destino"] = ua_destino
+            return ua_destino
 
+        ua_destino = obter_ua_ponto_central(uo_destino)
         if not ua_destino:
             raise ValidationError(
                 {
-                    "unidade_administrativa_destino": "Unidade administrativa de destino é obrigatória."
+                    "unidade_orcamentaria_destino": MENSAGEM_SEM_PONTO_CENTRAL
                 }
             )
+        cleaned_data["unidade_administrativa_destino"] = ua_destino
+        return ua_destino
+
+    def _validar_estado_origem_destino(self, ua_origem, ua_destino, uo_destino):
         if not ua_origem.is_ativa:
             raise ValidationError(
                 {
@@ -347,7 +345,6 @@ class MovimentacaoBemPatrimonialForm(forms.ModelForm):
             raise ValidationError(
                 "Operação não permitida: origem e destino são iguais."
             )
-
         if ua_destino.unidade_orcamentaria_id != uo_destino.id:
             raise ValidationError(
                 {
@@ -358,6 +355,15 @@ class MovimentacaoBemPatrimonialForm(forms.ModelForm):
                 }
             )
 
+    def _validar_escopo_origem_destino(
+        self,
+        user,
+        ua_origem,
+        ua_destino,
+        uo_destino,
+        uo_referencia,
+        destino_mesma_uo,
+    ):
         if not user:
             return
 
@@ -389,6 +395,36 @@ class MovimentacaoBemPatrimonialForm(forms.ModelForm):
                     "unidade_orcamentaria_destino": "UO de destino fora das opções disponíveis."
                 }
             )
+
+    def _validate_ua_origem_destino_new(self, cleaned_data, user):
+        ua_origem = cleaned_data.get("unidade_administrativa_origem")
+
+        if not ua_origem:
+            raise ValidationError(
+                {
+                    "unidade_administrativa_origem": "Unidade administrativa de origem é obrigatória."
+                }
+            )
+
+        uo_destino, uo_referencia, destino_mesma_uo = self._obter_uo_destino(
+            cleaned_data,
+            user,
+            ua_origem,
+        )
+        ua_destino = self._obter_ua_destino(
+            cleaned_data,
+            uo_destino,
+            destino_mesma_uo,
+        )
+        self._validar_estado_origem_destino(ua_origem, ua_destino, uo_destino)
+        self._validar_escopo_origem_destino(
+            user,
+            ua_origem,
+            ua_destino,
+            uo_destino,
+            uo_referencia,
+            destino_mesma_uo,
+        )
 
     def clean(self):
         cleaned_data = super().clean()

--- a/bem_patrimonial/admins/movimentacao_bem_patrimonial.py
+++ b/bem_patrimonial/admins/movimentacao_bem_patrimonial.py
@@ -82,30 +82,28 @@ def _mensagem_mov_origem_destino_inativas(mov, request, acao_verb):
     return False
 
 
-def _check_operador_destino_aprovacao(mov, request):
-    if _movimentacao_entre_uos_diferentes(mov):
-        return False
-    if not request.user.is_operador_inventario:
+def _check_operador_destino_mesma_uo(mov, request, acao):
+    if _movimentacao_entre_uos_diferentes(mov) or not request.user.is_operador_inventario:
         return False
     if mov.unidade_administrativa_destino != request.user.unidade_administrativa:
         messages.add_message(
             request,
             messages.ERROR,
             f"Movimentação #{mov.pk}: Apenas operadores da unidade de destino "
-            "podem aprovar esta movimentação.",
+            f"podem {acao} esta movimentação.",
         )
         return True
     if mov.solicitado_por_id == request.user.pk:
         messages.add_message(
             request,
             messages.WARNING,
-            f"Movimentação #{mov.pk}: Você não pode aprovar sua própria solicitação.",
+            f"Movimentação #{mov.pk}: Você não pode {acao} sua própria solicitação.",
         )
         return True
     return False
 
 
-def _check_aprovacao_entre_uos(mov, request):
+def _check_acao_entre_uos(mov, request, acao):
     if not _movimentacao_entre_uos_diferentes(mov):
         return False
 
@@ -114,7 +112,7 @@ def _check_aprovacao_entre_uos(mov, request):
         messages.add_message(
             request,
             messages.WARNING,
-            f"Movimentação #{mov.pk}: Você não pode aprovar sua própria solicitação em movimentações entre UOs.",
+            f"Movimentação #{mov.pk}: Você não pode {acao} sua própria solicitação em movimentações entre UOs.",
         )
         return True
 
@@ -123,7 +121,7 @@ def _check_aprovacao_entre_uos(mov, request):
             messages.add_message(
                 request,
                 messages.ERROR,
-                f"Movimentação #{mov.pk}: Apenas operadores da unidade de destino podem aprovar esta movimentação.",
+                f"Movimentação #{mov.pk}: Apenas operadores da unidade de destino podem {acao} esta movimentação.",
             )
             return True
         return False
@@ -134,66 +132,7 @@ def _check_aprovacao_entre_uos(mov, request):
         messages.add_message(
             request,
             messages.ERROR,
-            f"Movimentação #{mov.pk}: Apenas gestores da UO de destino podem aprovar esta movimentação entre UOs.",
-        )
-        return True
-
-    return False
-
-
-def _check_operador_destino_rejeicao(mov, request):
-    if _movimentacao_entre_uos_diferentes(mov):
-        return False
-    if not request.user.is_operador_inventario:
-        return False
-    if mov.unidade_administrativa_destino != request.user.unidade_administrativa:
-        messages.add_message(
-            request,
-            messages.ERROR,
-            f"Movimentação #{mov.pk}: Apenas operadores da unidade de destino "
-            "podem rejeitar esta movimentação.",
-        )
-        return True
-    if mov.solicitado_por_id == request.user.pk:
-        messages.add_message(
-            request,
-            messages.WARNING,
-            f"Movimentação #{mov.pk}: Você não pode rejeitar sua própria solicitação.",
-        )
-        return True
-    return False
-
-
-def _check_rejeicao_entre_uos(mov, request):
-    if not _movimentacao_entre_uos_diferentes(mov):
-        return False
-
-    usuario = request.user
-    if mov.solicitado_por_id == usuario.pk:
-        messages.add_message(
-            request,
-            messages.WARNING,
-            f"Movimentação #{mov.pk}: Você não pode rejeitar sua própria solicitação em movimentações entre UOs.",
-        )
-        return True
-
-    if usuario.is_operador_inventario and not usuario.is_gestor_patrimonio:
-        if mov.unidade_administrativa_destino_id != usuario.unidade_administrativa_id:
-            messages.add_message(
-                request,
-                messages.ERROR,
-                f"Movimentação #{mov.pk}: Apenas operadores da unidade de destino podem rejeitar esta movimentação.",
-            )
-            return True
-        return False
-
-    if usuario.is_gestor_patrimonio and not _usuario_e_gestor_da_uo(
-        usuario, mov.unidade_administrativa_destino.unidade_orcamentaria_id
-    ):
-        messages.add_message(
-            request,
-            messages.ERROR,
-            f"Movimentação #{mov.pk}: Apenas gestores da UO de destino podem rejeitar esta movimentação entre UOs.",
+            f"Movimentação #{mov.pk}: Apenas gestores da UO de destino podem {acao} esta movimentação entre UOs.",
         )
         return True
 
@@ -233,6 +172,18 @@ def _bloqueio_se_algum(request, mov, checks):
     return False
 
 
+def _nao_pode_processar_movimentacao(mov, request, checks, acao):
+    if _bloqueio_se_algum(request, mov, checks):
+        return True
+    if _mensagem_mov_origem_destino_inativas(mov, request, acao):
+        return True
+    if _check_acao_entre_uos(mov, request, acao):
+        return True
+    if _check_operador_destino_mesma_uo(mov, request, acao):
+        return True
+    return False
+
+
 def _nao_pode_aprovar(mov, request):
     checks = [
         (
@@ -251,15 +202,7 @@ def _nao_pode_aprovar(mov, request):
             messages.ERROR,
         ),
     ]
-    if _bloqueio_se_algum(request, mov, checks):
-        return True
-    if _mensagem_mov_origem_destino_inativas(mov, request, "aprovar"):
-        return True
-    if _check_aprovacao_entre_uos(mov, request):
-        return True
-    if _check_operador_destino_aprovacao(mov, request):
-        return True
-    return False
+    return _nao_pode_processar_movimentacao(mov, request, checks, "aprovar")
 
 
 def aprovar_solicitacao(modeladmin, request, queryset):
@@ -315,15 +258,7 @@ def _nao_pode_rejeitar(mov, request):
             messages.ERROR,
         ),
     ]
-    if _bloqueio_se_algum(request, mov, checks):
-        return True
-    if _mensagem_mov_origem_destino_inativas(mov, request, "rejeitar"):
-        return True
-    if _check_rejeicao_entre_uos(mov, request):
-        return True
-    if _check_operador_destino_rejeicao(mov, request):
-        return True
-    return False
+    return _nao_pode_processar_movimentacao(mov, request, checks, "rejeitar")
 
 
 def rejeitar_solicitacao(modeladmin, request, queryset):

--- a/bem_patrimonial/admins/movimentacao_bem_patrimonial.py
+++ b/bem_patrimonial/admins/movimentacao_bem_patrimonial.py
@@ -27,7 +27,30 @@ from dados_comuns.escopo import (
 )
 
 
-UNIDADE_ADMINISTRATIVA_ORIGEM_AUTOCOMPLETE = "unidade_administrativa_origem"
+def _obter_uo_id_do_usuario(usuario):
+    uo_id = getattr(usuario, "unidade_orcamentaria_id", None)
+    if uo_id:
+        return uo_id
+
+    unidade_administrativa = getattr(usuario, "unidade_administrativa", None)
+    return getattr(unidade_administrativa, "unidade_orcamentaria_id", None)
+
+
+def _movimentacao_entre_uos_diferentes(mov):
+    origem_uo_id = getattr(
+        mov.unidade_administrativa_origem, "unidade_orcamentaria_id", None
+    )
+    destino_uo_id = getattr(
+        mov.unidade_administrativa_destino, "unidade_orcamentaria_id", None
+    )
+    return bool(origem_uo_id and destino_uo_id and origem_uo_id != destino_uo_id)
+
+
+def _usuario_e_gestor_da_uo(usuario, uo_id):
+    return bool(
+        getattr(usuario, "is_gestor_patrimonio", False)
+        and _obter_uo_id_do_usuario(usuario) == uo_id
+    )
 
 
 def _bens_da_movimentacao(mov):
@@ -60,6 +83,8 @@ def _mensagem_mov_origem_destino_inativas(mov, request, acao_verb):
 
 
 def _check_operador_destino_aprovacao(mov, request):
+    if _movimentacao_entre_uos_diferentes(mov):
+        return False
     if not request.user.is_operador_inventario:
         return False
     if mov.unidade_administrativa_destino != request.user.unidade_administrativa:
@@ -80,7 +105,45 @@ def _check_operador_destino_aprovacao(mov, request):
     return False
 
 
+def _check_aprovacao_entre_uos(mov, request):
+    if not _movimentacao_entre_uos_diferentes(mov):
+        return False
+
+    usuario = request.user
+    if mov.solicitado_por_id == usuario.pk:
+        messages.add_message(
+            request,
+            messages.WARNING,
+            f"Movimentação #{mov.pk}: Você não pode aprovar sua própria solicitação em movimentações entre UOs.",
+        )
+        return True
+
+    if usuario.is_operador_inventario and not usuario.is_gestor_patrimonio:
+        if mov.unidade_administrativa_destino_id != usuario.unidade_administrativa_id:
+            messages.add_message(
+                request,
+                messages.ERROR,
+                f"Movimentação #{mov.pk}: Apenas operadores da unidade de destino podem aprovar esta movimentação.",
+            )
+            return True
+        return False
+
+    if usuario.is_gestor_patrimonio and not _usuario_e_gestor_da_uo(
+        usuario, mov.unidade_administrativa_destino.unidade_orcamentaria_id
+    ):
+        messages.add_message(
+            request,
+            messages.ERROR,
+            f"Movimentação #{mov.pk}: Apenas gestores da UO de destino podem aprovar esta movimentação entre UOs.",
+        )
+        return True
+
+    return False
+
+
 def _check_operador_destino_rejeicao(mov, request):
+    if _movimentacao_entre_uos_diferentes(mov):
+        return False
     if not request.user.is_operador_inventario:
         return False
     if mov.unidade_administrativa_destino != request.user.unidade_administrativa:
@@ -99,6 +162,66 @@ def _check_operador_destino_rejeicao(mov, request):
         )
         return True
     return False
+
+
+def _check_rejeicao_entre_uos(mov, request):
+    if not _movimentacao_entre_uos_diferentes(mov):
+        return False
+
+    usuario = request.user
+    if mov.solicitado_por_id == usuario.pk:
+        messages.add_message(
+            request,
+            messages.WARNING,
+            f"Movimentação #{mov.pk}: Você não pode rejeitar sua própria solicitação em movimentações entre UOs.",
+        )
+        return True
+
+    if usuario.is_operador_inventario and not usuario.is_gestor_patrimonio:
+        if mov.unidade_administrativa_destino_id != usuario.unidade_administrativa_id:
+            messages.add_message(
+                request,
+                messages.ERROR,
+                f"Movimentação #{mov.pk}: Apenas operadores da unidade de destino podem rejeitar esta movimentação.",
+            )
+            return True
+        return False
+
+    if usuario.is_gestor_patrimonio and not _usuario_e_gestor_da_uo(
+        usuario, mov.unidade_administrativa_destino.unidade_orcamentaria_id
+    ):
+        messages.add_message(
+            request,
+            messages.ERROR,
+            f"Movimentação #{mov.pk}: Apenas gestores da UO de destino podem rejeitar esta movimentação entre UOs.",
+        )
+        return True
+
+    return False
+
+
+def _check_cancelamento_entre_uos(mov, request):
+    if not _movimentacao_entre_uos_diferentes(mov):
+        return False
+
+    usuario = request.user
+    if not usuario.is_gestor_patrimonio:
+        return False
+
+    usuario_uo_id = _obter_uo_id_do_usuario(usuario)
+    uos_permitidas = {
+        mov.unidade_administrativa_origem.unidade_orcamentaria_id,
+        mov.unidade_administrativa_destino.unidade_orcamentaria_id,
+    }
+    if usuario_uo_id in uos_permitidas:
+        return False
+
+    messages.add_message(
+        request,
+        messages.ERROR,
+        f"Movimentação #{mov.pk}: Apenas gestores da UO de origem ou destino podem cancelar esta movimentação entre UOs.",
+    )
+    return True
 
 
 def _bloqueio_se_algum(request, mov, checks):
@@ -131,6 +254,8 @@ def _nao_pode_aprovar(mov, request):
     if _bloqueio_se_algum(request, mov, checks):
         return True
     if _mensagem_mov_origem_destino_inativas(mov, request, "aprovar"):
+        return True
+    if _check_aprovacao_entre_uos(mov, request):
         return True
     if _check_operador_destino_aprovacao(mov, request):
         return True
@@ -193,6 +318,8 @@ def _nao_pode_rejeitar(mov, request):
     if _bloqueio_se_algum(request, mov, checks):
         return True
     if _mensagem_mov_origem_destino_inativas(mov, request, "rejeitar"):
+        return True
+    if _check_rejeicao_entre_uos(mov, request):
         return True
     if _check_operador_destino_rejeicao(mov, request):
         return True
@@ -263,7 +390,11 @@ def _nao_pode_cancelar(mov, request):
             messages.ERROR,
         ),
     ]
-    return _bloqueio_se_algum(request, mov, checks)
+    if _bloqueio_se_algum(request, mov, checks):
+        return True
+    if _check_cancelamento_entre_uos(mov, request):
+        return True
+    return False
 
 
 def cancelar_solicitacao(modeladmin, request, queryset):
@@ -295,6 +426,25 @@ cancelar_solicitacao.short_description = "Cancelar movimentação selecionada"
 
 class MovimentacaoBemPatrimonialAdmin(admin.ModelAdmin):
     model = MovimentacaoBemPatrimonial
+    create_fields = (
+        "unidade_administrativa_origem",
+        "unidade_orcamentaria_destino",
+        "unidade_administrativa_destino",
+        "observacao",
+    )
+    change_fields = (
+        "status",
+        "numero_cimbpm",
+        "get_documento_cimbpm_link",
+        "solicitado_por",
+        "aprovado_por",
+        "rejeitado_por",
+        "cancelado_por",
+        "unidade_administrativa_origem",
+        "get_unidade_orcamentaria_destino",
+        "unidade_administrativa_destino",
+        "observacao",
+    )
 
     list_display = (
         "id",
@@ -341,7 +491,6 @@ class MovimentacaoBemPatrimonialAdmin(admin.ModelAdmin):
 
     autocomplete_fields = (
         "unidade_administrativa_origem",
-        "unidade_administrativa_destino",
     )
 
     readonly_fields = (
@@ -352,6 +501,7 @@ class MovimentacaoBemPatrimonialAdmin(admin.ModelAdmin):
         "status",
         "numero_cimbpm",
         "get_documento_cimbpm_link",
+        "get_unidade_orcamentaria_destino",
         "unidade_administrativa_origem",
         "unidade_administrativa_destino",
     )
@@ -371,6 +521,7 @@ class MovimentacaoBemPatrimonialAdmin(admin.ModelAdmin):
         js = (
             "js/bem_patrimonial/prevenir_duplo_submit.js",
             "admin/movimentacao_filtra_bens_por_ua.js",
+            "admin/movimentacao_uo_destino.js",
         )
         css = {
             "all": (
@@ -381,25 +532,10 @@ class MovimentacaoBemPatrimonialAdmin(admin.ModelAdmin):
         }
 
     def get_fields(self, request, obj=None):
-        base_fields = [
-            "unidade_administrativa_origem",
-            "unidade_administrativa_destino",
-            "observacao",
-        ]
-
         if obj is not None:
-            return [
-                "status",
-                "numero_cimbpm",
-                "get_documento_cimbpm_link",
-                "solicitado_por",
-                "aprovado_por",
-                "rejeitado_por",
-                "cancelado_por",
-                *base_fields,
-            ]
+            return self.change_fields
 
-        return base_fields
+        return self.create_fields
 
     def get_readonly_fields(self, request, obj=None):
         if obj is None:
@@ -411,21 +547,8 @@ class MovimentacaoBemPatrimonialAdmin(admin.ModelAdmin):
 
         class RequestForm(form_class):
             def __init__(self_inner, *a, **kw):
+                kw["request"] = request
                 super().__init__(*a, **kw)
-                self_inner.request = request
-
-                if obj is None:
-                    ua_user = getattr(request.user, "unidade_administrativa", None)
-                    if (
-                        ua_user
-                        and ua_user.is_ativa
-                        and hasattr(self_inner, "base_fields")
-                        and UNIDADE_ADMINISTRATIVA_ORIGEM_AUTOCOMPLETE
-                        in self_inner.base_fields
-                    ):
-                        self_inner.base_fields[
-                            UNIDADE_ADMINISTRATIVA_ORIGEM_AUTOCOMPLETE
-                        ].initial = ua_user.pk
 
         return RequestForm
 
@@ -464,9 +587,14 @@ class MovimentacaoBemPatrimonialAdmin(admin.ModelAdmin):
 
     get_documento_cimbpm_link.short_description = "Documento CIMBPM"
 
-    def get_actions(self, request):
-        actions = super().get_actions(request)
-        return actions
+    def get_unidade_orcamentaria_destino(self, obj):
+        if not obj or not obj.unidade_administrativa_destino_id:
+            return "-"
+        return obj.unidade_administrativa_destino.unidade_orcamentaria
+
+    get_unidade_orcamentaria_destino.short_description = (
+        "Unidade orçamentária de destino"
+    )
 
     def response_action(self, request, queryset):
 

--- a/bem_patrimonial/tests/tests_movimentacao_bloqueio.py
+++ b/bem_patrimonial/tests/tests_movimentacao_bloqueio.py
@@ -3,6 +3,7 @@ from django.test import TestCase, RequestFactory
 from django.contrib.admin.sites import AdminSite
 from django.contrib.messages.storage.fallback import FallbackStorage
 from django.contrib import messages
+from unittest.mock import Mock, patch
 
 from bem_patrimonial.models import (
     BemPatrimonial,
@@ -14,14 +15,19 @@ from bem_patrimonial.constants import (
     BLOQUEADO,
     ENVIADA,
     ACEITA,
+    CANCELADA,
     REJEITADA,
 )
 from bem_patrimonial.admins.movimentacao_bem_patrimonial import (
     MovimentacaoBemPatrimonialAdmin,
     aprovar_solicitacao,
+    cancelar_solicitacao,
     rejeitar_solicitacao,
 )
-from dados_comuns.tests.factories import criar_ua
+from bem_patrimonial.admins.forms.movimentacao_bem_patrimonial_form import (
+    obter_ua_ponto_central,
+)
+from dados_comuns.tests.factories import criar_ua, criar_uo
 from usuario.models import Usuario
 from usuario.constants import GRUPO_OPERADOR_INVENTARIO, GRUPO_GESTOR_PATRIMONIO
 from django.contrib.auth.models import Group
@@ -361,6 +367,40 @@ class PermissoesAdminActionsTestCase(TestCase):
         self.assertEqual(self.movimentacao.status, ACEITA)
         self.assertEqual(self.movimentacao.aprovado_por, self.gestor)
 
+    def test_gestor_pode_aprovar_propria_solicitacao_na_mesma_uo(self):
+        movimentacao = self.test_data.create_movimentacao_com_item(
+            bem=self.bem,
+            ua_origem=self.ua_origem,
+            ua_destino=self.ua_destino,
+            solicitado_por=self.gestor,
+        )
+
+        request = self._create_request_with_messages(self.gestor)
+        queryset = MovimentacaoBemPatrimonial.objects.filter(pk=movimentacao.pk)
+
+        aprovar_solicitacao(self.admin, request, queryset)
+
+        movimentacao.refresh_from_db()
+        self.assertEqual(movimentacao.status, ACEITA)
+        self.assertEqual(movimentacao.aprovado_por, self.gestor)
+
+    def test_gestor_pode_rejeitar_propria_solicitacao_na_mesma_uo(self):
+        movimentacao = self.test_data.create_movimentacao_com_item(
+            bem=self.bem,
+            ua_origem=self.ua_origem,
+            ua_destino=self.ua_destino,
+            solicitado_por=self.gestor,
+        )
+
+        request = self._create_request_with_messages(self.gestor)
+        queryset = MovimentacaoBemPatrimonial.objects.filter(pk=movimentacao.pk)
+
+        rejeitar_solicitacao(self.admin, request, queryset)
+
+        movimentacao.refresh_from_db()
+        self.assertEqual(movimentacao.status, REJEITADA)
+        self.assertEqual(movimentacao.rejeitado_por, self.gestor)
+
     def test_solicitante_nao_pode_aprovar_propria_solicitacao(self):
         self.bem.unidade_administrativa = self.ua_destino
         self.bem.save()
@@ -431,6 +471,123 @@ class PermissoesAdminActionsTestCase(TestCase):
         self.assertTrue(
             any("já foi rejeitada anteriormente" in msg for msg in mensagens)
         )
+
+    def test_operador_fora_da_ua_destino_nao_pode_rejeitar(self):
+        request = self._create_request_with_messages(self.operador_origem)
+        queryset = MovimentacaoBemPatrimonial.objects.filter(pk=self.movimentacao.pk)
+
+        rejeitar_solicitacao(self.admin, request, queryset)
+
+        self.movimentacao.refresh_from_db()
+        self.assertEqual(self.movimentacao.status, ENVIADA)
+        mensagens = [str(m) for m in messages.get_messages(request)]
+        self.assertTrue(any("Apenas operadores da unidade de destino" in msg for msg in mensagens))
+
+    def test_solicitante_nao_pode_rejeitar_propria_solicitacao(self):
+        movimentacao2 = self.test_data.create_movimentacao_com_item(
+            bem=self.bem,
+            ua_origem=self.ua_origem,
+            ua_destino=self.ua_destino,
+            solicitado_por=self.operador_destino,
+        )
+
+        request = self._create_request_with_messages(self.operador_destino)
+        queryset = MovimentacaoBemPatrimonial.objects.filter(pk=movimentacao2.pk)
+
+        rejeitar_solicitacao(self.admin, request, queryset)
+
+        movimentacao2.refresh_from_db()
+        self.assertEqual(movimentacao2.status, ENVIADA)
+        mensagens = [str(m) for m in messages.get_messages(request)]
+        self.assertTrue(any("Você não pode rejeitar sua própria solicitação" in msg for msg in mensagens))
+
+    def test_aprovar_movimentacao_sem_itens_exibe_erro(self):
+        movimentacao_sem_itens = MovimentacaoBemPatrimonial.objects.create(
+            unidade_administrativa_origem=self.ua_origem,
+            unidade_administrativa_destino=self.ua_destino,
+            solicitado_por=self.operador_origem,
+        )
+
+        request = self._create_request_with_messages(self.gestor)
+        queryset = MovimentacaoBemPatrimonial.objects.filter(pk=movimentacao_sem_itens.pk)
+
+        aprovar_solicitacao(self.admin, request, queryset)
+
+        mensagens = [str(m) for m in messages.get_messages(request)]
+        self.assertTrue(any("não possui bens associados" in msg for msg in mensagens))
+
+    def test_rejeitar_movimentacao_sem_itens_exibe_erro(self):
+        movimentacao_sem_itens = MovimentacaoBemPatrimonial.objects.create(
+            unidade_administrativa_origem=self.ua_origem,
+            unidade_administrativa_destino=self.ua_destino,
+            solicitado_por=self.operador_origem,
+        )
+
+        request = self._create_request_with_messages(self.gestor)
+        queryset = MovimentacaoBemPatrimonial.objects.filter(pk=movimentacao_sem_itens.pk)
+
+        rejeitar_solicitacao(self.admin, request, queryset)
+
+        mensagens = [str(m) for m in messages.get_messages(request)]
+        self.assertTrue(any("não possui bens associados" in msg for msg in mensagens))
+
+    def test_get_documento_cimbpm_link_sem_numero(self):
+        self.movimentacao.numero_cimbpm = ""
+        self.movimentacao.save(update_fields=["numero_cimbpm"])
+
+        self.assertEqual(
+            self.admin.get_documento_cimbpm_link(self.movimentacao),
+            "Número CIMBPM não gerado",
+        )
+
+    def test_get_documento_cimbpm_link_com_numero(self):
+        resultado = self.admin.get_documento_cimbpm_link(self.movimentacao)
+        self.assertIn("Baixar Documento CIMBPM", str(resultado))
+
+    def test_get_unidade_orcamentaria_destino_sem_destino(self):
+        movimentacao = MovimentacaoBemPatrimonial.objects.create(
+            solicitado_por=self.operador_origem,
+            unidade_administrativa_origem=self.ua_origem,
+            unidade_administrativa_destino=self.ua_destino,
+        )
+        movimentacao.unidade_administrativa_destino = None
+        movimentacao.unidade_administrativa_destino_id = None
+        self.assertEqual(self.admin.get_unidade_orcamentaria_destino(movimentacao), "-")
+
+    @patch("bem_patrimonial.admins.movimentacao_bem_patrimonial.verificar_movimentacoes_duplicadas")
+    def test_response_action_verificar_movimentacoes_duplicadas(self, mock_verificar):
+        request = self._create_request_with_messages(self.gestor)
+        request.POST = request.POST.copy()
+        request.POST["action"] = "verificar_movimentacoes_duplicadas"
+        queryset = MovimentacaoBemPatrimonial.objects.filter(pk=self.movimentacao.pk)
+        mock_changelist = Mock()
+        mock_changelist.get_queryset.return_value = queryset
+        self.admin.get_changelist_instance = Mock(return_value=mock_changelist)
+        mock_verificar.return_value = "ok"
+
+        resposta = self.admin.response_action(request, queryset)
+
+        self.assertEqual(resposta, "ok")
+        mock_verificar.assert_called_once_with(self.admin, request, queryset)
+
+    @patch("django.contrib.admin.options.ModelAdmin.get_inline_formsets")
+    def test_get_inline_formsets_desabilita_campos_na_edicao(self, mock_super_get_inline_formsets):
+        campo = Mock()
+        form = Mock(fields={"bem": campo, "descricao": Mock()})
+        formset = Mock(can_add=True, can_delete=True, forms=[form])
+        mock_super_get_inline_formsets.return_value = [formset]
+
+        retorno = self.admin.get_inline_formsets(
+            request=self._create_request_with_messages(self.gestor),
+            formsets=[],
+            inline_instances=[],
+            obj=self.movimentacao,
+        )
+
+        self.assertEqual(retorno, [formset])
+        self.assertFalse(formset.can_add)
+        self.assertFalse(formset.can_delete)
+        self.assertTrue(all(field.disabled for field in form.fields.values()))
 
 
 class IntegracaoCompletaTestCase(TestCase):
@@ -518,3 +675,260 @@ class IntegracaoCompletaTestCase(TestCase):
 
         self.bem.refresh_from_db()
         self.assertEqual(self.bem.unidade_administrativa, self.ua_origem)
+
+    def test_aprovacao_para_outra_uo_move_bem_para_ua_ponto_central(self):
+        uo_destino_externa = criar_uo(
+            codigo="01.16.11",
+            nome="UO Destino Externa",
+            sigla="UO5",
+        )
+        criar_ua(
+            uo=uo_destino_externa,
+            codigo="01.16.11.001",
+            nome="Ponto Central Externo",
+            sigla="PCE",
+        )
+        ua_destino_externa = obter_ua_ponto_central(uo_destino_externa)
+
+        movimentacao = self.test_data.create_movimentacao_com_item(
+            bem=self.bem,
+            ua_origem=self.ua_origem,
+            ua_destino=ua_destino_externa,
+            solicitado_por=self.operador_origem,
+        )
+
+        movimentacao.aprovar_solicitacao(self.gestor)
+        self.bem.refresh_from_db()
+
+        self.assertEqual(self.bem.unidade_administrativa, ua_destino_externa)
+
+
+class PermissoesEntreUOsAdminActionsTestCase(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.site = AdminSite()
+        self.admin = MovimentacaoBemPatrimonialAdmin(
+            MovimentacaoBemPatrimonial, self.site
+        )
+
+        self.grupo_operador, _ = Group.objects.get_or_create(
+            name=GRUPO_OPERADOR_INVENTARIO
+        )
+        self.grupo_gestor, _ = Group.objects.get_or_create(
+            name=GRUPO_GESTOR_PATRIMONIO
+        )
+
+        self.uo_origem = criar_uo(
+            codigo="01.16.20",
+            nome="UO Origem",
+            sigla="UOOR",
+        )
+        self.ua_origem = criar_ua(
+            uo=self.uo_origem,
+            codigo="01.16.20.005",
+            nome="UA Origem",
+            sigla="UAOR",
+        )
+        self.ua_gestor_origem = criar_ua(
+            uo=self.uo_origem,
+            codigo="01.16.20.010",
+            nome="UA Gestor Origem",
+            sigla="UGOR",
+        )
+
+        self.uo_destino = criar_uo(
+            codigo="01.16.21",
+            nome="UO Destino",
+            sigla="UODE",
+        )
+        self.ua_destino_central = criar_ua(
+            uo=self.uo_destino,
+            codigo="01.16.21.001",
+            nome="Ponto Central Destino",
+            sigla="PCDE",
+        )
+        self.ua_gestor_destino = criar_ua(
+            uo=self.uo_destino,
+            codigo="01.16.21.010",
+            nome="UA Gestor Destino",
+            sigla="UGDE",
+        )
+
+        self.operador_origem = Usuario.objects.create_user(
+            username="operador_origem_uo_diff",
+            email="operador.origem.uo.diff@test.com",
+            **auth_kwargs("test123"),
+            unidade_orcamentaria=self.uo_origem,
+            unidade_administrativa=self.ua_origem,
+        )
+        self.operador_origem.groups.add(self.grupo_operador)
+        self.operador_origem.unidades_administrativas.add(self.ua_origem)
+
+        self.operador_destino = Usuario.objects.create_user(
+            username="operador_destino_uo_diff",
+            email="operador.destino.uo.diff@test.com",
+            **auth_kwargs("test123"),
+            unidade_orcamentaria=self.uo_destino,
+            unidade_administrativa=self.ua_destino_central,
+        )
+        self.operador_destino.groups.add(self.grupo_operador)
+        self.operador_destino.unidades_administrativas.add(self.ua_destino_central)
+
+        self.gestor_origem = self._create_gestor(
+            username="gestor_origem_uo_diff",
+            email="gestor.origem.uo.diff@test.com",
+            unidade_orcamentaria=self.uo_origem,
+            unidade_administrativa=self.ua_gestor_origem,
+        )
+        self.gestor_destino = self._create_gestor(
+            username="gestor_destino_uo_diff",
+            email="gestor.destino.uo.diff@test.com",
+            unidade_orcamentaria=self.uo_destino,
+            unidade_administrativa=self.ua_gestor_destino,
+        )
+
+        self.bem = BemPatrimonial.objects.create(
+            nome="Notebook Inter UO",
+            descricao="Notebook para testar movimentacao entre UOs",
+            numero_processo="PROC-INTER-UO",
+            valor_unitario=2500.00,
+            marca="Dell",
+            modelo="Latitude",
+            numero_patrimonial="999.999999999-9",
+            numero_formato_antigo=False,
+            sem_numeracao=False,
+            localizacao="Sala 1",
+            criado_por=self.operador_origem,
+            status=APROVADO,
+            unidade_administrativa=self.ua_origem,
+        )
+
+        self.movimentacao = self._create_movimentacao(solicitado_por=self.operador_origem)
+
+    def _create_gestor(
+        self, username, email, unidade_orcamentaria, unidade_administrativa
+    ):
+        gestor = Usuario.objects.create_user(
+            username=username,
+            email=email,
+            **auth_kwargs("test123"),
+            is_staff=True,
+            unidade_orcamentaria=unidade_orcamentaria,
+            unidade_administrativa=unidade_administrativa,
+        )
+        gestor.groups.add(self.grupo_gestor)
+        return gestor
+
+    def _create_request_with_messages(self, user):
+        request = self.factory.post("/admin/")
+        request.user = user
+        setattr(request, "session", "session")
+        setattr(request, "_messages", FallbackStorage(request))
+        return request
+
+    def _create_movimentacao(self, solicitado_por):
+        movimentacao = MovimentacaoBemPatrimonial.objects.create(
+            bem_patrimonial=self.bem,
+            unidade_administrativa_origem=self.ua_origem,
+            unidade_administrativa_destino=self.ua_destino_central,
+            solicitado_por=solicitado_por,
+        )
+        MovimentacaoBensItem.objects.create(
+            movimentacao=movimentacao,
+            bem=self.bem,
+        )
+        return movimentacao
+
+    def test_gestor_origem_nao_pode_aprovar_movimentacao_entre_uos(self):
+        request = self._create_request_with_messages(self.gestor_origem)
+        queryset = MovimentacaoBemPatrimonial.objects.filter(pk=self.movimentacao.pk)
+
+        aprovar_solicitacao(self.admin, request, queryset)
+
+        self.movimentacao.refresh_from_db()
+        self.assertEqual(self.movimentacao.status, ENVIADA)
+        mensagens = [str(m) for m in messages.get_messages(request)]
+        self.assertTrue(any("Apenas gestores da UO de destino" in msg for msg in mensagens))
+
+    def test_gestor_origem_nao_pode_rejeitar_movimentacao_entre_uos(self):
+        request = self._create_request_with_messages(self.gestor_origem)
+        queryset = MovimentacaoBemPatrimonial.objects.filter(pk=self.movimentacao.pk)
+
+        rejeitar_solicitacao(self.admin, request, queryset)
+
+        self.movimentacao.refresh_from_db()
+        self.assertEqual(self.movimentacao.status, ENVIADA)
+        mensagens = [str(m) for m in messages.get_messages(request)]
+        self.assertTrue(any("Apenas gestores da UO de destino" in msg for msg in mensagens))
+
+    def test_gestor_destino_pode_aprovar_movimentacao_entre_uos(self):
+        request = self._create_request_with_messages(self.gestor_destino)
+        queryset = MovimentacaoBemPatrimonial.objects.filter(pk=self.movimentacao.pk)
+
+        aprovar_solicitacao(self.admin, request, queryset)
+
+        self.movimentacao.refresh_from_db()
+        self.assertEqual(self.movimentacao.status, ACEITA)
+        self.assertEqual(self.movimentacao.aprovado_por, self.gestor_destino)
+
+    def test_gestor_destino_pode_rejeitar_movimentacao_entre_uos(self):
+        request = self._create_request_with_messages(self.gestor_destino)
+        queryset = MovimentacaoBemPatrimonial.objects.filter(pk=self.movimentacao.pk)
+
+        rejeitar_solicitacao(self.admin, request, queryset)
+
+        self.movimentacao.refresh_from_db()
+        self.assertEqual(self.movimentacao.status, REJEITADA)
+        self.assertEqual(self.movimentacao.rejeitado_por, self.gestor_destino)
+
+    @patch(
+        "bem_patrimonial.admins.movimentacao_bem_patrimonial.envia_email_solicitacao_movimentacao_cancelada"
+    )
+    def test_gestor_origem_pode_cancelar_movimentacao_entre_uos(self, mock_email):
+        request = self._create_request_with_messages(self.gestor_origem)
+        queryset = MovimentacaoBemPatrimonial.objects.filter(pk=self.movimentacao.pk)
+
+        cancelar_solicitacao(self.admin, request, queryset)
+
+        self.movimentacao.refresh_from_db()
+        self.assertEqual(self.movimentacao.status, CANCELADA)
+        self.assertEqual(self.movimentacao.cancelado_por, self.gestor_origem)
+        mock_email.assert_called_once()
+
+    @patch(
+        "bem_patrimonial.admins.movimentacao_bem_patrimonial.envia_email_solicitacao_movimentacao_cancelada"
+    )
+    def test_gestor_destino_pode_cancelar_movimentacao_entre_uos(self, mock_email):
+        request = self._create_request_with_messages(self.gestor_destino)
+        queryset = MovimentacaoBemPatrimonial.objects.filter(pk=self.movimentacao.pk)
+
+        cancelar_solicitacao(self.admin, request, queryset)
+
+        self.movimentacao.refresh_from_db()
+        self.assertEqual(self.movimentacao.status, CANCELADA)
+        self.assertEqual(self.movimentacao.cancelado_por, self.gestor_destino)
+        mock_email.assert_called_once()
+
+    def test_gestor_origem_nao_pode_aprovar_propria_movimentacao_entre_uos(self):
+        movimentacao = self._create_movimentacao(solicitado_por=self.gestor_origem)
+        request = self._create_request_with_messages(self.gestor_origem)
+        queryset = MovimentacaoBemPatrimonial.objects.filter(pk=movimentacao.pk)
+
+        aprovar_solicitacao(self.admin, request, queryset)
+
+        movimentacao.refresh_from_db()
+        self.assertEqual(movimentacao.status, ENVIADA)
+        mensagens = [str(m) for m in messages.get_messages(request)]
+        self.assertTrue(any("não pode aprovar sua própria solicitação em movimentações entre UOs" in msg for msg in mensagens))
+
+    def test_gestor_destino_nao_pode_rejeitar_propria_movimentacao_entre_uos(self):
+        movimentacao = self._create_movimentacao(solicitado_por=self.gestor_destino)
+        request = self._create_request_with_messages(self.gestor_destino)
+        queryset = MovimentacaoBemPatrimonial.objects.filter(pk=movimentacao.pk)
+
+        rejeitar_solicitacao(self.admin, request, queryset)
+
+        movimentacao.refresh_from_db()
+        self.assertEqual(movimentacao.status, ENVIADA)
+        mensagens = [str(m) for m in messages.get_messages(request)]
+        self.assertTrue(any("não pode rejeitar sua própria solicitação em movimentações entre UOs" in msg for msg in mensagens))

--- a/bem_patrimonial/tests/tests_movimentacao_bloqueio.py
+++ b/bem_patrimonial/tests/tests_movimentacao_bloqueio.py
@@ -1,4 +1,4 @@
-from dados_comuns.tests.auth_test_utils import auth_kwargs
+from dados_comuns.tests.auth_test_utils import auth_kwargs, codigo_ua
 from django.test import TestCase, RequestFactory
 from django.contrib.admin.sites import AdminSite
 from django.contrib.messages.storage.fallback import FallbackStorage
@@ -136,6 +136,10 @@ class SetupMovimentacaoData:
             bem=bem,
         )
         return mov
+
+
+def codigo_uo(a, b, c):
+    return f"{int(a):02d}.{int(b):02d}.{int(c):02d}"
 
 
 class BloqueioAutomaticoTestCase(TestCase):
@@ -678,13 +682,13 @@ class IntegracaoCompletaTestCase(TestCase):
 
     def test_aprovacao_para_outra_uo_move_bem_para_ua_ponto_central(self):
         uo_destino_externa = criar_uo(
-            codigo="01.16.11",
+            codigo=codigo_uo(1, 16, 11),
             nome="UO Destino Externa",
             sigla="UO5",
         )
         criar_ua(
             uo=uo_destino_externa,
-            codigo="01.16.11.001",
+            codigo=codigo_ua(1, 16, 11, 1),
             nome="Ponto Central Externo",
             sigla="PCE",
         )
@@ -719,37 +723,37 @@ class PermissoesEntreUOsAdminActionsTestCase(TestCase):
         )
 
         self.uo_origem = criar_uo(
-            codigo="01.16.20",
+            codigo=codigo_uo(1, 16, 20),
             nome="UO Origem",
             sigla="UOOR",
         )
         self.ua_origem = criar_ua(
             uo=self.uo_origem,
-            codigo="01.16.20.005",
+            codigo=codigo_ua(1, 16, 20, 5),
             nome="UA Origem",
             sigla="UAOR",
         )
         self.ua_gestor_origem = criar_ua(
             uo=self.uo_origem,
-            codigo="01.16.20.010",
+            codigo=codigo_ua(1, 16, 20, 10),
             nome="UA Gestor Origem",
             sigla="UGOR",
         )
 
         self.uo_destino = criar_uo(
-            codigo="01.16.21",
+            codigo=codigo_uo(1, 16, 21),
             nome="UO Destino",
             sigla="UODE",
         )
         self.ua_destino_central = criar_ua(
             uo=self.uo_destino,
-            codigo="01.16.21.001",
+            codigo=codigo_ua(1, 16, 21, 1),
             nome="Ponto Central Destino",
             sigla="PCDE",
         )
         self.ua_gestor_destino = criar_ua(
             uo=self.uo_destino,
-            codigo="01.16.21.010",
+            codigo=codigo_ua(1, 16, 21, 10),
             nome="UA Gestor Destino",
             sigla="UGDE",
         )

--- a/bem_patrimonial/tests/tests_movimentacao_bloqueio.py
+++ b/bem_patrimonial/tests/tests_movimentacao_bloqueio.py
@@ -839,96 +839,101 @@ class PermissoesEntreUOsAdminActionsTestCase(TestCase):
         )
         return movimentacao
 
+    def _executar_acao(self, action, user, movimentacao=None):
+        movimentacao = movimentacao or self.movimentacao
+        request = self._create_request_with_messages(user)
+        queryset = MovimentacaoBemPatrimonial.objects.filter(pk=movimentacao.pk)
+
+        action(self.admin, request, queryset)
+        movimentacao.refresh_from_db()
+        return request, movimentacao
+
+    def _assert_acao_bloqueada(self, action, user, mensagem, movimentacao=None):
+        request, movimentacao = self._executar_acao(action, user, movimentacao)
+        self.assertEqual(movimentacao.status, ENVIADA)
+        mensagens = [str(item) for item in messages.get_messages(request)]
+        self.assertTrue(any(mensagem in item for item in mensagens))
+
+    def _assert_acao_permitida(
+        self,
+        action,
+        user,
+        expected_status,
+        campo_usuario,
+        movimentacao=None,
+    ):
+        _, movimentacao = self._executar_acao(action, user, movimentacao)
+        self.assertEqual(movimentacao.status, expected_status)
+        self.assertEqual(getattr(movimentacao, campo_usuario), user)
+
     def test_gestor_origem_nao_pode_aprovar_movimentacao_entre_uos(self):
-        request = self._create_request_with_messages(self.gestor_origem)
-        queryset = MovimentacaoBemPatrimonial.objects.filter(pk=self.movimentacao.pk)
-
-        aprovar_solicitacao(self.admin, request, queryset)
-
-        self.movimentacao.refresh_from_db()
-        self.assertEqual(self.movimentacao.status, ENVIADA)
-        mensagens = [str(m) for m in messages.get_messages(request)]
-        self.assertTrue(any("Apenas gestores da UO de destino" in msg for msg in mensagens))
+        self._assert_acao_bloqueada(
+            aprovar_solicitacao,
+            self.gestor_origem,
+            "Apenas gestores da UO de destino",
+        )
 
     def test_gestor_origem_nao_pode_rejeitar_movimentacao_entre_uos(self):
-        request = self._create_request_with_messages(self.gestor_origem)
-        queryset = MovimentacaoBemPatrimonial.objects.filter(pk=self.movimentacao.pk)
-
-        rejeitar_solicitacao(self.admin, request, queryset)
-
-        self.movimentacao.refresh_from_db()
-        self.assertEqual(self.movimentacao.status, ENVIADA)
-        mensagens = [str(m) for m in messages.get_messages(request)]
-        self.assertTrue(any("Apenas gestores da UO de destino" in msg for msg in mensagens))
+        self._assert_acao_bloqueada(
+            rejeitar_solicitacao,
+            self.gestor_origem,
+            "Apenas gestores da UO de destino",
+        )
 
     def test_gestor_destino_pode_aprovar_movimentacao_entre_uos(self):
-        request = self._create_request_with_messages(self.gestor_destino)
-        queryset = MovimentacaoBemPatrimonial.objects.filter(pk=self.movimentacao.pk)
-
-        aprovar_solicitacao(self.admin, request, queryset)
-
-        self.movimentacao.refresh_from_db()
-        self.assertEqual(self.movimentacao.status, ACEITA)
-        self.assertEqual(self.movimentacao.aprovado_por, self.gestor_destino)
+        self._assert_acao_permitida(
+            aprovar_solicitacao,
+            self.gestor_destino,
+            ACEITA,
+            "aprovado_por",
+        )
 
     def test_gestor_destino_pode_rejeitar_movimentacao_entre_uos(self):
-        request = self._create_request_with_messages(self.gestor_destino)
-        queryset = MovimentacaoBemPatrimonial.objects.filter(pk=self.movimentacao.pk)
-
-        rejeitar_solicitacao(self.admin, request, queryset)
-
-        self.movimentacao.refresh_from_db()
-        self.assertEqual(self.movimentacao.status, REJEITADA)
-        self.assertEqual(self.movimentacao.rejeitado_por, self.gestor_destino)
+        self._assert_acao_permitida(
+            rejeitar_solicitacao,
+            self.gestor_destino,
+            REJEITADA,
+            "rejeitado_por",
+        )
 
     @patch(
         "bem_patrimonial.admins.movimentacao_bem_patrimonial.envia_email_solicitacao_movimentacao_cancelada"
     )
     def test_gestor_origem_pode_cancelar_movimentacao_entre_uos(self, mock_email):
-        request = self._create_request_with_messages(self.gestor_origem)
-        queryset = MovimentacaoBemPatrimonial.objects.filter(pk=self.movimentacao.pk)
-
-        cancelar_solicitacao(self.admin, request, queryset)
-
-        self.movimentacao.refresh_from_db()
-        self.assertEqual(self.movimentacao.status, CANCELADA)
-        self.assertEqual(self.movimentacao.cancelado_por, self.gestor_origem)
+        self._assert_acao_permitida(
+            cancelar_solicitacao,
+            self.gestor_origem,
+            CANCELADA,
+            "cancelado_por",
+        )
         mock_email.assert_called_once()
 
     @patch(
         "bem_patrimonial.admins.movimentacao_bem_patrimonial.envia_email_solicitacao_movimentacao_cancelada"
     )
     def test_gestor_destino_pode_cancelar_movimentacao_entre_uos(self, mock_email):
-        request = self._create_request_with_messages(self.gestor_destino)
-        queryset = MovimentacaoBemPatrimonial.objects.filter(pk=self.movimentacao.pk)
-
-        cancelar_solicitacao(self.admin, request, queryset)
-
-        self.movimentacao.refresh_from_db()
-        self.assertEqual(self.movimentacao.status, CANCELADA)
-        self.assertEqual(self.movimentacao.cancelado_por, self.gestor_destino)
+        self._assert_acao_permitida(
+            cancelar_solicitacao,
+            self.gestor_destino,
+            CANCELADA,
+            "cancelado_por",
+        )
         mock_email.assert_called_once()
 
     def test_gestor_origem_nao_pode_aprovar_propria_movimentacao_entre_uos(self):
         movimentacao = self._create_movimentacao(solicitado_por=self.gestor_origem)
-        request = self._create_request_with_messages(self.gestor_origem)
-        queryset = MovimentacaoBemPatrimonial.objects.filter(pk=movimentacao.pk)
-
-        aprovar_solicitacao(self.admin, request, queryset)
-
-        movimentacao.refresh_from_db()
-        self.assertEqual(movimentacao.status, ENVIADA)
-        mensagens = [str(m) for m in messages.get_messages(request)]
-        self.assertTrue(any("não pode aprovar sua própria solicitação em movimentações entre UOs" in msg for msg in mensagens))
+        self._assert_acao_bloqueada(
+            aprovar_solicitacao,
+            self.gestor_origem,
+            "não pode aprovar sua própria solicitação em movimentações entre UOs",
+            movimentacao,
+        )
 
     def test_gestor_destino_nao_pode_rejeitar_propria_movimentacao_entre_uos(self):
         movimentacao = self._create_movimentacao(solicitado_por=self.gestor_destino)
-        request = self._create_request_with_messages(self.gestor_destino)
-        queryset = MovimentacaoBemPatrimonial.objects.filter(pk=movimentacao.pk)
-
-        rejeitar_solicitacao(self.admin, request, queryset)
-
-        movimentacao.refresh_from_db()
-        self.assertEqual(movimentacao.status, ENVIADA)
-        mensagens = [str(m) for m in messages.get_messages(request)]
-        self.assertTrue(any("não pode rejeitar sua própria solicitação em movimentações entre UOs" in msg for msg in mensagens))
+        self._assert_acao_bloqueada(
+            rejeitar_solicitacao,
+            self.gestor_destino,
+            "não pode rejeitar sua própria solicitação em movimentações entre UOs",
+            movimentacao,
+        )

--- a/bem_patrimonial/tests/tests_movimentacao_edicao_readonly.py
+++ b/bem_patrimonial/tests/tests_movimentacao_edicao_readonly.py
@@ -12,11 +12,12 @@ from bem_patrimonial.admins.movimentacao_bem_patrimonial import (
     MovimentacaoBemPatrimonialAdmin,
 )
 from bem_patrimonial.admins.forms.movimentacao_bem_patrimonial_form import (
+    MENSAGEM_SEM_PONTO_CENTRAL,
     MovimentacaoBemPatrimonialForm,
 )
 from bem_patrimonial.constants import APROVADO
 from dados_comuns.models import UnidadeAdministrativa
-from dados_comuns.tests.factories import criar_ua
+from dados_comuns.tests.factories import criar_ua, criar_uo
 from usuario.models import Usuario
 from usuario.constants import GRUPO_GESTOR_PATRIMONIO, GRUPO_OPERADOR_INVENTARIO
 
@@ -98,11 +99,36 @@ class MovimentacaoEdicaoReadonlyTestCase(TestCase):
         request.user = self.gestor
 
         readonly_edicao = self.admin.get_readonly_fields(request, obj=self.movimentacao)
+        self.assertIn("get_unidade_orcamentaria_destino", readonly_edicao)
         self.assertIn("unidade_administrativa_origem", readonly_edicao)
         self.assertIn("unidade_administrativa_destino", readonly_edicao)
 
         readonly_criacao = self.admin.get_readonly_fields(request, obj=None)
         self.assertEqual(len(readonly_criacao), 0)
+
+    def test_form_de_edicao_instancia_sem_keyerror_com_campos_readonly(self):
+        request = self.factory.get(
+            "/admin/bem_patrimonial/movimentacaobempatrimonial/1/change/"
+        )
+        request.user = self.gestor
+
+        form_class = self.admin.get_form(request, obj=self.movimentacao)
+        form = form_class(instance=self.movimentacao)
+
+        self.assertIn("unidade_orcamentaria_destino", form.fields)
+        self.assertTrue(form.fields["unidade_orcamentaria_destino"].disabled)
+        self.assertNotIn("unidade_administrativa_origem", form.fields)
+        self.assertNotIn("unidade_administrativa_destino", form.fields)
+
+    def test_campo_uo_destino_exibido_entre_origem_e_destino(self):
+        request = self.factory.get("/admin/bem_patrimonial/movimentacaobempatrimonial/add/")
+        request.user = self.gestor
+
+        fields = self.admin.get_fields(request)
+
+        self.assertEqual(fields[0], "unidade_administrativa_origem")
+        self.assertEqual(fields[1], "unidade_orcamentaria_destino")
+        self.assertEqual(fields[2], "unidade_administrativa_destino")
 
     def test_validacao_uas_so_acontece_na_criacao(self):
         form_criacao = MovimentacaoBemPatrimonialForm(
@@ -110,9 +136,9 @@ class MovimentacaoEdicaoReadonlyTestCase(TestCase):
                 "unidade_administrativa_origem": self.ua1.pk,
                 "unidade_administrativa_destino": self.ua1.pk,  # Mesma UA - inválido
                 "observacao": "Teste",
-            }
+            },
+            request=type("obj", (object,), {"user": self.gestor})(),
         )
-        form_criacao.request = type("obj", (object,), {"user": self.gestor})()
 
         self.assertFalse(form_criacao.is_valid())
         self.assertIn(
@@ -127,7 +153,72 @@ class MovimentacaoEdicaoReadonlyTestCase(TestCase):
                 "observacao": "Observação atualizada",
             },
             instance=self.movimentacao,
+            request=type("obj", (object,), {"user": self.gestor})(),
         )
-        form_edicao.request = type("obj", (object,), {"user": self.gestor})()
 
         self.assertTrue(form_edicao.is_valid())
+
+    def test_uo_destino_padrao_e_uo_do_usuario(self):
+        form = MovimentacaoBemPatrimonialForm(request=type("obj", (object,), {"user": self.gestor})())
+
+        self.assertEqual(
+            form.fields["unidade_orcamentaria_destino"].initial,
+            self.gestor.unidade_orcamentaria_id,
+        )
+
+    def test_uo_externa_preenche_ua_001_automaticamente(self):
+        outra_uo = criar_uo(
+            codigo="01.16.11",
+            nome="UO Destino Externa",
+            sigla="UO3",
+        )
+        criar_ua(
+            uo=outra_uo,
+            codigo="01.16.11.001",
+            nome="Ponto Central",
+            sigla="PC",
+        )
+
+        form = MovimentacaoBemPatrimonialForm(
+            data={
+                "unidade_administrativa_origem": self.ua1.pk,
+                "unidade_orcamentaria_destino": outra_uo.pk,
+                "observacao": "Teste UO externa",
+            },
+            request=type("obj", (object,), {"user": self.gestor})(),
+        )
+
+        self.assertTrue(form.is_valid(), form.errors)
+        self.assertEqual(
+            form.cleaned_data["unidade_administrativa_destino"].codigo,
+            "01.16.11.001",
+        )
+        self.assertEqual(
+            form.cleaned_data["unidade_administrativa_destino"].unidade_orcamentaria,
+            outra_uo,
+        )
+
+    def test_uo_externa_sem_ponto_central_exibe_erro_amigavel(self):
+        uo_sem_ponto = criar_uo(
+            codigo="01.16.12",
+            nome="UO Sem Central",
+            sigla="UO4",
+        )
+        criar_ua(
+            uo=uo_sem_ponto,
+            codigo="01.16.12.010",
+            nome="UA Secundária",
+            sigla="SEC",
+        )
+
+        form = MovimentacaoBemPatrimonialForm(
+            data={
+                "unidade_administrativa_origem": self.ua1.pk,
+                "unidade_orcamentaria_destino": uo_sem_ponto.pk,
+                "observacao": "Teste UO sem central",
+            },
+            request=type("obj", (object,), {"user": self.gestor})(),
+        )
+
+        self.assertFalse(form.is_valid())
+        self.assertIn(MENSAGEM_SEM_PONTO_CENTRAL, str(form.errors))

--- a/bem_patrimonial/tests/tests_movimentacao_edicao_readonly.py
+++ b/bem_patrimonial/tests/tests_movimentacao_edicao_readonly.py
@@ -1,4 +1,4 @@
-from dados_comuns.tests.auth_test_utils import auth_kwargs
+from dados_comuns.tests.auth_test_utils import auth_kwargs, codigo_ua
 from django.test import TestCase, RequestFactory
 from django.contrib.admin.sites import AdminSite
 from django.contrib.auth.models import Group
@@ -94,6 +94,9 @@ class MovimentacaoEdicaoReadonlyTestCase(TestCase):
             MovimentacaoBemPatrimonial, self.site
         )
 
+    def _codigo_uo(self, a, b, c):
+        return f"{int(a):02d}.{int(b):02d}.{int(c):02d}"
+
     def test_uas_readonly_na_edicao_nao_na_criacao(self):
         request = self.factory.get("/admin/bem_patrimonial/movimentacaobempatrimonial/")
         request.user = self.gestor
@@ -168,13 +171,13 @@ class MovimentacaoEdicaoReadonlyTestCase(TestCase):
 
     def test_uo_externa_preenche_ua_001_automaticamente(self):
         outra_uo = criar_uo(
-            codigo="01.16.11",
+            codigo=self._codigo_uo(1, 16, 11),
             nome="UO Destino Externa",
             sigla="UO3",
         )
         criar_ua(
             uo=outra_uo,
-            codigo="01.16.11.001",
+            codigo=codigo_ua(1, 16, 11, 1),
             nome="Ponto Central",
             sigla="PC",
         )
@@ -191,7 +194,7 @@ class MovimentacaoEdicaoReadonlyTestCase(TestCase):
         self.assertTrue(form.is_valid(), form.errors)
         self.assertEqual(
             form.cleaned_data["unidade_administrativa_destino"].codigo,
-            "01.16.11.001",
+            codigo_ua(1, 16, 11, 1),
         )
         self.assertEqual(
             form.cleaned_data["unidade_administrativa_destino"].unidade_orcamentaria,
@@ -200,13 +203,13 @@ class MovimentacaoEdicaoReadonlyTestCase(TestCase):
 
     def test_uo_externa_sem_ponto_central_exibe_erro_amigavel(self):
         uo_sem_ponto = criar_uo(
-            codigo="01.16.12",
+            codigo=self._codigo_uo(1, 16, 12),
             nome="UO Sem Central",
             sigla="UO4",
         )
         criar_ua(
             uo=uo_sem_ponto,
-            codigo="01.16.12.010",
+            codigo=codigo_ua(1, 16, 12, 10),
             nome="UA Secundária",
             sigla="SEC",
         )

--- a/bem_patrimonial/tests/tests_unidade_administrativa_status.py
+++ b/bem_patrimonial/tests/tests_unidade_administrativa_status.py
@@ -36,9 +36,7 @@ class CriacaoMovimentacaoComUAInativaTestCase(TestCase):
     def _create_form_with_request(self, user, data):
         request = self.factory.post("/admin/")
         request.user = user
-        form = MovimentacaoBemPatrimonialForm(data=data)
-        form.request = request
-        return form
+        return MovimentacaoBemPatrimonialForm(data=data, request=request)
 
     def test_nao_pode_criar_movimentacao_com_ua_origem_inativa(self):
         data = {

--- a/static/admin/movimentacao_uo_destino.js
+++ b/static/admin/movimentacao_uo_destino.js
@@ -1,0 +1,107 @@
+(function() {
+    function criarOpcao(item, selected) {
+        return new Option(item.label, item.id, false, selected);
+    }
+
+    function limparSelect(selectEl) {
+        while (selectEl.options.length > 0) {
+            selectEl.remove(0);
+        }
+    }
+
+    function garantirCaixaErro(jq, $uoField) {
+        const targetId = 'movimentacao-uo-destino-error';
+        let $error = jq('#' + targetId);
+        if ($error.length) {
+            return $error;
+        }
+
+        $error = jq('<ul/>', {
+            id: targetId,
+            class: 'errorlist',
+            css: { display: 'none' }
+        });
+
+        $uoField.closest('.form-row, .field-unidade_orcamentaria_destino').append($error);
+        return $error;
+    }
+
+    function atualizarDestino(jq, $uoField, $uaField, config, $error) {
+        const uoSelecionada = String($uoField.val() || '');
+        const uoReferencia = String(config.uoReferenciaId || '');
+        const centraisPorUo = config.centraisPorUo || {};
+        const opcoesMesmaUo = Array.isArray(config.opcoesMesmaUo) ? config.opcoesMesmaUo : [];
+        const valorAtual = String($uaField.val() || '');
+        const selectEl = $uaField.get(0);
+
+        limparSelect(selectEl);
+        selectEl.add(criarOpcao({ id: '', label: '---------' }, false));
+        $error.empty().hide();
+
+        if (!uoSelecionada) {
+            $uaField.prop('disabled', true).val('');
+            return;
+        }
+
+        if (uoReferencia && uoSelecionada === uoReferencia) {
+            opcoesMesmaUo.forEach(function(item) {
+                const selected = valorAtual && String(item.id) === valorAtual;
+                selectEl.add(criarOpcao(item, selected));
+            });
+            $uaField.prop('disabled', false);
+            if (valorAtual) {
+                $uaField.val(valorAtual);
+            }
+            return;
+        }
+
+        const central = centraisPorUo[uoSelecionada];
+        if (!central) {
+            $uaField.prop('disabled', true).val('');
+            $error.append(jq('<li/>').text(config.mensagemSemPontoCentral || ''));
+            $error.show();
+            return;
+        }
+
+        selectEl.add(criarOpcao(central, true));
+        $uaField.prop('disabled', true).val(String(central.id));
+    }
+
+    function init() {
+        if (!window.django || !django.jQuery) {
+            return setTimeout(init, 100);
+        }
+
+        const jq = django.jQuery;
+
+        jq(function() {
+            const $uoField = jq('#id_unidade_orcamentaria_destino');
+            const $uaField = jq('#id_unidade_administrativa_destino');
+
+            if (!$uoField.length || !$uaField.length) {
+                return;
+            }
+
+            const rawConfig = $uoField.attr('data-movimentacao-destino-config');
+            if (!rawConfig) {
+                return;
+            }
+
+            let config = null;
+            try {
+                config = JSON.parse(rawConfig);
+            } catch (_error) {
+                return;
+            }
+
+            const $error = garantirCaixaErro(jq, $uoField);
+
+            atualizarDestino(jq, $uoField, $uaField, config, $error);
+            $uoField.on('change', function() {
+                atualizarDestino(jq, $uoField, $uaField, config, $error);
+            });
+        });
+    }
+
+    init();
+})();

--- a/static/admin/movimentacao_uo_destino.js
+++ b/static/admin/movimentacao_uo_destino.js
@@ -90,7 +90,8 @@
             let config = null;
             try {
                 config = JSON.parse(rawConfig);
-            } catch (_error) {
+            } catch (error) {
+                console.error('Falha ao ler configuracao de destino da movimentacao.', error);
                 return;
             }
 


### PR DESCRIPTION
## 🌿 Contexto

Escopo da entrega: ajustes no Django Admin de movimentações patrimoniais para suportar movimentação entre Unidades Orçamentárias diferentes, preservando as regras já existentes para movimentações dentro da mesma UO.

## 🎯 Objetivo

Esta entrega foi criada para permitir o cadastro e o tratamento de movimentações entre UOs diferentes dentro do admin, com foco em três pontos:

- permitir escolher a Unidade Orçamentária de destino no momento da criação da movimentação;
- resolver automaticamente a Unidade Administrativa de destino para o ponto central da UO escolhida quando a movimentação for para outra UO;
- ajustar as regras de ação do admin para aprovação, rejeição e cancelamento em cenários entre UOs, sem alterar a regra já consolidada para movimentações da mesma UO.

## ✅ O que foi entregue

- Inclusão do campo `unidade_orcamentaria_destino` no formulário de criação de movimentação.
- Preenchimento automático da UO destino com a UO de referência do usuário quando aplicável.
- Resolução automática da UA de destino para a UA ativa de código `001` ou com sufixo `.001` quando a movimentação for para outra UO.
- Exibição de mensagem amigável quando a UO de destino não possui ponto central cadastrado.
- Exibição da UO de destino como informação readonly na edição da movimentação.
- Inclusão de comportamento client-side no admin para atualizar a UA de destino conforme a UO selecionada.
- Ajuste das regras de aprovação, rejeição e cancelamento para movimentações entre UOs diferentes.
- Preservação da visibilidade anterior do queryset do admin: usuário com UA continua vendo apenas movimentações em que sua UA aparece como origem ou destino; visão por UO inteira continua restrita ao gestor sem UA associada.

## 🔒 Regras de negócio consolidadas

### 🏢 Movimentações dentro da mesma UO

- O comportamento anterior foi preservado.
- Gestor continua podendo aprovar e rejeitar a própria solicitação dentro da mesma UO.
- Operador continua restrito à UA de destino para aprovar ou rejeitar.

### 🌐 Movimentações entre UOs diferentes

- Aprovar: permitido apenas para gestor da UO de destino ou operador da UA de destino.
- Rejeitar: permitido apenas para gestor da UO de destino ou operador da UA de destino.
- Cancelar: permitido para gestor da UO de origem ou gestor da UO de destino.
- Autoaprovação e autorrejeição ficam bloqueadas nesse cenário.
- A aprovação move o bem para a UA ponto central da UO de destino.

### 📍 Resolução da UA de destino

- Se a UO destino for igual à UO de referência, a UA destino continua selecionável manualmente.
- Se a UO destino for diferente da UO de referência, a UA destino é resolvida automaticamente para a UA ativa de código `001` ou com sufixo `.001`.
- Se não existir ponto central para a UO selecionada, a criação da movimentação é bloqueada com mensagem amigável.

## 🧪 Testes criados ou alterados

### 🧪 bem_patrimonial/tests/tests_movimentacao_bloqueio.py

- `test_gestor_pode_aprovar_propria_solicitacao_na_mesma_uo`: garante que a regra antiga da mesma UO foi preservada para aprovação pelo próprio gestor.
- `test_gestor_pode_rejeitar_propria_solicitacao_na_mesma_uo`: garante que a regra antiga da mesma UO foi preservada para rejeição pelo próprio gestor.
- `test_operador_fora_da_ua_destino_nao_pode_rejeitar`: valida que operador fora da UA destino não pode rejeitar a movimentação.
- `test_solicitante_nao_pode_rejeitar_propria_solicitacao`: valida bloqueio de autorrejeição para operador no fluxo já existente.
- `test_aprovar_movimentacao_sem_itens_exibe_erro`: valida mensagem de erro quando se tenta aprovar uma movimentação sem itens vinculados.
- `test_rejeitar_movimentacao_sem_itens_exibe_erro`: valida mensagem de erro quando se tenta rejeitar uma movimentação sem itens vinculados.
- `test_get_documento_cimbpm_link_sem_numero`: valida retorno textual quando não existe número CIMBPM gerado.
- `test_get_documento_cimbpm_link_com_numero`: valida geração do link de download do documento CIMBPM.
- `test_get_unidade_orcamentaria_destino_sem_destino`: valida fallback do método readonly da UO destino quando a movimentação não possui UA destino.
- `test_response_action_verificar_movimentacoes_duplicadas`: garante que a action customizada de verificação de movimentações duplicadas continua sendo roteada corretamente.
- `test_get_inline_formsets_desabilita_campos_na_edicao`: valida que os inline formsets ficam bloqueados na edição da movimentação.
- `test_aprovacao_para_outra_uo_move_bem_para_ua_ponto_central`: garante que a aprovação de uma movimentação entre UOs move o bem para a UA ponto central da UO destino.
- `test_gestor_origem_nao_pode_aprovar_movimentacao_entre_uos`: garante que o gestor da UO de origem não aprova movimentação entre UOs.
- `test_gestor_origem_nao_pode_rejeitar_movimentacao_entre_uos`: garante que o gestor da UO de origem não rejeita movimentação entre UOs.
- `test_gestor_destino_pode_aprovar_movimentacao_entre_uos`: garante que o gestor da UO de destino pode aprovar movimentação entre UOs.
- `test_gestor_destino_pode_rejeitar_movimentacao_entre_uos`: garante que o gestor da UO de destino pode rejeitar movimentação entre UOs.
- `test_gestor_origem_pode_cancelar_movimentacao_entre_uos`: garante que o gestor da UO de origem pode cancelar movimentação entre UOs.
- `test_gestor_destino_pode_cancelar_movimentacao_entre_uos`: garante que o gestor da UO de destino pode cancelar movimentação entre UOs.
- `test_gestor_origem_nao_pode_aprovar_propria_movimentacao_entre_uos`: garante bloqueio de autoaprovação entre UOs para gestor da origem.
- `test_gestor_destino_nao_pode_rejeitar_propria_movimentacao_entre_uos`: garante bloqueio de autorrejeição entre UOs para gestor da destino.

### 🧪 bem_patrimonial/tests/tests_movimentacao_edicao_readonly.py

- `test_uas_readonly_na_edicao_nao_na_criacao`: alterado para validar também a exposição readonly da UO destino na edição.
- `test_form_de_edicao_instancia_sem_keyerror_com_campos_readonly`: garante que o form de edição não quebra quando o admin remove campos readonly de `form.fields`.
- `test_campo_uo_destino_exibido_entre_origem_e_destino`: valida a posição do novo campo de UO destino no admin de criação.
- `test_validacao_uas_so_acontece_na_criacao`: alterado para usar `request` no construtor do form e garantir que a validação de origem/destino iguais continua restrita à criação.
- `test_uo_destino_padrao_e_uo_do_usuario`: valida preenchimento inicial da UO destino com a UO do usuário.
- `test_uo_externa_preenche_ua_001_automaticamente`: valida resolução automática da UA `.001` quando a UO destino é diferente.
- `test_uo_externa_sem_ponto_central_exibe_erro_amigavel`: valida mensagem amigável quando a UO externa não possui ponto central.

### 🧪 bem_patrimonial/tests/tests_unidade_administrativa_status.py

- Ajuste técnico em `_create_form_with_request`: Não houve criação de novo cenário de negócio nesse arquivo; a alteração foi necessária para manter os testes existentes compatíveis com a nova assinatura do formulário.

## ✅ Validação executada

**Bateria focada nos arquivos alterados:**

```bash
docker compose -f docker-compose-dev.yml exec web python manage.py test bem_patrimonial.tests.tests_movimentacao_bloqueio bem_patrimonial.tests.tests_movimentacao_edicao_readonly bem_patrimonial.tests.tests_unidade_administrativa_status
```

Resultado:

- `60` testes executados em `20.212s`
- Status final do runner: `OK`
- Sem falhas

**Suíte completa do sistema:**

```bash
docker compose -f docker-compose-dev.yml exec web python manage.py test
```

Resultado:

- `652` testes executados em `132.417s`
- Status final: `OK`
- Sem falhas

## ⚠️ Observações importantes

- Não houve alteração de model ou migration nesta entrega.
- A entrega está concentrada no Django Admin, no form de movimentação e em testes.
- As regras novas foram aplicadas apenas ao fluxo entre UOs diferentes; o comportamento da mesma UO foi preservado.
