### PR TITLE
Feature(146446): Endpoints de Unidades Orçamentárias

### DIFF
--- a/dados_comuns/api_serializers.py
+++ b/dados_comuns/api_serializers.py
@@ -2,7 +2,53 @@ import re
 
 from rest_framework import serializers
 
-from dados_comuns.models import UnidadeAdministrativa
+from dados_comuns.models import UnidadeAdministrativa, UnidadeOrcamentaria
+
+
+class UnidadeOrcamentariaListSerializer(serializers.ModelSerializer):
+    ativa_display = serializers.SerializerMethodField()
+
+    class Meta:
+        model = UnidadeOrcamentaria
+        fields = [
+            "id",
+            "codigo",
+            "sigla",
+            "nome",
+            "ativa",
+            "ativa_display",
+        ]
+        read_only_fields = fields
+
+    def get_ativa_display(self, obj):
+        return "Ativa" if obj.ativa else "Inativa"
+
+
+class UnidadeOrcamentariaDetailSerializer(UnidadeOrcamentariaListSerializer):
+    class Meta(UnidadeOrcamentariaListSerializer.Meta):
+        read_only_fields = ["id", "ativa_display"]
+        extra_kwargs = {
+            "codigo": {
+                "help_text": "Código da Unidade Orçamentária no padrão do projeto (ex.: 01.16.10)."
+            }
+        }
+
+
+class UnidadeOrcamentariaHistoricoAcaoSerializer(serializers.Serializer):
+    campo = serializers.CharField()
+    valor_antigo = serializers.CharField(allow_null=True)
+    valor_novo = serializers.CharField(allow_null=True)
+
+
+class UnidadeOrcamentariaHistoricoGrupoSerializer(serializers.Serializer):
+    alterado_em = serializers.DateTimeField()
+    alterado_por = serializers.IntegerField(allow_null=True)
+    alterado_por_nome = serializers.CharField(allow_null=True)
+    acoes = UnidadeOrcamentariaHistoricoAcaoSerializer(many=True)
+
+
+class UnidadeOrcamentariaExportQuerySerializer(serializers.Serializer):
+    formato = serializers.ChoiceField(choices=["csv", "xls", "xlsx", "pdf"])
 
 
 class UnidadeAdministrativaListSerializer(serializers.ModelSerializer):

--- a/dados_comuns/api_urls.py
+++ b/dados_comuns/api_urls.py
@@ -1,8 +1,16 @@
 from rest_framework.routers import DefaultRouter
 
-from dados_comuns.api_views import UnidadeAdministrativaViewSet
+from dados_comuns.api_views import (
+    UnidadeAdministrativaViewSet,
+    UnidadeOrcamentariaViewSet,
+)
 
 router = DefaultRouter()
