### PR TITLE
Fix(usuario): Retorna is_superuser no Endpoint /me

### DIFF
--- a/usuario/serializers.py
+++ b/usuario/serializers.py
@@ -146,6 +146,7 @@ class FirstAccessPasswordChangeSerializer(serializers.Serializer):
 
 
 class UserProfileSerializer(serializers.ModelSerializer):
+    is_superuser = serializers.BooleanField(read_only=True)
     is_gestor_patrimonio = serializers.BooleanField(read_only=True)
     is_operador_inventario = serializers.BooleanField(read_only=True)
     uo_ativa = serializers.SerializerMethodField()
@@ -160,6 +161,7 @@ class UserProfileSerializer(serializers.ModelSerializer):
             "email",
             "nome",
             "rf",
+            "is_superuser",
             "is_gestor_patrimonio",
             "is_operador_inventario",
             "must_change_password",

--- a/usuario/tests/tests_auth_endpoints.py
+++ b/usuario/tests/tests_auth_endpoints.py
@@ -135,6 +135,31 @@ class AuthEndpointsTestCase(APITestCase):
         resp = self.client.get(me_url, HTTP_AUTHORIZATION=f"Bearer {access}")
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         self.assertEqual(resp.data["username"], "testuser")
+        self.assertIs(resp.data["is_superuser"], False)
+
+    def test_me_authenticated_superuser(self):
+        superuser = Usuario.objects.create_superuser(
+            username="adminuser",
+            email="adminuser@example.com",
+            **auth_kwargs("adminpass123"),
+            must_change_password=False,
+        )
+
+        login_url = "/api/auth/login/"
+        resp = self.client.post(
+            login_url,
+            {"username": "adminuser", **auth_kwargs("adminpass123")},
+            format="json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+        access = resp.data["access"]
+        me_url = "/api/auth/me/"
+        resp = self.client.get(me_url, HTTP_AUTHORIZATION=f"Bearer {access}")
+
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.data["id"], superuser.id)
+        self.assertIs(resp.data["is_superuser"], True)
 
     def test_token_refresh(self):
         login_url = "/api/auth/login/"


### PR DESCRIPTION
## Objetivo
Adicionar o campo is_superuser na resposta do endpoint /api/auth/me/, permitindo que o cliente saiba explicitamente se o usuário autenticado é superusuário.

## O que foi alterado
- Adicionado o campo is_superuser ao serializer de perfil do usuário em serializers.py
- Adicionados testes cobrindo o retorno de is_superuser para:
  - usuário comum
  - superusuário
- Cobertura adicionada em tests_auth_endpoints.py

## Resultado esperado
A resposta de /api/auth/me/ passa a incluir o atributo is_superuser com valor booleano:
- false para usuários comuns
- true para superusuários

## Validação realizada
- Execução dos testes de autenticação em tests_auth_endpoints.py
- Resultado: 19 testes passando

## Impacto
Mudança compatível com versões anteriores, apenas com adição de um novo campo na resposta do endpoint.