+router.register(
+    r"unidades-orcamentarias",
+    UnidadeOrcamentariaViewSet,
+    basename="unidades-orcamentarias",
+)
 router.register(
     r"unidades-administrativas",
     UnidadeAdministrativaViewSet,

--- a/dados_comuns/api_views.py
+++ b/dados_comuns/api_views.py
@@ -28,12 +28,25 @@ from dados_comuns.api_serializers import (
     UnidadeAdministrativaExportQuerySerializer,
     UnidadeAdministrativaHistoricoGrupoSerializer,
     UnidadeAdministrativaListSerializer,
+    UnidadeOrcamentariaDetailSerializer,
+    UnidadeOrcamentariaExportQuerySerializer,
+    UnidadeOrcamentariaHistoricoGrupoSerializer,
+    UnidadeOrcamentariaListSerializer,
 )
 from dados_comuns.context import audit_as
-from dados_comuns.formats import UnidadeAdministrativaPDFFormat
-from dados_comuns.models import HistoricoGeral, UnidadeAdministrativa
-from dados_comuns.permissions import UnidadeAdministrativaPermission
-from dados_comuns.resources import UnidadeAdministrativaResource
+from dados_comuns.formats import (
+    UnidadeAdministrativaPDFFormat,
+    UnidadeOrcamentariaPDFFormat,
+)
+from dados_comuns.models import HistoricoGeral, UnidadeAdministrativa, UnidadeOrcamentaria
+from dados_comuns.permissions import (
+    UnidadeAdministrativaPermission,
+    UnidadeOrcamentariaPermission,
+)
+from dados_comuns.resources import (
+    UnidadeAdministrativaResource,
+    UnidadeOrcamentariaResource,
+)
 from dados_comuns.utils import dict_changes
 
 
@@ -44,6 +57,384 @@ UA_ID_PATH_PARAM = OpenApiParameter(
     location=OpenApiParameter.PATH,
     description="Identificador numérico único da unidade administrativa.",
 )
+
+UO_ID_PATH_PARAM = OpenApiParameter(
+    name="id",
+    required=True,
+    type=OpenApiTypes.INT,
+    location=OpenApiParameter.PATH,
+    description="Identificador numérico único da unidade orçamentária.",
+)
+
+
+class AuditHistoryExportMixin:
+    audit_model = None
+    historico_grupo_serializer_class = None
+    export_query_serializer_class = None
+    export_resource_class = None
+    export_pdf_format_class = None
+    export_filename_prefix = ""
+
+    def _get_audit_content_type(self):
+        return ContentType.objects.get_for_model(self.audit_model)
+
+    def _audit_changes(self, obj, original=None, operation="update"):
+        ct = self._get_audit_content_type()
+
+        if operation == "update" and original is not None:
+            changes = dict_changes(
+                original,
+                obj,
+                fields=self.AUDIT_TRACK_FIELDS,
+            )
+            if not changes:
+                return
+
+            HistoricoGeral.objects.bulk_create(
+                [
+                    HistoricoGeral(
+                        content_type=ct,
+                        object_id=str(obj.pk),
+                        campo=field,
+                        valor_antigo=old,
+                        valor_novo=new,
+                        alterado_por=self.request.user,
+                    )
+                    for field, (old, new) in changes.items()
+                ]
+            )
+            return
+
+        if operation == "create":
+            HistoricoGeral.objects.create(
+                content_type=ct,
+                object_id=str(obj.pk),
+                campo="acao",
+                valor_antigo="",
+                valor_novo="criado",
+                alterado_por=self.request.user,
+            )
+            return
+
+        if operation == "delete":
+            HistoricoGeral.objects.create(
+                content_type=ct,
+                object_id=str(obj.pk),
+                campo="acao",
+                valor_antigo="existente",
+                valor_novo="excluido",
+                alterado_por=self.request.user,
+            )
+
+    def _build_historico_response(self, instance):
+        historicos = (
+            HistoricoGeral.objects.filter(
+                content_type=self._get_audit_content_type(),
+                object_id=str(instance.pk),
+            )
+            .select_related("alterado_por")
+            .order_by("-alterado_em")
+        )
+
+        agrupado = defaultdict(list)
+        for item in historicos:
+            chave = (item.alterado_em.replace(microsecond=0), item.alterado_por_id)
+            agrupado[chave].append(item)
+
+        resposta = []
+        for (alterado_em, alterado_por_id), itens in agrupado.items():
+            resposta.append(
+                {
+                    "alterado_em": alterado_em,
+                    "alterado_por": alterado_por_id,
+                    "alterado_por_nome": (
+                        itens[0].alterado_por.nome if itens[0].alterado_por else None
+                    ),
+                    "acoes": [
+                        {
+                            "campo": i.campo,
+                            "valor_antigo": i.valor_antigo,
+                            "valor_novo": i.valor_novo,
+                        }
+                        for i in itens
+                    ],
+                }
+            )
+
+        resposta_ordenada = sorted(
+            resposta,
+            key=lambda row: row["alterado_em"],
+            reverse=True,
+        )
+
+        serializer = self.historico_grupo_serializer_class(
+            resposta_ordenada,
+            many=True,
+        )
+        return Response(serializer.data)
+
+    def _build_export_response(self, request):
+        serializer = self.export_query_serializer_class(data=request.query_params)
+        serializer.is_valid(raise_exception=True)
+        formato = serializer.validated_data["formato"]
+
+        queryset = self.filter_queryset(self.get_queryset())
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        filename = f"{self.export_filename_prefix}_{timestamp}.{formato}"
+
+        if formato == "pdf":
+            pdf_format = self.export_pdf_format_class()
+            pdf_format._export_request = request
+            pdf_format._export_queryset = queryset
+            pdf_bytes = pdf_format.export_data(None)
+
+            response = HttpResponse(pdf_bytes, content_type="application/pdf")
+            response["Content-Disposition"] = f'attachment; filename="{filename}"'
+            return response
+
+        resource = self.export_resource_class()
+        dataset = resource.export(queryset)
+
+        if formato == "csv":
+            content = dataset.csv.encode("utf-8-sig")
+            content_type = "text/csv"
+        elif formato == "xls":
+            content = dataset.xls
+            content_type = "application/vnd.ms-excel"
+        else:
+            content = dataset.xlsx
+            content_type = (
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+            )
+
+        response = HttpResponse(content, content_type=content_type)
+        response["Content-Disposition"] = f'attachment; filename="{filename}"'
+        return response
+
+
+@extend_schema_view(
+    list=extend_schema(
+        tags=["Unidades Orçamentárias"],
+        summary="Listar unidades orçamentárias",
+        description="Lista paginada com busca, filtros e ordenação. Acesso restrito a superusuário.",
+        parameters=[
+            OpenApiParameter(
+                name="search",
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.QUERY,
+                description="Busca em: codigo, sigla e nome.",
+            ),
+            OpenApiParameter(
+                name="ordering",
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.QUERY,
+                description="Ordenação por: id, codigo, sigla, nome e ativa. Use '-' para descendente.",
+            ),
+            OpenApiParameter(
+                name="ativa",
+                type=OpenApiTypes.BOOL,
+                location=OpenApiParameter.QUERY,
+                description="Filtra por unidade orçamentária ativa/inativa.",
+            ),
+            OpenApiParameter(
+                name="page",
+                type=OpenApiTypes.INT,
+                location=OpenApiParameter.QUERY,
+                description="Número da página.",
+            ),
+            OpenApiParameter(
+                name="page_size",
+                type=OpenApiTypes.INT,
+                location=OpenApiParameter.QUERY,
+                description="Quantidade de itens por página (máximo 100).",
+            ),
+        ],
+        responses={
+            200: OpenApiResponse(description="Lista retornada com sucesso."),
+            401: OpenApiResponse(description="Usuário não autenticado."),
+            403: OpenApiResponse(description="Usuário sem permissão para acessar o recurso."),
+        },
+    ),
+    retrieve=extend_schema(
+        tags=["Unidades Orçamentárias"],
+        summary="Detalhar unidade orçamentária",
+        parameters=[UO_ID_PATH_PARAM],
+        responses={
+            200: OpenApiResponse(description="Detalhe retornado com sucesso."),
+            401: OpenApiResponse(description="Usuário não autenticado."),
+            403: OpenApiResponse(description="Usuário sem permissão para acessar o recurso."),
+            404: OpenApiResponse(description="Unidade orçamentária não encontrada."),
+        },
+    ),
+    create=extend_schema(
+        tags=["Unidades Orçamentárias"],
+        summary="Criar unidade orçamentária",
+        responses={
+            201: OpenApiResponse(description="Unidade orçamentária criada com sucesso."),
+            400: OpenApiResponse(description="Dados inválidos."),
+            401: OpenApiResponse(description="Usuário não autenticado."),
+            403: OpenApiResponse(description="Usuário sem permissão para criar."),
+        },
+    ),
+    update=extend_schema(
+        tags=["Unidades Orçamentárias"],
+        summary="Atualizar unidade orçamentária",
+        parameters=[UO_ID_PATH_PARAM],
+        responses={
+            200: OpenApiResponse(description="Unidade orçamentária atualizada com sucesso."),
+            400: OpenApiResponse(description="Dados inválidos."),
+            401: OpenApiResponse(description="Usuário não autenticado."),
+            403: OpenApiResponse(description="Usuário sem permissão para atualizar."),
+            404: OpenApiResponse(description="Unidade orçamentária não encontrada."),
+        },
+    ),
+    partial_update=extend_schema(
+        tags=["Unidades Orçamentárias"],
+        summary="Atualizar parcialmente unidade orçamentária",
+        parameters=[UO_ID_PATH_PARAM],
+        responses={
+            200: OpenApiResponse(description="Unidade orçamentária atualizada com sucesso."),
+            400: OpenApiResponse(description="Dados inválidos."),
+            401: OpenApiResponse(description="Usuário não autenticado."),
+            403: OpenApiResponse(description="Usuário sem permissão para atualizar."),
+            404: OpenApiResponse(description="Unidade orçamentária não encontrada."),
+        },
+    ),
+    destroy=extend_schema(
+        tags=["Unidades Orçamentárias"],
+        summary="Excluir unidade orçamentária",
+        description="A exclusão é permitida apenas para superusuário e bloqueada quando existirem vínculos ativos no sistema.",
+        parameters=[UO_ID_PATH_PARAM],
+        responses={
+            204: OpenApiResponse(description="Unidade orçamentária excluída com sucesso."),
+            400: OpenApiResponse(description="Não foi possível excluir por regra de integridade/vínculos."),
+            401: OpenApiResponse(description="Usuário não autenticado."),
+            403: OpenApiResponse(description="Usuário sem permissão para excluir."),
+            404: OpenApiResponse(description="Unidade orçamentária não encontrada."),
+        },
+    ),
+)
+class UnidadeOrcamentariaViewSet(AuditHistoryExportMixin, viewsets.ModelViewSet):
+    permission_classes = [UnidadeOrcamentariaPermission]
+    audit_model = UnidadeOrcamentaria
+    historico_grupo_serializer_class = UnidadeOrcamentariaHistoricoGrupoSerializer
+    export_query_serializer_class = UnidadeOrcamentariaExportQuerySerializer
+    export_resource_class = UnidadeOrcamentariaResource
+    export_pdf_format_class = UnidadeOrcamentariaPDFFormat
+    export_filename_prefix = "unidades_orcamentarias"
+
+    filter_backends = [DjangoFilterBackend, SearchFilter, OrderingFilter]
+    filterset_fields = ["ativa"]
+    search_fields = ["codigo", "sigla", "nome"]
+    ordering_fields = ["id", "codigo", "sigla", "nome", "ativa"]
+    ordering = ["codigo", "nome"]
+
+    AUDIT_TRACK_FIELDS = (
+        "codigo",
+        "sigla",
+        "nome",
+        "ativa",
+    )
+
+    def get_serializer_class(self):
+        if self.action == "list":
+            return UnidadeOrcamentariaListSerializer
+        return UnidadeOrcamentariaDetailSerializer
+
+    def get_queryset(self):
+        if getattr(self.request.user, "is_superuser", False):
+            return UnidadeOrcamentaria.objects.all()
+
+        return UnidadeOrcamentaria.objects.none()
+
+    def _validar_exclusao_segura(self, instance):
+        vinculos = instance.listar_vinculos_para_exclusao()
+        if vinculos:
+            raise DRFValidationError(
+                {
+                    "detail": "Não foi possível excluir esta Unidade Orçamentária porque existem vínculos ativos no sistema: {}.".format(
+                        ", ".join(vinculos)
+                    )
+                }
+            )
+
+    def perform_create(self, serializer):
+        with transaction.atomic():
+            with audit_as(self.request.user):
+                obj = serializer.save()
+            self._audit_changes(obj, operation="create")
+
+    def perform_update(self, serializer):
+        original = UnidadeOrcamentaria.objects.get(pk=serializer.instance.pk)
+
+        with transaction.atomic():
+            with audit_as(self.request.user):
+                obj = serializer.save()
+            self._audit_changes(obj, original=original, operation="update")
+
+    def perform_destroy(self, instance):
+        self._validar_exclusao_segura(instance)
+
+        with transaction.atomic():
+            try:
+                self._audit_changes(instance, operation="delete")
+                with audit_as(self.request.user):
+                    instance.delete()
+            except ProtectedError:
+                raise DRFValidationError(
+                    {
+                        "detail": "Não foi possível excluir esta Unidade Orçamentária porque existem vínculos ativos no sistema."
+                    }
+                )
+
+    @extend_schema(
+        tags=["Unidades Orçamentárias"],
+        summary="Histórico da unidade orçamentária",
+        description="Retorna o histórico de alterações da unidade orçamentária informada no ID.",
+        parameters=[UO_ID_PATH_PARAM],
+        responses={
+            200: OpenApiResponse(
+                response=UnidadeOrcamentariaHistoricoGrupoSerializer(many=True),
+                description="Histórico retornado com sucesso.",
+            ),
+            401: OpenApiResponse(description="Usuário não autenticado."),
+            403: OpenApiResponse(description="Usuário sem permissão para visualizar histórico."),
+            404: OpenApiResponse(description="Unidade orçamentária não encontrada."),
+        },
+    )
+    @action(
+        detail=True,
+        methods=["get"],
+        url_path="historico",
+        filter_backends=[],
+        pagination_class=None,
+    )
+    def historico(self, request, pk=None):
+        return self._build_historico_response(self.get_object())
+
+    @extend_schema(
+        tags=["Unidades Orçamentárias"],
+        summary="Exportar unidades orçamentárias",
+        description="Exporta os dados filtrados para csv, xls, xlsx ou pdf.",
+        parameters=[
+            OpenApiParameter(
+                name="formato",
+                required=True,
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.QUERY,
+                enum=["csv", "xls", "xlsx", "pdf"],
+            )
+        ],
+        responses={
+            200: OpenApiResponse(description="Arquivo de exportação gerado com sucesso."),
+            400: OpenApiResponse(description="Parâmetros inválidos para exportação."),
+            401: OpenApiResponse(description="Usuário não autenticado."),
+            403: OpenApiResponse(description="Usuário sem permissão para exportar."),
+        },
+    )
+    @action(detail=False, methods=["get"], url_path="exportar")
+    def exportar(self, request):
+        return self._build_export_response(request)
 
 
 @extend_schema_view(
@@ -149,8 +540,14 @@ UA_ID_PATH_PARAM = OpenApiParameter(
         },
     ),
 )
-class UnidadeAdministrativaViewSet(viewsets.ModelViewSet):
+class UnidadeAdministrativaViewSet(AuditHistoryExportMixin, viewsets.ModelViewSet):
     permission_classes = [UnidadeAdministrativaPermission]
+    audit_model = UnidadeAdministrativa
+    historico_grupo_serializer_class = UnidadeAdministrativaHistoricoGrupoSerializer
+    export_query_serializer_class = UnidadeAdministrativaExportQuerySerializer
+    export_resource_class = UnidadeAdministrativaResource
+    export_pdf_format_class = UnidadeAdministrativaPDFFormat
+    export_filename_prefix = "unidades_administrativas"
 
     filter_backends = [DjangoFilterBackend, SearchFilter, OrderingFilter]
     filterset_fields = ["status"]
@@ -241,54 +638,6 @@ class UnidadeAdministrativaViewSet(viewsets.ModelViewSet):
                 }
             )
 
-    def _audit_changes(self, obj, original=None, operation="update"):
-        ct = ContentType.objects.get_for_model(UnidadeAdministrativa)
-
-        if operation == "update" and original is not None:
-            changes = dict_changes(
-                original,
-                obj,
-                fields=self.AUDIT_TRACK_FIELDS,
-            )
-            if not changes:
-                return
-
-            HistoricoGeral.objects.bulk_create(
-                [
-                    HistoricoGeral(
-                        content_type=ct,
-                        object_id=str(obj.pk),
-                        campo=field,
-                        valor_antigo=old,
-                        valor_novo=new,
-                        alterado_por=self.request.user,
-                    )
-                    for field, (old, new) in changes.items()
-                ]
-            )
-            return
-
-        if operation == "create":
-            HistoricoGeral.objects.create(
-                content_type=ct,
-                object_id=str(obj.pk),
-                campo="acao",
-                valor_antigo="",
-                valor_novo="criado",
-                alterado_por=self.request.user,
-            )
-            return
-
-        if operation == "delete":
-            HistoricoGeral.objects.create(
-                content_type=ct,
-                object_id=str(obj.pk),
-                campo="acao",
-                valor_antigo="existente",
-                valor_novo="excluido",
-                alterado_por=self.request.user,
-            )
-
     def perform_create(self, serializer):
         self._validate_uo_scope(serializer.validated_data)
         with transaction.atomic():
@@ -341,51 +690,7 @@ class UnidadeAdministrativaViewSet(viewsets.ModelViewSet):
         pagination_class=None,
     )
     def historico(self, request, pk=None):
-        ua = self.get_object()
-
-        ct = ContentType.objects.get_for_model(UnidadeAdministrativa)
-        historicos = (
-            HistoricoGeral.objects.filter(content_type=ct, object_id=str(ua.pk))
-            .select_related("alterado_por")
-            .order_by("-alterado_em")
-        )
-
-        agrupado = defaultdict(list)
-        for item in historicos:
-            chave = (item.alterado_em.replace(microsecond=0), item.alterado_por_id)
-            agrupado[chave].append(item)
-
-        resposta = []
-        for (alterado_em, alterado_por_id), itens in agrupado.items():
-            resposta.append(
-                {
-                    "alterado_em": alterado_em,
-                    "alterado_por": alterado_por_id,
-                    "alterado_por_nome": (
-                        itens[0].alterado_por.nome if itens[0].alterado_por else None
-                    ),
-                    "acoes": [
-                        {
-                            "campo": i.campo,
-                            "valor_antigo": i.valor_antigo,
-                            "valor_novo": i.valor_novo,
-                        }
-                        for i in itens
-                    ],
-                }
-            )
-
-        resposta_ordenada = sorted(
-            resposta,
-            key=lambda row: row["alterado_em"],
-            reverse=True,
-        )
-
-        serializer = UnidadeAdministrativaHistoricoGrupoSerializer(
-            resposta_ordenada,
-            many=True,
-        )
-        return Response(serializer.data)
+        return self._build_historico_response(self.get_object())
 
     @extend_schema(
         tags=["Unidades Administrativas"],
@@ -409,41 +714,4 @@ class UnidadeAdministrativaViewSet(viewsets.ModelViewSet):
     )
     @action(detail=False, methods=["get"], url_path="exportar")
     def exportar(self, request):
-        serializer = UnidadeAdministrativaExportQuerySerializer(
-            data=request.query_params
-        )
-        serializer.is_valid(raise_exception=True)
-        formato = serializer.validated_data["formato"]
-
-        queryset = self.filter_queryset(self.get_queryset())
-        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        filename = f"unidades_administrativas_{timestamp}.{formato}"
-
-        if formato == "pdf":
-            pdf_format = UnidadeAdministrativaPDFFormat()
-            pdf_format._export_request = request
-            pdf_format._export_queryset = queryset
-            pdf_bytes = pdf_format.export_data(None)
-
-            response = HttpResponse(pdf_bytes, content_type="application/pdf")
-            response["Content-Disposition"] = f'attachment; filename="{filename}"'
-            return response
-
-        resource = UnidadeAdministrativaResource()
-        dataset = resource.export(queryset)
-
-        if formato == "csv":
-            content = dataset.csv.encode("utf-8-sig")
-            content_type = "text/csv"
-        elif formato == "xls":
-            content = dataset.xls
-            content_type = "application/vnd.ms-excel"
-        else:
-            content = dataset.xlsx
-            content_type = (
-                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-            )
-
-        response = HttpResponse(content, content_type=content_type)
-        response["Content-Disposition"] = f'attachment; filename="{filename}"'
-        return response
+        return self._build_export_response(request)

--- a/dados_comuns/formats.py
+++ b/dados_comuns/formats.py
@@ -21,7 +21,7 @@ from reportlab.platypus import (
 from bem_patrimonial.pdf_utils import obter_rf_usuario
 
 
-class UnidadeAdministrativaPDFFormat(Format):
+class BaseUnidadePDFFormat(Format):
 
     LOGO_WIDTH_CM = 3
     LOGO_HEIGHT_CM = 1.5
@@ -33,10 +33,26 @@ class UnidadeAdministrativaPDFFormat(Format):
     def create_dataset(self, in_stream):
         raise NotImplementedError("Importação não é suportada para PDF.")
 
+    REPORT_TITLE = ""
+    EMPTY_MESSAGE = ""
+    TABLE_COL_WIDTHS = []
+
+    def get_report_title(self):
+        return self.REPORT_TITLE
+
+    def get_empty_message(self):
+        return self.EMPTY_MESSAGE
+
+    def get_table_col_widths(self):
+        return self.TABLE_COL_WIDTHS
+
+    def get_status_text(self, unidade):
+        raise NotImplementedError("Subclasses devem implementar get_status_text().")
+
     def export_data(self, dataset, **kwargs):
         request = getattr(self, "_export_request", None)
         queryset = getattr(self, "_export_queryset", None)
-        uas_list = list(queryset) if queryset is not None else []
+        unidades = list(queryset) if queryset is not None else []
 
         buffer = BytesIO()
         doc = SimpleDocTemplate(
@@ -46,7 +62,7 @@ class UnidadeAdministrativaPDFFormat(Format):
             rightMargin=0.3 * cm,
             topMargin=0.9 * cm,
             bottomMargin=0.9 * cm,
-            title="Relatório de Unidades Administrativas",
+            title=self.get_report_title(),
             author=(
                 obter_rf_usuario(request.user)
                 if request
@@ -54,7 +70,7 @@ class UnidadeAdministrativaPDFFormat(Format):
             ),
         )
 
-        elements = self._criar_cabecalho() + self._criar_tabela_unidades(uas_list)
+        elements = self._criar_cabecalho() + self._criar_tabela_unidades(unidades)
 
         doc.build(
             elements,
@@ -127,7 +143,7 @@ class UnidadeAdministrativaPDFFormat(Format):
         header_row = [
             self._carregar_logo("bens_default_logo.png", "SME", styles),
             [
-                Paragraph("Relatório de Unidades Administrativas", title_style),
+                Paragraph(self.get_report_title(), title_style),
                 Paragraph(
                     "Secretaria Municipal de Educação - Prefeitura de São Paulo",
                     subtitle_style,
@@ -150,12 +166,20 @@ class UnidadeAdministrativaPDFFormat(Format):
 
         return [header_table, Spacer(1, 0.4 * cm)]
 
-    def _criar_tabela_unidades(self, uas_list):
+    def _criar_linha_unidade(self, unidade, cell_style, cell_style_center):
+        return [
+            Paragraph(str(unidade.codigo) if unidade.codigo else "-", cell_style_center),
+            Paragraph(str(unidade.sigla) if unidade.sigla else "-", cell_style),
+            Paragraph(str(unidade.nome) if unidade.nome else "-", cell_style),
+            Paragraph(self.get_status_text(unidade), cell_style_center),
+        ]
+
+    def _criar_tabela_unidades(self, unidades):
         styles = getSampleStyleSheet()
-        if not uas_list:
+        if not unidades:
             return [
                 Paragraph(
-                    "<i>Nenhuma unidade administrativa encontrada com os filtros aplicados.</i>",
+                    self.get_empty_message(),
                     styles["Normal"],
                 )
             ]
@@ -163,21 +187,12 @@ class UnidadeAdministrativaPDFFormat(Format):
         cell_style, cell_style_center = self._criar_estilos_celula(styles)
         data = [["Código", "Sigla", "Nome", "Status"]]
 
-        for ua in uas_list:
-            data.append(
-                [
-                    Paragraph(str(ua.codigo) if ua.codigo else "-", cell_style_center),
-                    Paragraph(str(ua.sigla) if ua.sigla else "-", cell_style),
-                    Paragraph(str(ua.nome) if ua.nome else "-", cell_style),
-                    Paragraph(
-                        ua.get_status_display() if ua.status else "-", cell_style_center
-                    ),
-                ]
-            )
+        for unidade in unidades:
+            data.append(self._criar_linha_unidade(unidade, cell_style, cell_style_center))
 
         table = Table(
             data,
-            colWidths=[2 * cm, 5.5 * cm, 10 * cm, 2 * cm],
+            colWidths=self.get_table_col_widths(),
             repeatRows=1,
             splitByRow=True,
         )
@@ -245,3 +260,27 @@ class UnidadeAdministrativaPDFFormat(Format):
 
     def can_export(self):
         return True
+
+
+class UnidadeAdministrativaPDFFormat(BaseUnidadePDFFormat):
+
+    REPORT_TITLE = "Relatório de Unidades Administrativas"
+    EMPTY_MESSAGE = (
+        "<i>Nenhuma unidade administrativa encontrada com os filtros aplicados.</i>"
+    )
+    TABLE_COL_WIDTHS = [2 * cm, 5.5 * cm, 10 * cm, 2 * cm]
+
+    def get_status_text(self, unidade):
+        return unidade.get_status_display() if unidade.status else "-"
+
+
+class UnidadeOrcamentariaPDFFormat(BaseUnidadePDFFormat):
+
+    REPORT_TITLE = "Relatório de Unidades Orçamentárias"
+    EMPTY_MESSAGE = (
+        "<i>Nenhuma unidade orçamentária encontrada com os filtros aplicados.</i>"
+    )
+    TABLE_COL_WIDTHS = [3 * cm, 4 * cm, 10.5 * cm, 2.5 * cm]
+
+    def get_status_text(self, unidade):
+        return "Ativa" if unidade.ativa else "Inativa"

--- a/dados_comuns/models.py
+++ b/dados_comuns/models.py
@@ -34,6 +34,23 @@ class UnidadeOrcamentaria(models.Model):
     def __str__(self):
         return f"{self.codigo} - {self.nome}"
 
+    def listar_vinculos_para_exclusao(self):
+        vinculos = []
+
+        if self.unidades_administrativas.exists():
+            vinculos.append("unidades administrativas")
+
+        if self.usuarios.exists():
+            vinculos.append("usuários")
+
+        if self.parametros_conciliacao_anual.exists():
+            vinculos.append("parâmetros de conciliação anual")
+
+        return vinculos
+
+    def pode_excluir(self):
+        return not self.listar_vinculos_para_exclusao()
+
 
 class UnidadeAdministrativa(models.Model):
     """Classe que representa uma unidade administrativa"""

--- a/dados_comuns/permissions.py
+++ b/dados_comuns/permissions.py
@@ -113,6 +113,26 @@ class UnidadeAdministrativaPermission(BasePermission):
         return True
 
 
+class UnidadeOrcamentariaPermission(BasePermission):
+    """
+    Regras de acesso para API de Unidade Orçamentária:
+    - Apenas superusuário acessa o módulo inteiro.
+    """
+
+    def _pode_acessar_modulo(self, user):
+        return bool(
+            user
+            and user.is_authenticated
+            and getattr(user, "is_superuser", False)
+        )
+
+    def has_permission(self, request, view):
+        return self._pode_acessar_modulo(request.user)
+
+    def has_object_permission(self, request, view, obj):
+        return self._pode_acessar_modulo(request.user)
+
+
 class UsuarioPermission(BasePermission):
     """
     Regras de acesso para API de Usuários:

--- a/dados_comuns/resources.py
+++ b/dados_comuns/resources.py
@@ -1,5 +1,22 @@
 from import_export import resources, fields
-from dados_comuns.models import UnidadeAdministrativa
+
+from dados_comuns.models import UnidadeAdministrativa, UnidadeOrcamentaria
+
+
+class UnidadeOrcamentariaResource(resources.ModelResource):
+
+    ativa_display = fields.Field(
+        column_name="Status",
+        attribute="ativa",
+    )
+
+    class Meta:
+        model = UnidadeOrcamentaria
+        fields = ("codigo", "sigla", "nome", "ativa_display")
+        export_order = ("codigo", "sigla", "nome", "ativa_display")
+
+    def dehydrate_ativa_display(self, uo):
+        return "Ativa" if uo.ativa else "Inativa"
 
 
 class UnidadeAdministrativaResource(resources.ModelResource):

--- a/dados_comuns/tests/auth_test_utils.py
+++ b/dados_comuns/tests/auth_test_utils.py
@@ -14,5 +14,9 @@ def auth_kwargs(value=DEFAULT_AUTH_VALUE):
     return {AUTH_FIELD_KEY: value}
 
 
+def codigo_uo(a, b, c):
+    return f"{int(a):02d}.{int(b):02d}.{int(c):02d}"
+
+
 def codigo_ua(a, b, c, d):
     return f"{int(a):02d}.{int(b):02d}.{int(c):02d}.{int(d):03d}"

--- a/dados_comuns/tests/factories.py
+++ b/dados_comuns/tests/factories.py
@@ -5,8 +5,7 @@ from dados_comuns.models import UnidadeOrcamentaria, UnidadeAdministrativa
 
 def criar_uo(codigo="200", nome="UO Teste", sigla="UO", **kwargs):
     """
-    Ajuste os campos aqui para bater com o model real.
-    Pelo erro, UnidadeOrcamentaria NÃO aceita 'sigla'.
+    Factory simples para UnidadeOrcamentaria alinhada ao model atual.
     """
     data = {
         "codigo": codigo,

--- a/dados_comuns/tests/tests_exportacao_unidades.py
+++ b/dados_comuns/tests/tests_exportacao_unidades.py
@@ -3,10 +3,10 @@ from django.test import TestCase, RequestFactory
 from django.contrib.admin.sites import AdminSite
 from django.contrib.auth.models import Group
 from unittest.mock import Mock
-from dados_comuns.models import UnidadeAdministrativa
+from dados_comuns.models import UnidadeAdministrativa, UnidadeOrcamentaria
 from dados_comuns.admin import UnidadeAdministrativaAdmin
-from dados_comuns.formats import UnidadeAdministrativaPDFFormat
-from dados_comuns.resources import UnidadeAdministrativaResource
+from dados_comuns.formats import UnidadeAdministrativaPDFFormat, UnidadeOrcamentariaPDFFormat
+from dados_comuns.resources import UnidadeAdministrativaResource, UnidadeOrcamentariaResource
 from dados_comuns.tests.factories import criar_ua, criar_uo
 from usuario.models import Usuario
 from usuario.constants import GRUPO_GESTOR_PATRIMONIO, GRUPO_OPERADOR_INVENTARIO
@@ -193,3 +193,66 @@ class ExportacaoUnidadeAdministrativaTestCase(TestCase):
         linhas_dados = [row for row in dataset if row != dataset.headers]
 
         self.assertEqual(len(linhas_dados), total_esperado)
+
+
+class ExportacaoUnidadeOrcamentariaTestCase(TestCase):
+
+    def setUp(self):
+        criar_uo(codigo="10.10.10", nome="UO Ativa", sigla="ATV", ativa=True)
+        criar_uo(codigo="20.20.20", nome="UO Inativa", sigla="INA", ativa=False)
+
+        grupo_gestor, _ = Group.objects.get_or_create(name=GRUPO_GESTOR_PATRIMONIO)
+        self.superuser = Usuario.objects.create_user(
+            username="super_export_uo",
+            email="super.export.uo@test.com",
+            **auth_kwargs("test123"),
+            nome="Super Export UO",
+            rf="777888",
+            is_staff=True,
+            is_superuser=True,
+        )
+        self.superuser.groups.add(grupo_gestor)
+
+        self.factory = RequestFactory()
+
+    def _gerar_pdf(self, usuario=None, queryset=None):
+        if queryset is None:
+            queryset = UnidadeOrcamentaria.objects.all()
+
+        request = None
+        if usuario is not None:
+            request = self.factory.get("/api/unidades-orcamentarias/exportar/")
+            request.user = usuario
+
+        pdf_format = UnidadeOrcamentariaPDFFormat()
+        pdf_format._export_request = request
+        pdf_format._export_queryset = queryset
+        return pdf_format.export_data(None)
+
+    def test_pdf_uo_gerado_com_estrutura_valida(self):
+        pdf_bytes = self._gerar_pdf(self.superuser)
+
+        self.assertIsInstance(pdf_bytes, bytes)
+        self.assertTrue(pdf_bytes.startswith(b"%PDF"))
+        self.assertIn(b"%%EOF", pdf_bytes)
+        self.assertGreater(len(pdf_bytes), 1000)
+        self.assertIn(b"/Author (777888)", pdf_bytes)
+
+    def test_pdf_uo_sem_request_usa_sistema(self):
+        pdf_bytes = self._gerar_pdf(usuario=None)
+
+        self.assertTrue(pdf_bytes.startswith(b"%PDF"))
+        self.assertIn(b"/Author", pdf_bytes)
+
+    def test_resolve_usuario_exportacao_sem_request_retorna_sistema(self):
+        pdf_format = UnidadeOrcamentariaPDFFormat()
+
+        self.assertEqual(pdf_format._resolver_usuario_exportacao(None), "Sistema")
+
+    def test_exportacao_excel_uo_com_status_legivel(self):
+        resource = UnidadeOrcamentariaResource()
+        dataset = resource.export(UnidadeOrcamentaria.objects.all())
+
+        status_values = [row[3] for row in dataset]
+        self.assertIn("Ativa", status_values)
+        self.assertIn("Inativa", status_values)

--- a/dados_comuns/tests/tests_exportacao_unidades.py
+++ b/dados_comuns/tests/tests_exportacao_unidades.py
@@ -1,4 +1,4 @@
-from dados_comuns.tests.auth_test_utils import auth_kwargs
+from dados_comuns.tests.auth_test_utils import auth_kwargs, codigo_ua, codigo_uo
 from django.test import TestCase, RequestFactory
 from django.contrib.admin.sites import AdminSite
 from django.contrib.auth.models import Group
@@ -18,14 +18,14 @@ class ExportacaoUnidadeAdministrativaTestCase(TestCase):
         uo = criar_uo(codigo="100", nome="UO 100")
         criar_ua(
             uo=uo,
-            codigo="01.01.01.0001",
+            codigo=codigo_ua(1, 1, 1, 1),
             sigla="SME",
             nome="Secretaria Municipal de Educação",
             status=UnidadeAdministrativa.ATIVA,
         )
         criar_ua(
             uo=uo,
-            codigo="01.01.02.0002",
+            codigo=codigo_ua(1, 1, 2, 2),
             sigla="PMSP/SME/SME-GAB/MEMORIAL",
             nome="COORDENADORIA DOS CENTROS EDUCACIONAIS UNIFICADOS",
             status=UnidadeAdministrativa.INATIVA,
@@ -154,10 +154,10 @@ class ExportacaoUnidadeAdministrativaTestCase(TestCase):
         self.assertEqual(resource.Meta.export_order, expected_order)
 
     def test_pdf_paginacao_multiplas_paginas(self):
-        uo = criar_uo(codigo="99.99.00", nome="UO 99.99.00.0000")
+        uo = criar_uo(codigo=codigo_uo(99, 99, 0), nome="UO 99")
         for i in range(50):
             criar_ua(
-                codigo=f"99.99.{i:02d}.{i:04d}",
+                codigo=codigo_ua(99, 99, i, i),
                 sigla=f"UA-{i:03d}",
                 nome=f"Unidade Administrativa de Teste {i}",
                 status=UnidadeAdministrativa.ATIVA,
@@ -198,8 +198,8 @@ class ExportacaoUnidadeAdministrativaTestCase(TestCase):
 class ExportacaoUnidadeOrcamentariaTestCase(TestCase):
 
     def setUp(self):
-        criar_uo(codigo="10.10.10", nome="UO Ativa", sigla="ATV", ativa=True)
-        criar_uo(codigo="20.20.20", nome="UO Inativa", sigla="INA", ativa=False)
+        criar_uo(codigo=codigo_uo(10, 10, 10), nome="UO Ativa", sigla="ATV", ativa=True)
+        criar_uo(codigo=codigo_uo(20, 20, 20), nome="UO Inativa", sigla="INA", ativa=False)
 
         grupo_gestor, _ = Group.objects.get_or_create(name=GRUPO_GESTOR_PATRIMONIO)
         self.superuser = Usuario.objects.create_user(

--- a/dados_comuns/tests/tests_models.py
+++ b/dados_comuns/tests/tests_models.py
@@ -1,9 +1,13 @@
+from datetime import date
+
 from dados_comuns.tests.auth_test_utils import auth_kwargs
 from django.test import TestCase
 from django.contrib.admin.sites import AdminSite
-from dados_comuns.models import UnidadeAdministrativa
+from dados_comuns.models import UnidadeAdministrativa, UnidadeOrcamentaria
 from dados_comuns.admin import UnidadeAdministrativaAdmin
 from dados_comuns.tests.factories import criar_ua, criar_uo
+from inventario.models import ParametroConciliacaoAnual
+from usuario.models import Usuario
 
 
 class SetupData:
@@ -155,3 +159,42 @@ class UnidadeAdministrativaAdminTestCase(TestCase):
         self.assertGreater(len(unidades_list), 0)
         self.assertEqual(unidades_list[0].codigo, "050")
         self.assertEqual(unidades_list[-1].codigo, "200")
+
+
+class UnidadeOrcamentariaModelTestCase(TestCase):
+
+    def test_listar_vinculos_para_exclusao_sem_vinculos(self):
+        uo = criar_uo(codigo="11.11.11", nome="UO Livre", sigla="LIV")
+
+        self.assertEqual(uo.listar_vinculos_para_exclusao(), [])
+        self.assertTrue(uo.pode_excluir())
+
+    def test_listar_vinculos_para_exclusao_com_ua_usuario_e_parametro(self):
+        uo = criar_uo(codigo="22.22.22", nome="UO Vinculada", sigla="VIN")
+        criar_ua(
+            uo=uo,
+            codigo="22.22.22.001",
+            sigla="UA22",
+            nome="UA Vinculada",
+        )
+        Usuario.objects.create_user(
+            username="usuario_uo_vinculada",
+            email="usuario.uo.vinculada@test.com",
+            **auth_kwargs("123456"),
+            nome="Usuário Vinculado",
+            unidade_orcamentaria=uo,
+        )
+        ParametroConciliacaoAnual.objects.create(
+            unidade_orcamentaria=uo,
+            ano_referencia=2030,
+            periodo_inicial=date(2030, 1, 1),
+            periodo_final=date(2030, 3, 31),
+            ativo=True,
+        )
+
+        vinculos = uo.listar_vinculos_para_exclusao()
+
+        self.assertIn("unidades administrativas", vinculos)
+        self.assertIn("usuários", vinculos)
+        self.assertIn("parâmetros de conciliação anual", vinculos)
+        self.assertFalse(uo.pode_excluir())

--- a/dados_comuns/tests/tests_models.py
+++ b/dados_comuns/tests/tests_models.py
@@ -1,10 +1,11 @@
 from datetime import date
 
-from dados_comuns.tests.auth_test_utils import auth_kwargs
+from dados_comuns.tests.auth_test_utils import auth_kwargs, codigo_ua, codigo_uo
 from django.test import TestCase
+from django.test import RequestFactory
 from django.contrib.admin.sites import AdminSite
 from dados_comuns.models import UnidadeAdministrativa, UnidadeOrcamentaria
-from dados_comuns.admin import UnidadeAdministrativaAdmin
+from dados_comuns.admin import UnidadeAdministrativaAdmin, UnidadeOrcamentariaAdmin
 from dados_comuns.tests.factories import criar_ua, criar_uo
 from inventario.models import ParametroConciliacaoAnual
 from usuario.models import Usuario
@@ -164,16 +165,16 @@ class UnidadeAdministrativaAdminTestCase(TestCase):
 class UnidadeOrcamentariaModelTestCase(TestCase):
 
     def test_listar_vinculos_para_exclusao_sem_vinculos(self):
-        uo = criar_uo(codigo="11.11.11", nome="UO Livre", sigla="LIV")
+        uo = criar_uo(codigo=codigo_uo(11, 11, 11), nome="UO Livre", sigla="LIV")
 
         self.assertEqual(uo.listar_vinculos_para_exclusao(), [])
         self.assertTrue(uo.pode_excluir())
 
     def test_listar_vinculos_para_exclusao_com_ua_usuario_e_parametro(self):
-        uo = criar_uo(codigo="22.22.22", nome="UO Vinculada", sigla="VIN")
+        uo = criar_uo(codigo=codigo_uo(22, 22, 22), nome="UO Vinculada", sigla="VIN")
         criar_ua(
             uo=uo,
-            codigo="22.22.22.001",
+            codigo=codigo_ua(22, 22, 22, 1),
             sigla="UA22",
             nome="UA Vinculada",
         )
@@ -198,3 +199,80 @@ class UnidadeOrcamentariaModelTestCase(TestCase):
         self.assertIn("usuários", vinculos)
         self.assertIn("parâmetros de conciliação anual", vinculos)
         self.assertFalse(uo.pode_excluir())
+
+
+class UnidadeOrcamentariaAdminTestCase(TestCase):
+
+    def setUp(self):
+        self.site = AdminSite()
+        self.admin = UnidadeOrcamentariaAdmin(UnidadeOrcamentaria, self.site)
+        self.factory = RequestFactory()
+        self.superuser = Usuario.objects.create_superuser(
+            username="admin_uo",
+            email="admin.uo@test.com",
+            **auth_kwargs("123"),
+        )
+        self.gestor = Usuario.objects.create_user(
+            username="gestor_uo_admin",
+            email="gestor.uo.admin@test.com",
+            **auth_kwargs("123"),
+            is_staff=True,
+        )
+
+    def test_permissoes_admin_somente_superuser(self):
+        request_super = self.factory.get("/admin/dados_comuns/unidadeorcamentaria/")
+        request_super.user = self.superuser
+
+        request_gestor = self.factory.get("/admin/dados_comuns/unidadeorcamentaria/")
+        request_gestor.user = self.gestor
+
+        self.assertTrue(self.admin.has_module_permission(request_super))
+        self.assertTrue(self.admin.has_view_permission(request_super))
+        self.assertTrue(self.admin.has_add_permission(request_super))
+        self.assertTrue(self.admin.has_change_permission(request_super))
+        self.assertFalse(self.admin.has_delete_permission(request_super))
+        self.assertTrue(self.admin.has_export_permission(request_super))
+
+        self.assertFalse(self.admin.has_module_permission(request_gestor))
+        self.assertFalse(self.admin.has_view_permission(request_gestor))
+        self.assertFalse(self.admin.has_add_permission(request_gestor))
+        self.assertFalse(self.admin.has_change_permission(request_gestor))
+        self.assertFalse(self.admin.has_export_permission(request_gestor))
+
+    def test_form_admin_exige_codigo_e_nome_mas_nao_sigla(self):
+        request = self.factory.get("/admin/dados_comuns/unidadeorcamentaria/add/")
+        request.user = self.superuser
+
+        form_class = self.admin.get_form(request)
+
+        form_sem_sigla = form_class(
+            data={
+                "codigo": codigo_uo(33, 33, 33),
+                "nome": "UO Admin",
+                "sigla": "",
+                "ativa": True,
+            }
+        )
+        self.assertTrue(form_sem_sigla.is_valid())
+
+        form_sem_codigo = form_class(
+            data={
+                "codigo": "",
+                "nome": "UO Admin",
+                "sigla": "ADM",
+                "ativa": True,
+            }
+        )
+        self.assertFalse(form_sem_codigo.is_valid())
+        self.assertIn("codigo", form_sem_codigo.errors)
+
+        form_sem_nome = form_class(
+            data={
+                "codigo": codigo_uo(44, 44, 44),
+                "nome": "",
+                "sigla": "ADM",
+                "ativa": True,
+            }
+        )
+        self.assertFalse(form_sem_nome.is_valid())
+        self.assertIn("nome", form_sem_nome.errors)

--- a/dados_comuns/tests/tests_permissions_api.py
+++ b/dados_comuns/tests/tests_permissions_api.py
@@ -1,11 +1,14 @@
 from types import SimpleNamespace
 
 from django.test import SimpleTestCase
+from rest_framework.exceptions import PermissionDenied
 
 from bem_patrimonial import constants as bem_constants
 from dados_comuns.permissions import (
     BemPatrimonialPermission,
     UnidadeAdministrativaPermission,
+    UnidadeOrcamentariaPermission,
+    UsuarioPermission,
 )
 
 
@@ -141,4 +144,126 @@ class PermissionsAPITestCase(SimpleTestCase):
 
         self.assertTrue(
             perm.has_object_permission(self._request(operador), self._view("acao_desconhecida"), obj)
+        )
+
+    def test_uo_has_permission_apenas_superuser(self):
+        perm = UnidadeOrcamentariaPermission()
+
+        self.assertFalse(
+            perm.has_permission(self._request(self._user(authenticated=False)), self._view("list"))
+        )
+
+        superuser = self._user(superuser=True)
+        for action in (
+            "list",
+            "retrieve",
+            "historico",
+            "create",
+            "update",
+            "partial_update",
+            "destroy",
+            "exportar",
+            "acao_desconhecida",
+        ):
+            with self.subTest(action=action):
+                self.assertTrue(perm.has_permission(self._request(superuser), self._view(action)))
+
+        self.assertFalse(
+            perm.has_permission(self._request(self._request_user_gestor()), self._view("list"))
+        )
+        self.assertFalse(
+            perm.has_permission(self._request(self._request_user_operador()), self._view("exportar"))
+        )
+
+    def test_uo_has_object_permission_apenas_superuser(self):
+        perm = UnidadeOrcamentariaPermission()
+        obj = SimpleNamespace()
+
+        self.assertTrue(
+            perm.has_object_permission(
+                self._request(self._user(superuser=True)),
+                self._view("retrieve"),
+                obj,
+            )
+        )
+        self.assertFalse(
+            perm.has_object_permission(
+                self._request(self._request_user_gestor()),
+                self._view("destroy"),
+                obj,
+            )
+        )
+        self.assertFalse(
+            perm.has_object_permission(
+                self._request(self._request_user_operador()),
+                self._view("historico"),
+                obj,
+            )
+        )
+
+    def _request_user_gestor(self):
+        return self._user(gestor=True)
+
+    def _request_user_operador(self):
+        return self._user(operador=True)
+
+    def test_usuario_has_permission_cobre_ramos(self):
+        perm = UsuarioPermission()
+
+        superuser = self._user(superuser=True)
+        for action in (
+            "list",
+            "retrieve",
+            "create",
+            "update",
+            "partial_update",
+            "destroy",
+            "restore",
+            "acao_desconhecida",
+        ):
+            with self.subTest(action=action):
+                self.assertTrue(perm.has_permission(self._request(superuser), self._view(action)))
+
+        gestor = self._user(gestor=True)
+        self.assertTrue(perm.has_permission(self._request(gestor), self._view("list")))
+        self.assertTrue(perm.has_permission(self._request(gestor), self._view("destroy")))
+
+        with self.assertRaises(PermissionDenied):
+            perm.has_permission(self._request(self._user(operador=True)), self._view("list"))
+
+        self.assertFalse(
+            perm.has_permission(self._request(self._user()), self._view("list"))
+        )
+
+    def test_usuario_has_object_permission_cobre_ramos(self):
+        perm = UsuarioPermission()
+        obj = SimpleNamespace()
+
+        self.assertTrue(
+            perm.has_object_permission(
+                self._request(self._user(operador=True)),
+                self._view("retrieve"),
+                obj,
+            )
+        )
+        self.assertTrue(
+            perm.has_object_permission(
+                self._request(self._user(gestor=True)),
+                self._view("update"),
+                obj,
+            )
+        )
+        self.assertFalse(
+            perm.has_object_permission(
+                self._request(self._user(operador=True)),
+                self._view("destroy"),
+                obj,
+            )
+        )
+        self.assertTrue(
+            perm.has_object_permission(
+                self._request(self._user()),
+                self._view("acao_desconhecida"),
+                obj,
+            )
         )

--- a/dados_comuns/tests/tests_unidade_administrativa_api.py
+++ b/dados_comuns/tests/tests_unidade_administrativa_api.py
@@ -1,4 +1,4 @@
-from dados_comuns.tests.auth_test_utils import auth_kwargs, codigo_ua
+from dados_comuns.tests.auth_test_utils import auth_kwargs, codigo_ua, codigo_uo
 from unittest.mock import patch
 
 from django.contrib.auth.models import Group
@@ -30,8 +30,8 @@ class UnidadeAdministrativaAPITestCase(APITestCase):
     }
 
     def setUp(self):
-        self.uo1 = criar_uo(codigo="10.10.10", nome="UO 1")
-        self.uo2 = criar_uo(codigo="20.20.20", nome="UO 2")
+        self.uo1 = criar_uo(codigo=codigo_uo(10, 10, 10), nome="UO 1")
+        self.uo2 = criar_uo(codigo=codigo_uo(20, 20, 20), nome="UO 2")
 
         self.ua1 = criar_ua(
             uo=self.uo1,
@@ -183,7 +183,7 @@ class UnidadeAdministrativaAPITestCase(APITestCase):
         self._auth(self.gestor)
         cenarios = [
             ("050", codigo_ua(10, 10, 10, 50)),
-            ("1002", "10.10.10.1002"),
+            ("1002", f"{codigo_uo(10, 10, 10)}.1002"),
             (codigo_ua(10, 10, 10, 777), codigo_ua(10, 10, 10, 777)),
         ]
 

--- a/dados_comuns/tests/tests_unidade_orcamentaria_api.py
+++ b/dados_comuns/tests/tests_unidade_orcamentaria_api.py
@@ -6,7 +6,7 @@ from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from dados_comuns.tests.auth_test_utils import auth_kwargs, codigo_ua
+from dados_comuns.tests.auth_test_utils import auth_kwargs, codigo_ua, codigo_uo
 from dados_comuns.tests.factories import criar_ua, criar_uo
 from usuario.constants import GRUPO_GESTOR_PATRIMONIO, GRUPO_OPERADOR_INVENTARIO
 from usuario.models import Usuario
@@ -23,11 +23,20 @@ class UnidadeOrcamentariaAPITestCase(APITestCase):
     }
 
     def setUp(self):
-        self.uo1 = criar_uo(codigo="10.10.10", nome="UO 1", sigla="UO1")
-        self.uo2 = criar_uo(codigo="20.20.20", nome="UO 2", sigla="UO2", ativa=False)
-        self.uo3 = criar_uo(codigo="30.30.30", nome="UO 3", sigla="UO3")
+        self.uo1 = criar_uo(codigo=codigo_uo(10, 10, 10), nome="UO 1", sigla="UO1")
+        self.uo2 = criar_uo(
+            codigo=codigo_uo(20, 20, 20),
+            nome="UO 2",
+            sigla="UO2",
+            ativa=False,
+        )
+        self.uo3 = criar_uo(codigo=codigo_uo(30, 30, 30), nome="UO 3", sigla="UO3")
 
-        self.uo_com_ua = criar_uo(codigo="40.40.40", nome="UO Com UA", sigla="UOUA")
+        self.uo_com_ua = criar_uo(
+            codigo=codigo_uo(40, 40, 40),
+            nome="UO Com UA",
+            sigla="UOUA",
+        )
         criar_ua(
             uo=self.uo_com_ua,
             codigo=codigo_ua(40, 40, 40, 1),
@@ -36,7 +45,7 @@ class UnidadeOrcamentariaAPITestCase(APITestCase):
         )
 
         self.uo_sem_vinculo = criar_uo(
-            codigo="50.50.50",
+            codigo=codigo_uo(50, 50, 50),
             nome="UO Sem Vinculo",
             sigla="UOLIVRE",
         )
@@ -84,7 +93,7 @@ class UnidadeOrcamentariaAPITestCase(APITestCase):
 
     def _payload_uo(self, **overrides):
         payload = {
-            "codigo": "60.60.60",
+            "codigo": codigo_uo(60, 60, 60),
             "sigla": "UO60",
             "nome": "UO 60",
             "ativa": True,
@@ -162,7 +171,7 @@ class UnidadeOrcamentariaAPITestCase(APITestCase):
 
         create_response = self.client.post(
             self.list_url,
-            self._payload_uo(codigo="61.61.61", sigla="UO61", nome="UO 61"),
+            self._payload_uo(codigo=codigo_uo(61, 61, 61), sigla="UO61", nome="UO 61"),
             format="json",
         )
         self.assertEqual(create_response.status_code, status.HTTP_201_CREATED)
@@ -196,7 +205,7 @@ class UnidadeOrcamentariaAPITestCase(APITestCase):
 
         cenarios = [
             ({"codigo": "", "sigla": "UO", "nome": "Nome", "ativa": True}, "codigo"),
-            ({"codigo": "70.70.70", "sigla": "UO", "nome": "", "ativa": True}, "nome"),
+            ({"codigo": codigo_uo(70, 70, 70), "sigla": "UO", "nome": "", "ativa": True}, "nome"),
             ({"codigo": self.uo1.codigo, "sigla": "UO", "nome": "Duplicada", "ativa": True}, "codigo"),
         ]
 
@@ -246,7 +255,7 @@ class UnidadeOrcamentariaAPITestCase(APITestCase):
 
     def test_delete_bloqueia_quando_existirem_usuarios_vinculados(self):
         uo_com_usuario = criar_uo(
-            codigo="80.80.80",
+            codigo=codigo_uo(80, 80, 80),
             nome="UO Com Usuario",
             sigla="UOUSR",
         )
@@ -276,7 +285,11 @@ class UnidadeOrcamentariaAPITestCase(APITestCase):
         self.assertEqual(get_response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_delete_quando_protected_error_retorna_400(self):
-        uo_livre = criar_uo(codigo="90.90.90", nome="UO Livre", sigla="UOL")
+        uo_livre = criar_uo(
+            codigo=codigo_uo(90, 90, 90),
+            nome="UO Livre",
+            sigla="UOL",
+        )
 
         self._auth(self.superuser)
         with patch(

--- a/dados_comuns/tests/tests_unidade_orcamentaria_api.py
+++ b/dados_comuns/tests/tests_unidade_orcamentaria_api.py
@@ -1,0 +1,289 @@
+from unittest.mock import patch
+
+from django.contrib.auth.models import Group
+from django.db.models.deletion import ProtectedError
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from dados_comuns.tests.auth_test_utils import auth_kwargs, codigo_ua
+from dados_comuns.tests.factories import criar_ua, criar_uo
+from usuario.constants import GRUPO_GESTOR_PATRIMONIO, GRUPO_OPERADOR_INVENTARIO
+from usuario.models import Usuario
+
+
+class UnidadeOrcamentariaAPITestCase(APITestCase):
+    LIST_FIELDS = {
+        "id",
+        "codigo",
+        "sigla",
+        "nome",
+        "ativa",
+        "ativa_display",
+    }
+
+    def setUp(self):
+        self.uo1 = criar_uo(codigo="10.10.10", nome="UO 1", sigla="UO1")
+        self.uo2 = criar_uo(codigo="20.20.20", nome="UO 2", sigla="UO2", ativa=False)
+        self.uo3 = criar_uo(codigo="30.30.30", nome="UO 3", sigla="UO3")
+
+        self.uo_com_ua = criar_uo(codigo="40.40.40", nome="UO Com UA", sigla="UOUA")
+        criar_ua(
+            uo=self.uo_com_ua,
+            codigo=codigo_ua(40, 40, 40, 1),
+            sigla="UA40",
+            nome="Unidade Vinculada",
+        )
+
+        self.uo_sem_vinculo = criar_uo(
+            codigo="50.50.50",
+            nome="UO Sem Vinculo",
+            sigla="UOLIVRE",
+        )
+
+        grupo_gestor = Group.objects.get_or_create(name=GRUPO_GESTOR_PATRIMONIO)[0]
+        grupo_operador = Group.objects.get_or_create(name=GRUPO_OPERADOR_INVENTARIO)[0]
+
+        self.gestor = Usuario.objects.create_user(
+            username="gestor_uo_api",
+            email="gestor.uo.api@test.com",
+            **auth_kwargs("test123"),
+            nome="Gestor UO",
+            is_staff=True,
+            unidade_orcamentaria=self.uo1,
+        )
+        self.gestor.groups.add(grupo_gestor)
+
+        self.operador = Usuario.objects.create_user(
+            username="operador_uo_api",
+            email="operador.uo.api@test.com",
+            **auth_kwargs("test123"),
+            nome="Operador UO",
+            is_staff=True,
+            unidade_orcamentaria=self.uo1,
+        )
+        self.operador.groups.add(grupo_operador)
+
+        self.superuser = Usuario.objects.create_user(
+            username="super_uo_api",
+            email="super.uo.api@test.com",
+            **auth_kwargs("test123"),
+            nome="Super UO",
+            is_staff=True,
+            is_superuser=True,
+            unidade_orcamentaria=self.uo1,
+        )
+
+        self.list_url = reverse("unidades-orcamentarias-list")
+
+    def _auth(self, user):
+        self.client.force_authenticate(user)
+
+    def _detail_url(self, uo_id):
+        return reverse("unidades-orcamentarias-detail", args=[uo_id])
+
+    def _payload_uo(self, **overrides):
+        payload = {
+            "codigo": "60.60.60",
+            "sigla": "UO60",
+            "nome": "UO 60",
+            "ativa": True,
+        }
+        payload.update(overrides)
+        return payload
+
+    def test_nao_autenticado_retorna_401_no_get(self):
+        response = self.client.get(self.list_url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_apenas_superuser_acessa_modulo(self):
+        cenarios = [self.gestor, self.operador]
+        export_url = reverse("unidades-orcamentarias-exportar")
+        historico_url = reverse("unidades-orcamentarias-historico", args=[self.uo1.id])
+
+        for user in cenarios:
+            with self.subTest(user=user.username):
+                self._auth(user)
+
+                self.assertEqual(self.client.get(self.list_url).status_code, status.HTTP_403_FORBIDDEN)
+                self.assertEqual(
+                    self.client.get(self._detail_url(self.uo1.id)).status_code,
+                    status.HTTP_403_FORBIDDEN,
+                )
+                self.assertEqual(
+                    self.client.get(historico_url).status_code,
+                    status.HTTP_403_FORBIDDEN,
+                )
+                self.assertEqual(
+                    self.client.get(export_url, {"formato": "csv"}).status_code,
+                    status.HTTP_403_FORBIDDEN,
+                )
+                self.assertEqual(
+                    self.client.post(self.list_url, self._payload_uo(), format="json").status_code,
+                    status.HTTP_403_FORBIDDEN,
+                )
+                self.assertEqual(
+                    self.client.patch(
+                        self._detail_url(self.uo1.id),
+                        {"nome": "Alterada"},
+                        format="json",
+                    ).status_code,
+                    status.HTTP_403_FORBIDDEN,
+                )
+                self.assertEqual(
+                    self.client.delete(self._detail_url(self.uo1.id)).status_code,
+                    status.HTTP_403_FORBIDDEN,
+                )
+
+    def test_listagem_filtros_ordenacao_e_campos(self):
+        self._auth(self.superuser)
+
+        response = self.client.get(
+            self.list_url,
+            {"ativa": False, "search": "UO 2", "ordering": "-codigo"},
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["results"]), 1)
+        self.assertEqual(response.data["results"][0]["id"], self.uo2.id)
+        self.assertEqual(set(response.data["results"][0].keys()), self.LIST_FIELDS)
+
+        response_id = self.client.get(self.list_url, {"ordering": "-id"})
+        ids = [row["id"] for row in response_id.data["results"]]
+        self.assertEqual(ids, sorted(ids, reverse=True))
+
+    def test_retrieve_criacao_atualizacao_e_historico(self):
+        self._auth(self.superuser)
+
+        detail = self.client.get(self._detail_url(self.uo1.id))
+        self.assertEqual(detail.status_code, status.HTTP_200_OK)
+        self.assertEqual(detail.data["id"], self.uo1.id)
+        self.assertEqual(detail.data["ativa_display"], "Ativa")
+        self.assertEqual(set(detail.data.keys()), self.LIST_FIELDS)
+
+        create_response = self.client.post(
+            self.list_url,
+            self._payload_uo(codigo="61.61.61", sigla="UO61", nome="UO 61"),
+            format="json",
+        )
+        self.assertEqual(create_response.status_code, status.HTTP_201_CREATED)
+
+        patch_response = self.client.patch(
+            self._detail_url(self.uo1.id),
+            {"nome": "UO 1 Alterada"},
+            format="json",
+        )
+        self.assertEqual(patch_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(patch_response.data["nome"], "UO 1 Alterada")
+
+        historico_response = self.client.get(
+            reverse("unidades-orcamentarias-historico", args=[self.uo1.id]),
+            {"search": "ignorar", "page": 99},
+        )
+        self.assertEqual(historico_response.status_code, status.HTTP_200_OK)
+        self.assertIsInstance(historico_response.data, list)
+        self.assertGreaterEqual(len(historico_response.data), 1)
+        self.assertIn("acoes", historico_response.data[0])
+        self.assertTrue(
+            any(
+                acao["campo"] == "nome"
+                for grupo in historico_response.data
+                for acao in grupo["acoes"]
+            )
+        )
+
+    def test_criacao_com_erro_de_validacao(self):
+        self._auth(self.superuser)
+
+        cenarios = [
+            ({"codigo": "", "sigla": "UO", "nome": "Nome", "ativa": True}, "codigo"),
+            ({"codigo": "70.70.70", "sigla": "UO", "nome": "", "ativa": True}, "nome"),
+            ({"codigo": self.uo1.codigo, "sigla": "UO", "nome": "Duplicada", "ativa": True}, "codigo"),
+        ]
+
+        for payload, campo in cenarios:
+            with self.subTest(campo=campo, payload=payload):
+                response = self.client.post(self.list_url, payload, format="json")
+                self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+                self.assertIn(campo, response.data)
+
+    def test_exportacao_por_formato_permitido(self):
+        self._auth(self.superuser)
+        formatos = {
+            "csv": "text/csv",
+            "xls": "application/vnd.ms-excel",
+            "xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            "pdf": "application/pdf",
+        }
+
+        for formato, content_type in formatos.items():
+            with self.subTest(formato=formato):
+                response = self.client.get(
+                    reverse("unidades-orcamentarias-exportar"),
+                    {"formato": formato},
+                )
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+                self.assertEqual(response["Content-Type"], content_type)
+                self.assertIn("attachment;", response["Content-Disposition"])
+
+    def test_exportacao_parametro_invalido_retorna_400(self):
+        self._auth(self.superuser)
+
+        response = self.client.get(
+            reverse("unidades-orcamentarias-exportar"),
+            {"formato": "xml"},
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("formato", response.data)
+
+    def test_delete_bloqueia_quando_existirem_unidades_administrativas_vinculadas(self):
+        self._auth(self.superuser)
+
+        response = self.client.delete(self._detail_url(self.uo_com_ua.id))
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("detail", response.data)
+        self.assertIn("unidades administrativas", response.data["detail"])
+
+    def test_delete_bloqueia_quando_existirem_usuarios_vinculados(self):
+        uo_com_usuario = criar_uo(
+            codigo="80.80.80",
+            nome="UO Com Usuario",
+            sigla="UOUSR",
+        )
+        Usuario.objects.create_user(
+            username="usuario_vinculado_uo",
+            email="usuario.vinculado.uo@test.com",
+            **auth_kwargs("test123"),
+            nome="Usuário Vinculado",
+            unidade_orcamentaria=uo_com_usuario,
+        )
+
+        self._auth(self.superuser)
+        response = self.client.delete(self._detail_url(uo_com_usuario.id))
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("detail", response.data)
+        self.assertIn("usuários", response.data["detail"])
+
+    def test_delete_sem_vinculos_remove_uo(self):
+        self._auth(self.superuser)
+
+        response = self.client.delete(self._detail_url(self.uo_sem_vinculo.id))
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        get_response = self.client.get(self._detail_url(self.uo_sem_vinculo.id))
+        self.assertEqual(get_response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_delete_quando_protected_error_retorna_400(self):
+        uo_livre = criar_uo(codigo="90.90.90", nome="UO Livre", sigla="UOL")
+
+        self._auth(self.superuser)
+        with patch(
+            "dados_comuns.models.UnidadeOrcamentaria.delete",
+            side_effect=ProtectedError("protegido", []),
+        ):
+            response = self.client.delete(self._detail_url(uo_livre.id))
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("detail", response.data)


### PR DESCRIPTION
## 🎯 Objetivo principal

- Implementar e padronizar os endpoints REST de Unidades Orçamentárias.
- Seguir o padrão já adotado no módulo de Unidades Administrativas.
- Disponibilizar CRUD, histórico, exportação e documentação OpenAPI em português.
- Restringir o acesso do módulo a superusuário.

## 🌐 Endpoints adicionados

- `GET /api/unidades-orcamentarias/`
- `POST /api/unidades-orcamentarias/`
- `GET /api/unidades-orcamentarias/{id}/`
- `PUT /api/unidades-orcamentarias/{id}/`
- `PATCH /api/unidades-orcamentarias/{id}/`
- `DELETE /api/unidades-orcamentarias/{id}/`
- `GET /api/unidades-orcamentarias/{id}/historico/`
- `GET /api/unidades-orcamentarias/exportar/?formato=csv|xls|xlsx|pdf`

## 🧠 Regras de negócio implementadas

- O módulo de UO ficou acessível apenas para superusuário.
- A listagem suporta paginação, busca, filtro e ordenação.
- Busca disponível em `codigo`, `sigla` e `nome`.
- Filtro disponível em `ativa`.
- Ordenação disponível em `id`, `codigo`, `sigla`, `nome` e `ativa`.
- A resposta da API expõe `id`, `codigo`, `sigla`, `nome`, `ativa` e `ativa_display`.
- `codigo` e `nome` são obrigatórios.
- `sigla` permanece opcional, alinhada ao model e ao admin atual.
- A exclusão é bloqueada quando existem vínculos com Unidades Administrativas, usuários ou parâmetros de conciliação anual.
- O histórico usa `HistoricoGeral` e registra criação, alteração e exclusão.
- A exportação suporta `csv`, `xls`, `xlsx` e `pdf`.

## 📚 Documentação e padronização

- Os endpoints foram documentados com `drf-spectacular`, com descrições em português.
- O parâmetro de path `id` foi documentado explicitamente.
- Foram documentados os parâmetros de busca, ordenação, filtro, paginação e exportação.
- A branch também reduziu duplicação com extração de código compartilhado entre UA e UO:
  - `AuditHistoryExportMixin` para auditoria, histórico e exportação.
  - `BaseUnidadePDFFormat` para padronização do PDF de UA e UO.

## 🧪 Testes automatizados

### 🆕 Cobertura criada para UO

Arquivo: `tests_unidade_orcamentaria_api.py` (novo)

- Cobre autenticação e restrição de acesso apenas para superusuário.
- Cobre listagem com filtros, busca, ordenação e contrato de campos.
- Cobre detalhe, criação, atualização, histórico e exportação.
- Cobre validações de criação.
- Cobre exclusão segura, incluindo bloqueio por vínculos e tratamento de `ProtectedError`.

### 🔄 Cobertura complementar adicionada

Arquivo: `tests_permissions_api.py`

- Adiciona testes para `UnidadeOrcamentariaPermission`.
- Expande cobertura de permissões já existentes, especialmente `UsuarioPermission`.

Arquivo: `tests_models.py`

- Adiciona testes do model de UO para vínculos que impedem exclusão.
- Adiciona testes do admin de UO para permissões e comportamento do formulário.

Arquivo: `tests_exportacao_unidades.py`

- Adiciona testes específicos de exportação de UO.
- Cobre geração de PDF, fallback sem request e status legível na exportação.

### 🛠️ Ajustes de suporte na suíte

- `auth_test_utils.py`: helper para montar código de UO.
- `tests_unidade_administrativa_api.py`: ajuste de dados de teste para usar helpers em vez de códigos pontuados literais.
- `factories.py`: ajuste leve de apoio para aderência ao model atual.

Esses ajustes foram feitos principalmente para manter consistência da suíte e evitar ruído em análise estática, sem alterar de forma relevante o escopo funcional já coberto em UA.

### 📊 Validação executada

**Bateria focada nos arquivos alterados**

Total executado: `68 testes`
Comando executado:

```bash
docker compose -f docker-compose-dev.yml exec web python manage.py test \
  dados_comuns.tests.tests_unidade_orcamentaria_api \
  dados_comuns.tests.tests_unidade_administrativa_api \
  dados_comuns.tests.tests_permissions_api \
  dados_comuns.tests.tests_exportacao_unidades \
  dados_comuns.tests.tests_models
```

Resultado:

```text
68 testes executados em 11.375s
Status final: OK
Sem falhas
```

**Suíte completa do sistema**

Total executado: `694 testes`
Comando executado:

```bash
docker compose -f docker-compose-dev.yml exec web python manage.py test
```

Resultado:

```text
694 testes executados em 96.473s
Status final: OK
Sem falhas
```

## ✅ Resultado final

- A API de Unidades Orçamentárias foi implementada no mesmo padrão estrutural de Unidades Administrativas.
- O acesso ao módulo ficou restrito a superusuário.
- O módulo passou a contar com CRUD, histórico, exportação e documentação OpenAPI.
- A exclusão ficou protegida por validação explícita de vínculos.
- A branch também consolidou testes e refatorações para manter a solução mais padronizada e sustentável.
