### PR TITLE
Feature(147325): Transferência de Bens Entre Secretarias

### DIFF
--- a/bem_patrimonial/admin.py
+++ b/bem_patrimonial/admin.py
@@ -2,10 +2,14 @@ from django.contrib import admin
 from bem_patrimonial.admins.baixa_fisica_bem_patrimonial import (
     BaixaFisicaBemPatrimonialAdmin,
 )
+from bem_patrimonial.admins.transferencia_bem_patrimonial import (
+    TransferenciaBemPatrimonialAdmin,
+)
 from bem_patrimonial.models import (
     BemPatrimonial,
     MovimentacaoBemPatrimonial,
     BaixaFisicaBemPatrimonial,
+    TransferenciaBemPatrimonial,
 )
 from .admins.bem_patrimonial import BemPatrimonialAdmin
 from .admins.movimentacao_bem_patrimonial import MovimentacaoBemPatrimonialAdmin
@@ -13,3 +17,4 @@ from .admins.movimentacao_bem_patrimonial import MovimentacaoBemPatrimonialAdmin
 admin.site.register(BemPatrimonial, BemPatrimonialAdmin)
 admin.site.register(MovimentacaoBemPatrimonial, MovimentacaoBemPatrimonialAdmin)
 admin.site.register(BaixaFisicaBemPatrimonial, BaixaFisicaBemPatrimonialAdmin)
+admin.site.register(TransferenciaBemPatrimonial, TransferenciaBemPatrimonialAdmin)

--- a/bem_patrimonial/admins/bem_patrimonial.py
+++ b/bem_patrimonial/admins/bem_patrimonial.py
@@ -29,15 +29,17 @@ from django.contrib.contenttypes.models import ContentType
 from django.contrib.auth import get_user_model
 
 from django.contrib.contenttypes.admin import GenericTabularInline
-from django.db.models.functions import Cast
+from django.db.models.functions import Cast, Concat
 from bem_patrimonial import constants
 from dados_comuns.models import HistoricoGeral, UnidadeAdministrativa
 from bem_patrimonial.admins.filters.baixados_periodo_filter import (
     BaixadosMaisDeUmPeriodoFilter,
 )
 from dados_comuns.escopo import (
+    filtrar_queryset_bem_por_escopo_com_transferencia,
     filtrar_queryset_por_escopo,
     filtrar_ua_origem_por_escopo,
+    obter_unidade_orcamentaria_id_do_usuario,
     usuario_e_super_admin,
 )
 
@@ -384,7 +386,7 @@ class BemPatrimonialAdmin(ImportExportModelAdmin):
         if obj and getattr(obj, "excluido", False):
             return False
 
-        if obj and obj.status == constants.BAIXA_FISICA:
+        if obj and obj.status in constants.STATUS_FINAIS_BEM:
             return False
 
         return True
@@ -399,7 +401,7 @@ class BemPatrimonialAdmin(ImportExportModelAdmin):
         if not request.user.is_gestor_patrimonio:
             return False
 
-        if obj.status == constants.BAIXA_FISICA:
+        if obj.status in constants.STATUS_FINAIS_BEM:
             return False
 
         return True
@@ -537,9 +539,9 @@ class BemPatrimonialAdmin(ImportExportModelAdmin):
     def save_model(self, request, obj, form, change):
         if change and obj.pk:
             original = BemPatrimonial.objects.get(pk=obj.pk)
-            if original.status == constants.BAIXA_FISICA:
+            if original.status in constants.STATUS_FINAIS_BEM:
                 raise ValidationError(
-                    "Este bem está com status 'Baixa Física' e não pode ser editado."
+                    f"Este bem está com status '{original.get_status_display()}' e não pode ser editado."
                 )
         if obj.id is None:
             obj.criado_por = request.user
@@ -590,11 +592,7 @@ class BemPatrimonialAdmin(ImportExportModelAdmin):
             .select_related("unidade_administrativa", "criado_por")
         )
 
-        qs = filtrar_queryset_por_escopo(
-            usuario=request.user,
-            queryset=qs,
-            campo_ua="unidade_administrativa",
-        )
+        qs = filtrar_queryset_bem_por_escopo_com_transferencia(request.user, qs)
 
         qs = self._anotar_baixa_data(qs)
 
@@ -905,18 +903,49 @@ class BemPatrimonialAdmin(ImportExportModelAdmin):
 
         if not (
             app_label == "bem_patrimonial"
-            and model_name in ("movimentacaobensitem", "baixafisicabensitem")
+            and model_name
+            in ("movimentacaobensitem", "baixafisicabensitem", "transferenciabensitem")
             and field_name == "bem"
         ):
             return qs, use_distinct
 
-        ua_origem = request.GET.get("ua_origem")
-        if not ua_origem:
-            return qs.none(), use_distinct
+        qs = qs.filter(status=constants.APROVADO)
 
-        qs = qs.filter(status=constants.APROVADO).filter(
-            unidade_administrativa_id=ua_origem
-        )
+        if model_name == "transferenciabensitem":
+            uo_referencia_id = obter_unidade_orcamentaria_id_do_usuario(request.user)
+            if not uo_referencia_id:
+                return qs.none(), use_distinct
+
+            qs = qs.filter(
+                unidade_administrativa__unidade_orcamentaria_id=uo_referencia_id
+            )
+
+            ua_origem = request.GET.get("ua_origem")
+            uo_origem = request.GET.get("uo_origem")
+            if ua_origem:
+                qs = qs.filter(unidade_administrativa_id=ua_origem)
+            elif uo_origem and str(uo_origem) != str(uo_referencia_id):
+                return qs.none(), use_distinct
+            else:
+                uo_origem = str(uo_referencia_id)
+
+            qs = qs.annotate(
+                autocomplete_label_transferencia=Concat(
+                    "unidade_administrativa__codigo",
+                    models.Value(" - "),
+                    "unidade_administrativa__sigla",
+                    models.Value(" | "),
+                    "numero_patrimonial",
+                    models.Value(" - "),
+                    "nome",
+                    output_field=models.CharField(),
+                )
+            )
+        else:
+            ua_origem = request.GET.get("ua_origem")
+            if not ua_origem:
+                return qs.none(), use_distinct
+            qs = qs.filter(unidade_administrativa_id=ua_origem)
 
         exclude_bens = request.GET.get("exclude_bens")
         if not exclude_bens:
@@ -942,16 +971,19 @@ class BemPatrimonialAdmin(ImportExportModelAdmin):
         request._busca_com_baixados_antigos = False
 
         qs, use_distinct = super().get_search_results(request, queryset, search_term)
-        qs = filtrar_queryset_por_escopo(
-            usuario=request.user,
-            queryset=qs,
-            campo_ua="unidade_administrativa",
-        )
 
         if request.path.endswith("/autocomplete/"):
+            if request.GET.get("model_name") != "transferenciabensitem":
+                qs = filtrar_queryset_por_escopo(
+                    usuario=request.user,
+                    queryset=qs,
+                    campo_ua="unidade_administrativa",
+                )
             return self._aplicar_filtros_autocomplete_bem(
                 request, qs, use_distinct
             )
+
+        qs = filtrar_queryset_bem_por_escopo_com_transferencia(request.user, qs)
 
         if (
             search_term

--- a/bem_patrimonial/admins/bem_patrimonial.py
+++ b/bem_patrimonial/admins/bem_patrimonial.py
@@ -926,8 +926,6 @@ class BemPatrimonialAdmin(ImportExportModelAdmin):
                 qs = qs.filter(unidade_administrativa_id=ua_origem)
             elif uo_origem and str(uo_origem) != str(uo_referencia_id):
                 return qs.none(), use_distinct
-            else:
-                uo_origem = str(uo_referencia_id)
 
             qs = qs.annotate(
                 autocomplete_label_transferencia=Concat(

--- a/bem_patrimonial/admins/forms/transferencia_bem_patrimonial_form.py
+++ b/bem_patrimonial/admins/forms/transferencia_bem_patrimonial_form.py
@@ -1,0 +1,139 @@
+from django import forms
+from django.core.exceptions import ValidationError
+
+from bem_patrimonial.models import TransferenciaBemPatrimonial
+from bem_patrimonial.admins.forms.movimentacao_bem_patrimonial_form import (
+    MENSAGEM_SEM_PONTO_CENTRAL,
+    obter_ua_ponto_central,
+    obter_uo_referencia_do_usuario,
+    queryset_uas_da_uo,
+)
+from dados_comuns.models import UnidadeAdministrativa, UnidadeOrcamentaria
+from dados_comuns.utils import PREFIXO_CODIGO_UO_SME
+
+
+def queryset_uos_destino_externas():
+    return UnidadeOrcamentaria.objects.filter(ativa=True).exclude(
+        codigo__startswith=PREFIXO_CODIGO_UO_SME
+    ).order_by("codigo", "nome")
+
+
+class TransferenciaBemPatrimonialForm(forms.ModelForm):
+    unidade_administrativa_filtro = forms.ModelChoiceField(
+        label="Filtrar bens por unidade administrativa",
+        queryset=UnidadeAdministrativa.objects.none(),
+        required=False,
+        empty_label="Todas as UAs da UO de origem",
+        help_text=(
+            "Use este filtro para localizar bens de uma UA específica. "
+            "Os bens já adicionados permanecem na lista mesmo quando o filtro mudar."
+        ),
+    )
+
+    class Meta:
+        model = TransferenciaBemPatrimonial
+        fields = (
+            "unidade_orcamentaria_origem",
+            "unidade_orcamentaria_destino",
+            "numero_processo",
+            "observacao",
+        )
+
+    def __init__(self, *args, **kwargs):
+        self.request = kwargs.pop("request", None)
+        super().__init__(*args, **kwargs)
+
+        user = self._get_user()
+        uo_origem = obter_uo_referencia_do_usuario(user)
+
+        possui_campo_uo_origem = "unidade_orcamentaria_origem" in self.fields
+        possui_campo_uo_destino = "unidade_orcamentaria_destino" in self.fields
+        possui_campo_processo = "numero_processo" in self.fields
+        possui_campo_observacao = "observacao" in self.fields
+        possui_campo_filtro_ua = "unidade_administrativa_filtro" in self.fields
+
+        if possui_campo_uo_origem:
+            self.fields["unidade_orcamentaria_origem"].queryset = UnidadeOrcamentaria.objects.none()
+        if possui_campo_uo_destino:
+            self.fields["unidade_orcamentaria_destino"].queryset = queryset_uos_destino_externas()
+        if possui_campo_filtro_ua and uo_origem:
+            self.fields["unidade_administrativa_filtro"].queryset = queryset_uas_da_uo(
+                uo_origem
+            )
+
+        if self.instance.pk:
+            if possui_campo_uo_origem:
+                self.fields["unidade_orcamentaria_origem"].queryset = UnidadeOrcamentaria.objects.filter(
+                    pk=self.instance.unidade_orcamentaria_origem_id
+                )
+                self.fields["unidade_orcamentaria_origem"].disabled = True
+            if possui_campo_uo_destino:
+                self.fields["unidade_orcamentaria_destino"].queryset = UnidadeOrcamentaria.objects.filter(
+                    pk=self.instance.unidade_orcamentaria_destino_id
+                )
+                self.fields["unidade_orcamentaria_destino"].disabled = True
+            if possui_campo_processo:
+                self.fields["numero_processo"].disabled = True
+            if possui_campo_observacao:
+                self.fields["observacao"].disabled = True
+            if possui_campo_filtro_ua:
+                self.fields["unidade_administrativa_filtro"].queryset = queryset_uas_da_uo(
+                    self.instance.unidade_orcamentaria_origem
+                )
+                self.fields["unidade_administrativa_filtro"].disabled = True
+            return
+
+        if uo_origem and possui_campo_uo_origem:
+            self.fields["unidade_orcamentaria_origem"].queryset = UnidadeOrcamentaria.objects.filter(
+                pk=uo_origem.pk
+            )
+            self.fields["unidade_orcamentaria_origem"].initial = uo_origem.pk
+
+        if possui_campo_uo_origem:
+            self.fields["unidade_orcamentaria_origem"].disabled = True
+
+    def _get_user(self):
+        if getattr(self, "request", None) and getattr(self.request, "user", None):
+            return self.request.user
+        return None
+
+    def clean(self):
+        cleaned_data = super().clean()
+        user = self._get_user()
+        uo_origem = getattr(self.instance, "unidade_orcamentaria_origem", None)
+
+        if not self.instance.pk:
+            uo_origem = obter_uo_referencia_do_usuario(user)
+            if not uo_origem:
+                raise ValidationError(
+                    {
+                        "unidade_orcamentaria_origem": "Não foi possível identificar a UO de origem do usuário."
+                    }
+                )
+            cleaned_data["unidade_orcamentaria_origem"] = uo_origem
+
+        uo_destino = cleaned_data.get("unidade_orcamentaria_destino")
+        if not uo_destino:
+            raise ValidationError(
+                {
+                    "unidade_orcamentaria_destino": "Unidade Orçamentária de destino é obrigatória."
+                }
+            )
+
+        if uo_origem and uo_destino.pk == uo_origem.pk:
+            raise ValidationError(
+                {
+                    "unidade_orcamentaria_destino": "A UO de destino deve ser diferente da UO de origem."
+                }
+            )
+
+        ua_destino = obter_ua_ponto_central(uo_destino)
+        if not ua_destino:
+            raise ValidationError(
+                {
+                    "unidade_orcamentaria_destino": MENSAGEM_SEM_PONTO_CENTRAL
+                }
+            )
+
+        cleaned_data["unidade_administrativa_destino"] = ua_destino
+        return cleaned_data

--- a/bem_patrimonial/admins/forms/transferencia_bem_patrimonial_form.py
+++ b/bem_patrimonial/admins/forms/transferencia_bem_patrimonial_form.py
@@ -46,51 +46,60 @@ class TransferenciaBemPatrimonialForm(forms.ModelForm):
         user = self._get_user()
         uo_origem = obter_uo_referencia_do_usuario(user)
 
-        possui_campo_uo_origem = "unidade_orcamentaria_origem" in self.fields
-        possui_campo_uo_destino = "unidade_orcamentaria_destino" in self.fields
-        possui_campo_processo = "numero_processo" in self.fields
-        possui_campo_observacao = "observacao" in self.fields
-        possui_campo_filtro_ua = "unidade_administrativa_filtro" in self.fields
+        self._configurar_campos_iniciais(uo_origem)
 
-        if possui_campo_uo_origem:
+        if self.instance.pk:
+            self._configurar_campos_edicao()
+            return
+
+        self._configurar_campos_criacao(uo_origem)
+
+    def _configurar_campos_iniciais(self, uo_origem):
+        if "unidade_orcamentaria_origem" in self.fields:
             self.fields["unidade_orcamentaria_origem"].queryset = UnidadeOrcamentaria.objects.none()
-        if possui_campo_uo_destino:
+
+        if "unidade_orcamentaria_destino" in self.fields:
             self.fields["unidade_orcamentaria_destino"].queryset = queryset_uos_destino_externas()
-        if possui_campo_filtro_ua and uo_origem:
+
+        if "unidade_administrativa_filtro" in self.fields and uo_origem:
             self.fields["unidade_administrativa_filtro"].queryset = queryset_uas_da_uo(
                 uo_origem
             )
 
-        if self.instance.pk:
-            if possui_campo_uo_origem:
-                self.fields["unidade_orcamentaria_origem"].queryset = UnidadeOrcamentaria.objects.filter(
-                    pk=self.instance.unidade_orcamentaria_origem_id
-                )
-                self.fields["unidade_orcamentaria_origem"].disabled = True
-            if possui_campo_uo_destino:
-                self.fields["unidade_orcamentaria_destino"].queryset = UnidadeOrcamentaria.objects.filter(
-                    pk=self.instance.unidade_orcamentaria_destino_id
-                )
-                self.fields["unidade_orcamentaria_destino"].disabled = True
-            if possui_campo_processo:
-                self.fields["numero_processo"].disabled = True
-            if possui_campo_observacao:
-                self.fields["observacao"].disabled = True
-            if possui_campo_filtro_ua:
-                self.fields["unidade_administrativa_filtro"].queryset = queryset_uas_da_uo(
-                    self.instance.unidade_orcamentaria_origem
-                )
-                self.fields["unidade_administrativa_filtro"].disabled = True
+    def _configurar_campos_edicao(self):
+        if "unidade_orcamentaria_origem" in self.fields:
+            self.fields["unidade_orcamentaria_origem"].queryset = UnidadeOrcamentaria.objects.filter(
+                pk=self.instance.unidade_orcamentaria_origem_id
+            )
+            self.fields["unidade_orcamentaria_origem"].disabled = True
+
+        if "unidade_orcamentaria_destino" in self.fields:
+            self.fields["unidade_orcamentaria_destino"].queryset = UnidadeOrcamentaria.objects.filter(
+                pk=self.instance.unidade_orcamentaria_destino_id
+            )
+            self.fields["unidade_orcamentaria_destino"].disabled = True
+
+        for field_name in ("numero_processo", "observacao"):
+            if field_name in self.fields:
+                self.fields[field_name].disabled = True
+
+        if "unidade_administrativa_filtro" in self.fields:
+            self.fields["unidade_administrativa_filtro"].queryset = queryset_uas_da_uo(
+                self.instance.unidade_orcamentaria_origem
+            )
+            self.fields["unidade_administrativa_filtro"].disabled = True
+
+    def _configurar_campos_criacao(self, uo_origem):
+        if "unidade_orcamentaria_origem" not in self.fields:
             return
 
-        if uo_origem and possui_campo_uo_origem:
+        if uo_origem:
             self.fields["unidade_orcamentaria_origem"].queryset = UnidadeOrcamentaria.objects.filter(
                 pk=uo_origem.pk
             )
             self.fields["unidade_orcamentaria_origem"].initial = uo_origem.pk
 
-        if possui_campo_uo_origem:
-            self.fields["unidade_orcamentaria_origem"].disabled = True
+        self.fields["unidade_orcamentaria_origem"].disabled = True
 
     def _get_user(self):
         if getattr(self, "request", None) and getattr(self.request, "user", None):

--- a/bem_patrimonial/admins/inlines/inlines.py
+++ b/bem_patrimonial/admins/inlines/inlines.py
@@ -1,10 +1,16 @@
+from functools import lru_cache
+
 from django.forms.models import BaseInlineFormSet, ModelForm
 from django.core.exceptions import ValidationError
 from django.contrib import admin
+from django.contrib.contenttypes.models import ContentType
+from django.urls import reverse
+from django.utils.html import format_html
 
 from bem_patrimonial.models import (
     MovimentacaoBensItem,
     BemPatrimonial,
+    TransferenciaBensItem,
 )
 from bem_patrimonial.constants import (
     APROVADO,
@@ -12,6 +18,7 @@ from bem_patrimonial.constants import (
     ENVIADA,
     AGUARDANDO_APROVACAO,
 )
+from dados_comuns.models import HistoricoGeral
 
 
 def _raise_bem_bloqueado_inventario(bem, item_bloqueante=None):
@@ -67,6 +74,50 @@ def _validate_bem_para_movimentacao(bem):
         )
 
 
+def _formatar_identificacao_bem_transferencia(bem):
+    numero_patrimonial = bem.numero_patrimonial or "SEM-NUMERO"
+    nome = bem.nome or "Sem nome"
+    unidade_administrativa = getattr(bem, "unidade_administrativa", None)
+    if unidade_administrativa:
+        return f"{unidade_administrativa} | {numero_patrimonial} - {nome}"
+    return f"{numero_patrimonial} - {nome}"
+
+
+def _normalizar_valor_historico_unidade_administrativa(valor):
+    if not valor:
+        return "-"
+
+    prefixo, separador, restante = valor.partition(" - ")
+    if separador and prefixo.isdigit():
+        return restante
+    return valor
+
+
+@lru_cache(maxsize=1)
+def _content_type_bem_patrimonial_id():
+    return ContentType.objects.get_for_model(BemPatrimonial).id
+
+
+def _obter_ua_origem_item_transferencia(item):
+    historico = (
+        HistoricoGeral.objects.filter(
+            content_type_id=_content_type_bem_patrimonial_id(),
+            object_id=str(item.bem_id),
+            campo="unidade_administrativa",
+        )
+        .order_by("-alterado_em")
+        .first()
+    )
+
+    if historico and historico.valor_antigo:
+        return _normalizar_valor_historico_unidade_administrativa(
+            historico.valor_antigo
+        )
+
+    unidade_administrativa = getattr(item.bem, "unidade_administrativa", None)
+    return str(unidade_administrativa) if unidade_administrativa else "-"
+
+
 class MovimentacaoBensItemInlineFormSet(BaseInlineFormSet):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -117,6 +168,89 @@ class MovimentacaoBensItemInline(admin.TabularInline):
     form = MovimentacaoBensItemInlineForm
     formset = MovimentacaoBensItemInlineFormSet
     autocomplete_fields = ("bem",)
+
+
+class TransferenciaBensItemInlineFormSet(BaseInlineFormSet):
+    def clean(self):
+        super().clean()
+
+        if any(self.errors):
+            return
+
+        bens_usados = []
+        for form in self.forms:
+            if form.cleaned_data.get("DELETE", False):
+                continue
+            bem = form.cleaned_data.get("bem")
+            if not bem:
+                continue
+            bens_usados.append(bem)
+            _validate_bem_para_movimentacao(bem)
+
+        if not bens_usados:
+            raise ValidationError("Adicione ao menos um bem na transferência.")
+
+
+class TransferenciaBensItemInlineForm(ModelForm):
+    class Meta:
+        model = TransferenciaBensItem
+        fields = ("bem",)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        if "bem" not in self.fields:
+            return
+
+        def _label(obj: BemPatrimonial):
+            return _formatar_identificacao_bem_transferencia(obj)
+
+        self.fields["bem"].label_from_instance = _label
+
+
+class TransferenciaBensItemInline(admin.TabularInline):
+    model = TransferenciaBensItem
+    extra = 1
+    form = TransferenciaBensItemInlineForm
+    formset = TransferenciaBensItemInlineFormSet
+    autocomplete_fields = ("bem",)
+    can_delete = False
+    template = "admin/edit_inline/transferencia_bens_tabular.html"
+
+    def get_queryset(self, request):
+        return super().get_queryset(request).select_related(
+            "bem",
+            "bem__unidade_administrativa",
+        )
+
+    def get_fields(self, request, obj=None):
+        if obj is None:
+            return ("bem",)
+        return ("bem_detalhado",)
+
+    def get_readonly_fields(self, request, obj=None):
+        if obj is None:
+            return ()
+        return ("bem_detalhado",)
+
+    def get_extra(self, request, obj=None, **kwargs):
+        if obj is None:
+            return self.extra
+        return 0
+
+    def bem_detalhado(self, obj):
+        numero_patrimonial = obj.bem.numero_patrimonial or "SEM-NUMERO"
+        nome = obj.bem.nome or "Sem nome"
+        unidade_administrativa = _obter_ua_origem_item_transferencia(obj)
+        return format_html(
+            '{} | <a href="{}" target="_blank">{} - {}</a>',
+            unidade_administrativa,
+            reverse("admin:bem_patrimonial_bempatrimonial_change", args=[obj.bem_id]),
+            numero_patrimonial,
+            nome,
+        )
+
+    bem_detalhado.short_description = "UA de origem | Bem patrimonial"
 
     def has_add_permission(self, request, obj=None):
 

--- a/bem_patrimonial/admins/transferencia_bem_patrimonial.py
+++ b/bem_patrimonial/admins/transferencia_bem_patrimonial.py
@@ -33,18 +33,17 @@ class TransferenciaBemPatrimonialAdmin(admin.ModelAdmin):
         "numero_processo",
         "observacao",
         "criado_por",
-        "efetivado_por",
         "criado_em",
-        "efetivado_em",
     )
 
     list_display = (
         "id",
+        "numero_ntbpm",
         "numero_processo",
         "unidade_orcamentaria_origem",
         "unidade_orcamentaria_destino",
         "criado_por",
-        "efetivado_em",
+        "criado_em",
     )
     search_fields = (
         "numero_processo",
@@ -68,9 +67,7 @@ class TransferenciaBemPatrimonialAdmin(admin.ModelAdmin):
         "numero_processo",
         "observacao",
         "criado_por",
-        "efetivado_por",
         "criado_em",
-        "efetivado_em",
     )
 
     class Media:
@@ -82,6 +79,7 @@ class TransferenciaBemPatrimonialAdmin(admin.ModelAdmin):
             "all": (
                 "css/prevenir_duplo_submit.css",
                 "css/custom_inline.css",
+                "css/transferencia_bem_patrimonial.css",
                 "css/hide_crud_icons.css",
             )
         }
@@ -133,7 +131,6 @@ class TransferenciaBemPatrimonialAdmin(admin.ModelAdmin):
                 "unidade_orcamentaria_destino",
                 "unidade_administrativa_destino",
                 "criado_por",
-                "efetivado_por",
             )
         )
         return filtrar_queryset_transferencia_por_escopo(request.user, qs).distinct()
@@ -223,7 +220,7 @@ class TransferenciaBemPatrimonialAdmin(admin.ModelAdmin):
         super().save_related(request, form, formsets, change)
 
         transferencia = form.instance
-        if not change and not transferencia.efetivado_em:
+        if not change and not transferencia.numero_ntbpm:
             transferencia.efetivar_transferencia(request.user)
 
     def get_inline_formsets(self, request, formsets, inline_instances, obj=None):

--- a/bem_patrimonial/admins/transferencia_bem_patrimonial.py
+++ b/bem_patrimonial/admins/transferencia_bem_patrimonial.py
@@ -1,0 +1,238 @@
+from django.contrib import admin
+from django.core.exceptions import PermissionDenied
+from django.db import transaction
+from django.urls import reverse
+from django.utils.html import format_html, format_html_join
+
+from bem_patrimonial.models import TransferenciaBemPatrimonial
+from bem_patrimonial.admins.forms.transferencia_bem_patrimonial_form import (
+    TransferenciaBemPatrimonialForm,
+)
+from bem_patrimonial.admins.inlines.inlines import TransferenciaBensItemInline
+from dados_comuns.escopo import filtrar_queryset_transferencia_por_escopo
+
+
+class TransferenciaBemPatrimonialAdmin(admin.ModelAdmin):
+    model = TransferenciaBemPatrimonial
+    form = TransferenciaBemPatrimonialForm
+    inlines = [TransferenciaBensItemInline]
+
+    create_fields = (
+        "unidade_orcamentaria_origem",
+        "unidade_orcamentaria_destino",
+        "numero_processo",
+        "observacao",
+        "unidade_administrativa_filtro",
+    )
+    change_fields = (
+        "numero_ntbpm",
+        "get_documento_ntbpm_link",
+        "unidade_orcamentaria_origem",
+        "unidade_orcamentaria_destino",
+        "unidade_administrativa_destino",
+        "numero_processo",
+        "observacao",
+        "criado_por",
+        "efetivado_por",
+        "criado_em",
+        "efetivado_em",
+    )
+
+    list_display = (
+        "id",
+        "numero_processo",
+        "unidade_orcamentaria_origem",
+        "unidade_orcamentaria_destino",
+        "criado_por",
+        "efetivado_em",
+    )
+    search_fields = (
+        "numero_processo",
+        "numero_ntbpm",
+        "unidade_orcamentaria_origem__codigo",
+        "unidade_orcamentaria_origem__nome",
+        "unidade_orcamentaria_destino__codigo",
+        "unidade_orcamentaria_destino__nome",
+        "itens__bem__numero_patrimonial",
+        "itens__bem__nome",
+    )
+    search_help_text = (
+        "Pesquise por número do processo, UO de origem/destino e número patrimonial ou nome do bem."
+    )
+    readonly_fields = (
+        "numero_ntbpm",
+        "get_documento_ntbpm_link",
+        "unidade_orcamentaria_origem",
+        "unidade_orcamentaria_destino",
+        "unidade_administrativa_destino",
+        "numero_processo",
+        "observacao",
+        "criado_por",
+        "efetivado_por",
+        "criado_em",
+        "efetivado_em",
+    )
+
+    class Media:
+        js = (
+            "js/bem_patrimonial/prevenir_duplo_submit.js",
+            "admin/transferencia_filtra_bens_por_uo.js",
+        )
+        css = {
+            "all": (
+                "css/prevenir_duplo_submit.css",
+                "css/custom_inline.css",
+                "css/hide_crud_icons.css",
+            )
+        }
+
+    def _usuario_pode_acessar(self, user):
+        return bool(getattr(user, "is_gestor_patrimonio", False))
+
+    def has_module_permission(self, request):
+        return self._usuario_pode_acessar(request.user)
+
+    def has_view_permission(self, request, obj=None):
+        return self._usuario_pode_acessar(request.user)
+
+    def has_add_permission(self, request):
+        return self._usuario_pode_acessar(request.user)
+
+    def has_change_permission(self, request, obj=None):
+        return self._usuario_pode_acessar(request.user)
+
+    def has_delete_permission(self, request, obj=None):
+        return False
+
+    def get_fields(self, request, obj=None):
+        if obj is None:
+            return self.create_fields
+        return self.change_fields
+
+    def get_readonly_fields(self, request, obj=None):
+        if obj is None:
+            return ()
+        return self.readonly_fields
+
+    def get_form(self, request, obj=None, **kwargs):
+        form_class = super().get_form(request, obj, **kwargs)
+
+        class RequestForm(form_class):
+            def __init__(self_inner, *a, **kw):
+                kw["request"] = request
+                super().__init__(*a, **kw)
+
+        return RequestForm
+
+    def get_queryset(self, request):
+        qs = (
+            super()
+            .get_queryset(request)
+            .select_related(
+                "unidade_orcamentaria_origem",
+                "unidade_orcamentaria_destino",
+                "unidade_administrativa_destino",
+                "criado_por",
+                "efetivado_por",
+            )
+        )
+        return filtrar_queryset_transferencia_por_escopo(request.user, qs).distinct()
+
+    def save_model(self, request, obj, form, change):
+        if obj.pk is None:
+            obj.criado_por = request.user
+        obj.unidade_administrativa_destino = form.cleaned_data[
+            "unidade_administrativa_destino"
+        ]
+        super().save_model(request, obj, form, change)
+
+    def get_documento_ntbpm_link(self, obj):
+        if obj and obj.numero_ntbpm:
+            url_protegida = reverse("download_documento_ntbpm", kwargs={"pk": obj.pk})
+            return format_html(
+                '<a href="{}" target="_blank">Baixar documento NTBPM</a>',
+                url_protegida,
+            )
+        return "Número NTBPM não gerado"
+
+    get_documento_ntbpm_link.short_description = "Documento NTBPM"
+
+    def _get_changeform_extra_context(self, object_id=None, extra_context=None):
+        context = dict(extra_context or {})
+
+        if object_id is not None:
+            context.update(
+                {
+                    "show_save": False,
+                    "show_save_and_continue": False,
+                    "show_save_and_add_another": False,
+                    "show_save_as_new": False,
+                    "show_delete": False,
+                    "show_delete_link": False,
+                    "show_close": True,
+                }
+            )
+
+        return context
+
+    def get_bens_transferidos_links(self, obj):
+        itens = list(
+            obj.itens.select_related("bem", "bem__unidade_administrativa").order_by(
+                "bem__numero_patrimonial", "bem__nome"
+            )
+        )
+        if not itens:
+            return "Nenhum bem vinculado"
+
+        return format_html(
+            "<ul>{}</ul>",
+            format_html_join(
+                "",
+                '<li><a href="{}" target="_blank">{}</a> <span>({})</span></li>',
+                (
+                    (
+                        reverse(
+                            "admin:bem_patrimonial_bempatrimonial_change",
+                            args=[item.bem_id],
+                        ),
+                        str(item.bem),
+                        str(getattr(item.bem, "unidade_administrativa", "-")),
+                    )
+                    for item in itens
+                ),
+            ),
+        )
+
+    get_bens_transferidos_links.short_description = "Bens transferidos"
+
+    def changeform_view(self, request, object_id=None, form_url="", extra_context=None):
+        if object_id is not None and request.method == "POST":
+            raise PermissionDenied(
+                "Transferencias existentes estao disponiveis apenas para visualizacao."
+            )
+
+        with transaction.atomic():
+            return super().changeform_view(
+                request,
+                object_id,
+                form_url,
+                self._get_changeform_extra_context(object_id, extra_context),
+            )
+
+    def save_related(self, request, form, formsets, change):
+        super().save_related(request, form, formsets, change)
+
+        transferencia = form.instance
+        if not change and not transferencia.efetivado_em:
+            transferencia.efetivar_transferencia(request.user)
+
+    def get_inline_formsets(self, request, formsets, inline_instances, obj=None):
+        inline_formsets = super().get_inline_formsets(
+            request, formsets, inline_instances, obj
+        )
+
+        if obj is not None:
+            for formset in inline_formsets:
+                formset.can_add = False
+                formset.can_delete = False
+        return inline_formsets

--- a/bem_patrimonial/api_serializers.py
+++ b/bem_patrimonial/api_serializers.py
@@ -14,8 +14,8 @@ User = get_user_model()
 
 _STATUS_BEM_INVALIDOS_PARA_BAIXA = {
     constants.BAIXA_FISICA_AGUARDANDO_APROVACAO,
-    constants.BAIXA_FISICA,
     constants.BLOQUEADO,
+    *constants.STATUS_FINAIS_BEM,
 }
 
 

--- a/bem_patrimonial/constants.py
+++ b/bem_patrimonial/constants.py
@@ -20,6 +20,7 @@ NAO_APROVADO = "nao_aprovado"
 BLOQUEADO = "bloqueado"
 BAIXA_FISICA_AGUARDANDO_APROVACAO = "baixa_fisica_aguardando_aprovacao"
 BAIXA_FISICA = "baixa_fisica"
+TRANSFERIDO = "transferido"
 
 STATUS = (
     (AGUARDANDO_APROVACAO, "Aguardando aprovação"),
@@ -28,6 +29,12 @@ STATUS = (
     (BLOQUEADO, "Bloqueado para movimentação"),
     (BAIXA_FISICA_AGUARDANDO_APROVACAO, "Baixa Física - Aguardando aprovação"),
     (BAIXA_FISICA, "Baixa Física"),
+    (TRANSFERIDO, "Transferido"),
+)
+
+STATUS_FINAIS_BEM = (
+    BAIXA_FISICA,
+    TRANSFERIDO,
 )
 # status movimentacao
 

--- a/bem_patrimonial/migrations/0034_bempatrimonial_status_transferido.py
+++ b/bem_patrimonial/migrations/0034_bempatrimonial_status_transferido.py
@@ -1,0 +1,53 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("bem_patrimonial", "0033_alter_bempatrimonial_localizacao_numero_processo_nullable"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="bempatrimonial",
+            name="status",
+            field=models.CharField(
+                choices=[
+                    ("aguardando_aprovacao", "Aguardando aprovação"),
+                    ("aprovado", "Aprovado"),
+                    ("nao_aprovado", "Não aprovado"),
+                    ("bloqueado", "Bloqueado para movimentação"),
+                    (
+                        "baixa_fisica_aguardando_aprovacao",
+                        "Baixa Física - Aguardando aprovação",
+                    ),
+                    ("baixa_fisica", "Baixa Física"),
+                    ("transferido", "Transferido"),
+                ],
+                default="aguardando_aprovacao",
+                max_length=50,
+                verbose_name="Status",
+            ),
+        ),
+        migrations.AlterField(
+            model_name="statusbempatrimonial",
+            name="status",
+            field=models.CharField(
+                choices=[
+                    ("aguardando_aprovacao", "Aguardando aprovação"),
+                    ("aprovado", "Aprovado"),
+                    ("nao_aprovado", "Não aprovado"),
+                    ("bloqueado", "Bloqueado para movimentação"),
+                    (
+                        "baixa_fisica_aguardando_aprovacao",
+                        "Baixa Física - Aguardando aprovação",
+                    ),
+                    ("baixa_fisica", "Baixa Física"),
+                    ("transferido", "Transferido"),
+                ],
+                default="aguardando_aprovacao",
+                max_length=50,
+                verbose_name="Status",
+            ),
+        ),
+    ]

--- a/bem_patrimonial/migrations/0035_transferenciabempatrimonial_and_more.py
+++ b/bem_patrimonial/migrations/0035_transferenciabempatrimonial_and_more.py
@@ -1,0 +1,148 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("bem_patrimonial", "0034_bempatrimonial_status_transferido"),
+        ("dados_comuns", "0012_unidadeorcamentaria_orgao_codigo_orgao"),
+        ("usuario", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="TransferenciaBemPatrimonial",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "numero_processo",
+                    models.CharField(max_length=64, verbose_name="Número do processo"),
+                ),
+                (
+                    "observacao",
+                    models.TextField(blank=True, verbose_name="Observação"),
+                ),
+                ("criado_em", models.DateTimeField(auto_now_add=True, verbose_name="Criado em")),
+                (
+                    "atualizado_em",
+                    models.DateTimeField(auto_now=True, verbose_name="Atualizado em"),
+                ),
+                (
+                    "efetivado_em",
+                    models.DateTimeField(blank=True, null=True, verbose_name="Efetivado em"),
+                ),
+                (
+                    "criado_por",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="transferencias_criadas",
+                        to="usuario.usuario",
+                        verbose_name="Criado por",
+                    ),
+                ),
+                (
+                    "efetivado_por",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="transferencias_efetivadas",
+                        to="usuario.usuario",
+                        verbose_name="Efetivado por",
+                    ),
+                ),
+                (
+                    "unidade_administrativa_destino",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="transferencias_recebidas",
+                        to="dados_comuns.unidadeadministrativa",
+                        verbose_name="Unidade administrativa de destino",
+                    ),
+                ),
+                (
+                    "unidade_orcamentaria_destino",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="transferencias_destino",
+                        to="dados_comuns.unidadeorcamentaria",
+                        verbose_name="Unidade orçamentária de destino",
+                    ),
+                ),
+                (
+                    "unidade_orcamentaria_origem",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="transferencias_origem",
+                        to="dados_comuns.unidadeorcamentaria",
+                        verbose_name="Unidade orçamentária de origem",
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "transferência de bem patrimonial",
+                "verbose_name_plural": "transferências de bens patrimoniais",
+            },
+        ),
+        migrations.CreateModel(
+            name="TransferenciaBensItem",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "bem",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="transferencias_itens",
+                        to="bem_patrimonial.bempatrimonial",
+                    ),
+                ),
+                (
+                    "transferencia",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="itens",
+                        to="bem_patrimonial.transferenciabempatrimonial",
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "item de transferência",
+                "verbose_name_plural": "itens de transferência",
+            },
+        ),
+        migrations.AddField(
+            model_name="transferenciabempatrimonial",
+            name="bens",
+            field=models.ManyToManyField(
+                blank=True,
+                related_name="transferencias",
+                through="bem_patrimonial.TransferenciaBensItem",
+                to="bem_patrimonial.bempatrimonial",
+                verbose_name="Bens patrimoniais",
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="transferenciabensitem",
+            constraint=models.UniqueConstraint(
+                fields=("transferencia", "bem"),
+                name="uniq_item_por_transferencia_bem",
+            ),
+        ),
+    ]

--- a/bem_patrimonial/migrations/0036_transferenciabempatrimonial_numero_ntbpm.py
+++ b/bem_patrimonial/migrations/0036_transferenciabempatrimonial_numero_ntbpm.py
@@ -1,0 +1,23 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("bem_patrimonial", "0035_transferenciabempatrimonial_and_more"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="transferenciabempatrimonial",
+            name="numero_ntbpm",
+            field=models.CharField(
+                blank=True,
+                db_index=True,
+                default="",
+                max_length=30,
+                unique=True,
+                verbose_name="Número NTBPM",
+            ),
+        ),
+    ]

--- a/bem_patrimonial/migrations/0037_alter_baixafisicabempatrimonial_criado_por_and_more.py
+++ b/bem_patrimonial/migrations/0037_alter_baixafisicabempatrimonial_criado_por_and_more.py
@@ -1,0 +1,41 @@
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ("bem_patrimonial", "0036_transferenciabempatrimonial_numero_ntbpm"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="baixafisicabempatrimonial",
+            name="criado_por",
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.PROTECT,
+                related_name="baixas_fisicas_criadas",
+                to=settings.AUTH_USER_MODEL,
+                verbose_name="Usuário que solicitou a baixa",
+            ),
+        ),
+        migrations.AlterField(
+            model_name="baixafisicabempatrimonial",
+            name="data_aprovacao",
+            field=models.DateTimeField(
+                blank=True,
+                null=True,
+                verbose_name="Data da aprovação",
+            ),
+        ),
+        migrations.AlterField(
+            model_name="baixafisicabempatrimonial",
+            name="data_criacao",
+            field=models.DateTimeField(
+                auto_now_add=True,
+                verbose_name="Data da solicitação",
+            ),
+        ),
+    ]

--- a/bem_patrimonial/migrations/0038_alter_transferenciabempatrimonial_numero_processo.py
+++ b/bem_patrimonial/migrations/0038_alter_transferenciabempatrimonial_numero_processo.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("bem_patrimonial", "0037_alter_baixafisicabempatrimonial_criado_por_and_more"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="transferenciabempatrimonial",
+            name="numero_processo",
+            field=models.CharField(
+                max_length=64,
+                unique=True,
+                verbose_name="Número do processo",
+            ),
+        ),
+    ]

--- a/bem_patrimonial/migrations/0039_remove_transferenciabempatrimonial_efetivado_por.py
+++ b/bem_patrimonial/migrations/0039_remove_transferenciabempatrimonial_efetivado_por.py
@@ -1,0 +1,15 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("bem_patrimonial", "0038_alter_transferenciabempatrimonial_numero_processo"),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name="transferenciabempatrimonial",
+            name="efetivado_por",
+        ),
+    ]

--- a/bem_patrimonial/migrations/0040_remove_transferenciabempatrimonial_efetivado_em.py
+++ b/bem_patrimonial/migrations/0040_remove_transferenciabempatrimonial_efetivado_em.py
@@ -1,0 +1,15 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("bem_patrimonial", "0039_remove_transferenciabempatrimonial_efetivado_por"),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name="transferenciabempatrimonial",
+            name="efetivado_em",
+        ),
+    ]

--- a/bem_patrimonial/models.py
+++ b/bem_patrimonial/models.py
@@ -27,6 +27,7 @@ from bem_patrimonial import constants
 NPAT_NUM_REGEX = r"^\d{3}\.\d{9}-\d$"
 NPAT_AUTO_REGEX = r"^SEM-NUMERO-\d+$"
 
+VERBOSE_CRIADO_EM = "Criado em"
 VERBOSE_ATUALIZADO_EM = "Atualizado em"
 
 
@@ -154,7 +155,7 @@ class BemPatrimonial(BaseModel):
         null=True,
         blank=True,
     )
-    criado_em = models.DateTimeField("Criado em", auto_now_add=True)
+    criado_em = models.DateTimeField(VERBOSE_CRIADO_EM, auto_now_add=True)
     atualizado_em = models.DateTimeField(
         VERBOSE_ATUALIZADO_EM, auto_now=True, blank=True
     )
@@ -482,7 +483,7 @@ class MovimentacaoBemPatrimonial(models.Model):
         null=True,
         blank=True,
     )
-    criado_em = models.DateTimeField("Criado em", auto_now_add=True)
+    criado_em = models.DateTimeField(VERBOSE_CRIADO_EM, auto_now_add=True)
     atualizado_em = models.DateTimeField(
         VERBOSE_ATUALIZADO_EM, auto_now=True, blank=True
     )
@@ -653,7 +654,7 @@ class TransferenciaBemPatrimonial(models.Model):
         null=False,
         blank=False,
     )
-    criado_em = models.DateTimeField("Criado em", auto_now_add=True)
+    criado_em = models.DateTimeField(VERBOSE_CRIADO_EM, auto_now_add=True)
     atualizado_em = models.DateTimeField(
         VERBOSE_ATUALIZADO_EM, auto_now=True, blank=True
     )

--- a/bem_patrimonial/models.py
+++ b/bem_patrimonial/models.py
@@ -10,8 +10,12 @@ from django.utils import timezone
 from django.contrib.contenttypes.models import ContentType
 from dados_comuns.models import HistoricoGeral
 from dados_comuns.context import get_user
-from dados_comuns.utils import dict_changes
-from dados_comuns.models import UnidadeAdministrativa
+from dados_comuns.utils import (
+    CODIGO_UA_PONTO_CENTRAL,
+    dict_changes,
+    unidade_orcamentaria_eh_externa,
+)
+from dados_comuns.models import UnidadeAdministrativa, UnidadeOrcamentaria
 from usuario.models import Usuario
 from bem_patrimonial.emails import (
     envia_email_nova_solicitacao_movimentacao,
@@ -175,6 +179,11 @@ class BemPatrimonial(BaseModel):
     AUDIT_IGNORE_FIELDS = ("id", "criado_em", "atualizado_em", "criado_por")
 
     def __str__(self):
+        label_autocomplete_transferencia = getattr(
+            self, "autocomplete_label_transferencia", None
+        )
+        if label_autocomplete_transferencia:
+            return label_autocomplete_transferencia
         return (
             f"{self.numero_patrimonial} - {self.nome}"
             if self.numero_patrimonial
@@ -559,6 +568,227 @@ class MovimentacaoBemPatrimonial(models.Model):
             bem = item.bem
             bem.status = constants.APROVADO
             bem.save()
+
+
+class TransferenciaBensItem(models.Model):
+
+    bem = models.ForeignKey(
+        BemPatrimonial,
+        on_delete=models.CASCADE,
+        related_name="transferencias_itens",
+    )
+    transferencia = models.ForeignKey(
+        "TransferenciaBemPatrimonial",
+        on_delete=models.CASCADE,
+        related_name="itens",
+    )
+
+    class Meta:
+        verbose_name = "item de transferência"
+        verbose_name_plural = "itens de transferência"
+        constraints = [
+            models.UniqueConstraint(
+                fields=["transferencia", "bem"],
+                name="uniq_item_por_transferencia_bem",
+            )
+        ]
+
+    def __str__(self):
+        return f"Transf#{self.transferencia_id} • {self.bem}"
+
+
+class TransferenciaBemPatrimonial(models.Model):
+    unidade_orcamentaria_origem = models.ForeignKey(
+        UnidadeOrcamentaria,
+        related_name="transferencias_origem",
+        verbose_name="Unidade orçamentária de origem",
+        on_delete=models.PROTECT,
+        null=False,
+        blank=False,
+    )
+    unidade_orcamentaria_destino = models.ForeignKey(
+        UnidadeOrcamentaria,
+        related_name="transferencias_destino",
+        verbose_name="Unidade orçamentária de destino",
+        on_delete=models.PROTECT,
+        null=False,
+        blank=False,
+    )
+    unidade_administrativa_destino = models.ForeignKey(
+        UnidadeAdministrativa,
+        related_name="transferencias_recebidas",
+        verbose_name="Unidade administrativa de destino",
+        on_delete=models.PROTECT,
+        null=False,
+        blank=False,
+    )
+    bens = models.ManyToManyField(
+        BemPatrimonial,
+        through="TransferenciaBensItem",
+        related_name="transferencias",
+        verbose_name="Bens patrimoniais",
+        blank=True,
+    )
+    numero_processo = models.CharField(
+        "Número do processo",
+        max_length=64,
+        null=False,
+        blank=False,
+    )
+    numero_ntbpm = models.CharField(
+        "Número NTBPM",
+        max_length=30,
+        unique=True,
+        blank=True,
+        default="",
+        db_index=True,
+    )
+    observacao = models.TextField("Observação", blank=True)
+    criado_por = models.ForeignKey(
+        Usuario,
+        verbose_name="Criado por",
+        related_name="transferencias_criadas",
+        on_delete=models.PROTECT,
+        null=False,
+        blank=False,
+    )
+    efetivado_por = models.ForeignKey(
+        Usuario,
+        verbose_name="Efetivado por",
+        related_name="transferencias_efetivadas",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+    )
+    criado_em = models.DateTimeField("Criado em", auto_now_add=True)
+    atualizado_em = models.DateTimeField(
+        VERBOSE_ATUALIZADO_EM, auto_now=True, blank=True
+    )
+    efetivado_em = models.DateTimeField("Efetivado em", null=True, blank=True)
+
+    class Meta:
+        verbose_name = "transferência de bem patrimonial"
+        verbose_name_plural = "transferências de bens patrimoniais"
+
+    def __str__(self):
+        return f"Transferência #{self.pk}"
+
+    def _validar_destino(self):
+        if not unidade_orcamentaria_eh_externa(self.unidade_orcamentaria_destino):
+            raise ValidationError(
+                {
+                    "unidade_orcamentaria_destino": (
+                        "A Unidade Orçamentária de destino deve ser externa à SME."
+                    )
+                }
+            )
+
+        if (
+            self.unidade_administrativa_destino.unidade_orcamentaria_id
+            != self.unidade_orcamentaria_destino_id
+        ):
+            raise ValidationError(
+                {
+                    "unidade_administrativa_destino": (
+                        "A Unidade Administrativa de destino não pertence à UO informada."
+                    )
+                }
+            )
+
+        codigo_destino = (self.unidade_administrativa_destino.codigo or "").strip()
+        if not (
+            codigo_destino == CODIGO_UA_PONTO_CENTRAL
+            or codigo_destino.endswith(f".{CODIGO_UA_PONTO_CENTRAL}")
+        ):
+            raise ValidationError(
+                {
+                    "unidade_administrativa_destino": (
+                        "A transferência deve usar a UA 001 da UO de destino."
+                    )
+                }
+            )
+
+        if not self.unidade_administrativa_destino.is_ativa:
+            raise ValidationError(
+                {
+                    "unidade_administrativa_destino": (
+                        "A Unidade Administrativa de destino está inativa."
+                    )
+                }
+            )
+
+    def _obter_itens_para_efetivar(self):
+        itens = list(
+            self.itens.select_related(
+                "bem",
+                "bem__unidade_administrativa",
+                "bem__unidade_administrativa__unidade_orcamentaria",
+            )
+        )
+
+        if not itens:
+            raise ValidationError("Não é possível efetivar transferência sem bens.")
+
+        return itens
+
+    def _validar_bens(self, itens):
+        for item in itens:
+            bem = item.bem
+            if bem.status != constants.APROVADO:
+                raise ValidationError(
+                    f"O bem '{bem.nome}' precisa estar com status 'Aprovado' para ser transferido."
+                )
+
+            unidade_administrativa = bem.unidade_administrativa
+            unidade_orcamentaria = getattr(
+                unidade_administrativa, "unidade_orcamentaria", None
+            )
+            if not unidade_orcamentaria or unidade_orcamentaria.pk != self.unidade_orcamentaria_origem_id:
+                raise ValidationError(
+                    f"O bem '{bem.nome}' não pertence à UO de origem da transferência."
+                )
+
+    @transaction.atomic
+    def efetivar_transferencia(self, usuario):
+        if self.efetivado_em:
+            return
+
+        self._validar_destino()
+        itens = self._obter_itens_para_efetivar()
+        self._validar_bens(itens)
+
+        observacao_status = (
+            f"Transferência concluída para {self.unidade_orcamentaria_destino} "
+            f"(processo {self.numero_processo})."
+        )
+
+        for item in itens:
+            bem = item.bem
+            bem.unidade_administrativa = self.unidade_administrativa_destino
+            bem.status = constants.TRANSFERIDO
+            bem.save(update_fields=["unidade_administrativa", "status", "atualizado_em"])
+
+            StatusBemPatrimonial.objects.create(
+                bem_patrimonial=bem,
+                status=constants.TRANSFERIDO,
+                atualizado_por=usuario,
+                observacao=observacao_status,
+            )
+
+        self.efetivado_por = usuario
+        self.efetivado_em = timezone.now()
+        if not self.numero_ntbpm:
+            from bem_patrimonial.ntbpm import gerar_numero_ntbpm
+
+            self.numero_ntbpm = gerar_numero_ntbpm(self)
+        self.save(
+            update_fields=[
+                "efetivado_por",
+                "efetivado_em",
+                "numero_ntbpm",
+                "atualizado_em",
+            ]
+        )
 
 
 @receiver(post_save, sender=BemPatrimonial)

--- a/bem_patrimonial/models.py
+++ b/bem_patrimonial/models.py
@@ -632,6 +632,7 @@ class TransferenciaBemPatrimonial(models.Model):
     numero_processo = models.CharField(
         "Número do processo",
         max_length=64,
+        unique=True,
         null=False,
         blank=False,
     )
@@ -652,19 +653,10 @@ class TransferenciaBemPatrimonial(models.Model):
         null=False,
         blank=False,
     )
-    efetivado_por = models.ForeignKey(
-        Usuario,
-        verbose_name="Efetivado por",
-        related_name="transferencias_efetivadas",
-        on_delete=models.SET_NULL,
-        null=True,
-        blank=True,
-    )
     criado_em = models.DateTimeField("Criado em", auto_now_add=True)
     atualizado_em = models.DateTimeField(
         VERBOSE_ATUALIZADO_EM, auto_now=True, blank=True
     )
-    efetivado_em = models.DateTimeField("Efetivado em", null=True, blank=True)
 
     class Meta:
         verbose_name = "transferência de bem patrimonial"
@@ -718,16 +710,26 @@ class TransferenciaBemPatrimonial(models.Model):
             )
 
     def _obter_itens_para_efetivar(self):
-        itens = list(
-            self.itens.select_related(
-                "bem",
-                "bem__unidade_administrativa",
-                "bem__unidade_administrativa__unidade_orcamentaria",
-            )
-        )
+        itens = list(self.itens.select_for_update().all())
 
         if not itens:
             raise ValidationError("Não é possível efetivar transferência sem bens.")
+
+        bens_por_id = BemPatrimonial.objects.select_for_update().in_bulk(
+            [item.bem_id for item in itens]
+        )
+        uas_por_id = UnidadeAdministrativa.objects.in_bulk(
+            {
+                bem.unidade_administrativa_id
+                for bem in bens_por_id.values()
+                if bem.unidade_administrativa_id
+            }
+        )
+
+        for item in itens:
+            bem = bens_por_id[item.bem_id]
+            bem.unidade_administrativa = uas_por_id.get(bem.unidade_administrativa_id)
+            item.bem = bem
 
         return itens
 
@@ -740,31 +742,35 @@ class TransferenciaBemPatrimonial(models.Model):
                 )
 
             unidade_administrativa = bem.unidade_administrativa
-            unidade_orcamentaria = getattr(
-                unidade_administrativa, "unidade_orcamentaria", None
-            )
-            if not unidade_orcamentaria or unidade_orcamentaria.pk != self.unidade_orcamentaria_origem_id:
+            if (
+                not unidade_administrativa
+                or unidade_administrativa.unidade_orcamentaria_id
+                != self.unidade_orcamentaria_origem_id
+            ):
                 raise ValidationError(
                     f"O bem '{bem.nome}' não pertence à UO de origem da transferência."
                 )
 
     @transaction.atomic
     def efetivar_transferencia(self, usuario):
-        if self.efetivado_em:
+        transferencia = type(self).objects.select_for_update().get(pk=self.pk)
+
+        if transferencia.numero_ntbpm:
+            self.refresh_from_db()
             return
 
-        self._validar_destino()
-        itens = self._obter_itens_para_efetivar()
-        self._validar_bens(itens)
+        transferencia._validar_destino()
+        itens = transferencia._obter_itens_para_efetivar()
+        transferencia._validar_bens(itens)
 
         observacao_status = (
-            f"Transferência concluída para {self.unidade_orcamentaria_destino} "
-            f"(processo {self.numero_processo})."
+            f"Transferência concluída para {transferencia.unidade_orcamentaria_destino} "
+            f"(processo {transferencia.numero_processo})."
         )
 
         for item in itens:
             bem = item.bem
-            bem.unidade_administrativa = self.unidade_administrativa_destino
+            bem.unidade_administrativa = transferencia.unidade_administrativa_destino
             bem.status = constants.TRANSFERIDO
             bem.save(update_fields=["unidade_administrativa", "status", "atualizado_em"])
 
@@ -774,21 +780,17 @@ class TransferenciaBemPatrimonial(models.Model):
                 atualizado_por=usuario,
                 observacao=observacao_status,
             )
-
-        self.efetivado_por = usuario
-        self.efetivado_em = timezone.now()
-        if not self.numero_ntbpm:
+        if not transferencia.numero_ntbpm:
             from bem_patrimonial.ntbpm import gerar_numero_ntbpm
 
-            self.numero_ntbpm = gerar_numero_ntbpm(self)
-        self.save(
+            transferencia.numero_ntbpm = gerar_numero_ntbpm(transferencia)
+        transferencia.save(
             update_fields=[
-                "efetivado_por",
-                "efetivado_em",
                 "numero_ntbpm",
                 "atualizado_em",
             ]
         )
+        self.refresh_from_db()
 
 
 @receiver(post_save, sender=BemPatrimonial)

--- a/bem_patrimonial/ntbpm.py
+++ b/bem_patrimonial/ntbpm.py
@@ -2,15 +2,24 @@ from io import BytesIO
 
 from django.core.exceptions import ValidationError
 from django.db import transaction
-from django.db.models import IntegerField, Max
-from django.db.models.functions import Cast, Substr
+from django.db.models import IntegerField, Max, Value
+from django.db.models.functions import Cast, Replace, Substr
 from django.utils import timezone
 
+from reportlab.lib import colors
 from reportlab.lib.pagesizes import A4
 from reportlab.lib.units import cm
 from reportlab.lib.styles import getSampleStyleSheet
 from reportlab.lib.enums import TA_LEFT
-from reportlab.platypus import BaseDocTemplate, Frame, PageTemplate, Spacer, Paragraph, Table
+from reportlab.platypus import (
+    BaseDocTemplate,
+    Frame,
+    PageTemplate,
+    Spacer,
+    Paragraph,
+    Table,
+    TableStyle,
+)
 
 from bem_patrimonial.models import TransferenciaBemPatrimonial
 from bem_patrimonial.pdf_utils import (
@@ -23,7 +32,6 @@ from bem_patrimonial.pdf_utils import (
 from bem_patrimonial.documentos_pdf_utils import (
     aplicar_estilo_tabela_info,
     criar_cabecalho_registro_documento,
-    criar_linha_ua_info,
     criar_tabela_bens_padrao,
     criar_tabela_rodape_responsaveis,
     criar_tabela_total_bens,
@@ -44,37 +52,45 @@ def gerar_numero_ntbpm(transferencia):
     if not isinstance(transferencia, TransferenciaBemPatrimonial):
         raise ValidationError("Objeto inválido para geração de NTBPM.")
 
+    """
+    Modelo alinhado ao NBBPM: <COD_UA_DESTINO>.<SEQ_7>.<ANO>
+    Ex: 001.0000001.2026
+    """
+
     ano_transferencia = (
-        transferencia.efetivado_em.year
-        if transferencia.efetivado_em
+        transferencia.criado_em.year
+        if transferencia.criado_em
         else timezone.localdate().year
     )
-    codigo_origem = extrair_codigo_ua(transferencia.unidade_orcamentaria_origem.codigo)
-    codigo_destino = extrair_codigo_ua(transferencia.unidade_orcamentaria_destino.codigo)
+    codigo_ua_destino = extrair_codigo_ua(
+        getattr(transferencia.unidade_administrativa_destino, "codigo", "")
+    )
 
     with transaction.atomic():
-        ultimo_sequencial = (
+        qs = (
             TransferenciaBemPatrimonial.objects.select_for_update()
             .filter(
                 numero_ntbpm__endswith=f".{ano_transferencia}",
                 numero_ntbpm__isnull=False,
             )
             .exclude(numero_ntbpm__exact="")
-            .annotate(sequencial_str=Substr("numero_ntbpm", 9, 7))
-            .aggregate(max_seq=Max(Cast("sequencial_str", IntegerField())))
-        )["max_seq"]
+        )
+
+        sequencial_raw = Substr("numero_ntbpm", 5, 7)
+        sequencial_digits = Replace(sequencial_raw, Value("."), Value(""))
+
+        ultimo_sequencial = qs.annotate(
+            sequencial_int=Cast(sequencial_digits, IntegerField())
+        ).aggregate(max_seq=Max("sequencial_int"))["max_seq"]
 
         numero_sequencial = (ultimo_sequencial or 0) + 1
 
-    return f"{codigo_origem}.{codigo_destino}.{numero_sequencial:07d}.{ano_transferencia}"
+    return f"{codigo_ua_destino}.{numero_sequencial:07d}.{ano_transferencia}"
 
 
 def gerar_pdf_ntbpm(transferencia, usuario_gerador=None, data_geracao=None):
     if not isinstance(transferencia, TransferenciaBemPatrimonial):
         raise ValidationError("Objeto inválido para gerar NTBPM.")
-
-    if not transferencia.efetivado_em:
-        raise ValidationError("Só é possível gerar NTBPM para transferências efetivadas.")
 
     if not getattr(transferencia, "numero_ntbpm", None):
         transferencia.numero_ntbpm = gerar_numero_ntbpm(transferencia)
@@ -116,6 +132,8 @@ def gerar_pdf_ntbpm(transferencia, usuario_gerador=None, data_geracao=None):
     elements.extend(_criar_tabela_bens(transferencia))
     elements.append(Spacer(1, 0.1 * cm))
     elements.extend(_criar_total_bens(transferencia))
+    elements.append(Spacer(1, 0.2 * cm))
+    elements.extend(_criar_informacoes_complementares(transferencia))
 
     doc.build(elements)
     buffer.seek(0)
@@ -156,22 +174,108 @@ def _criar_cabecalho_e_registro_ntbpm(transferencia):
         label_data_2="ACEITE",
         label_numero="NÚMERO NTBPM",
         valor_data_1=formatar_data(transferencia.criado_em),
-        valor_data_2=formatar_data(transferencia.efetivado_em),
+        valor_data_2=formatar_data(transferencia.criado_em),
         valor_numero=transferencia.numero_ntbpm or "",
         config_cls=PDFConfig,
     )
 
 
-def _criar_linha_ua(unidade_orcamentaria, label, sigla, nome, codigo, label_style, value_style):
-    return criar_linha_ua_info(
-        unidade_orcamentaria=unidade_orcamentaria,
-        label=label,
-        sigla=sigla,
-        nome=nome,
-        codigo=codigo,
-        label_style=label_style,
-        value_style=value_style,
+def _criar_linha_uo(label, sigla, nome, codigo, label_style, value_style):
+    return [
+        [
+            Paragraph("<b>PREFIXO</b>", label_style),
+            Paragraph(f"<b>{label}</b>", label_style),
+            Paragraph("<b>CÓDIGO</b>", label_style),
+        ],
+        [
+            Paragraph(str(sigla or "-").upper(), value_style),
+            Paragraph(str(nome or "-").upper(), value_style),
+            Paragraph(str(codigo or "-"), value_style),
+        ],
+    ]
+
+
+def _criar_linha_orgao(sigla_orgao, orgao, codigo_orgao, label_style, value_style):
+    return [
+        [
+            Paragraph("<b>PREFIXO</b>", label_style),
+            Paragraph("<b>ÓRGÃO</b>", label_style),
+            Paragraph("<b>CÓDIGO</b>", label_style),
+        ],
+        [
+            Paragraph(str(sigla_orgao or "-").upper(), value_style),
+            Paragraph(str(orgao or "-").upper(), value_style),
+            Paragraph(str(codigo_orgao or "-"), value_style),
+        ],
+    ]
+
+
+def _criar_tabela_resumo_transferencia(transferencia, label_style, value_style):
+    resumo_table = Table(
+        [
+            [
+                Paragraph("<b>NÚMERO DO PROCESSO</b>", label_style),
+                Paragraph("<b>DATA DA TRANSFERÊNCIA</b>", label_style),
+                Paragraph("<b>STATUS</b>", label_style),
+            ],
+            [
+                Paragraph(
+                    str(transferencia.numero_processo or "-").upper(),
+                    value_style,
+                ),
+                Paragraph(
+                    transferencia.criado_em.strftime(DATE_FMT_BR)
+                    if transferencia.criado_em
+                    else "-",
+                    value_style,
+                ),
+                Paragraph("TRANSFERIDO", value_style),
+            ],
+        ],
+        colWidths=[8 * cm, 5 * cm, 5 * cm],
     )
+    resumo_table.setStyle(
+        TableStyle(
+            [
+                ("BACKGROUND", (0, 0), (2, 0), PDFConfig.COR_CINZA_CLARO),
+                ("ALIGN", (0, 0), (-1, -1), "LEFT"),
+                ("VALIGN", (0, 0), (-1, -1), "TOP"),
+                ("LEFTPADDING", (0, 0), (-1, -1), 4),
+                ("RIGHTPADDING", (0, 0), (-1, -1), 4),
+                ("TOPPADDING", (0, 0), (-1, -1), 3),
+                ("BOTTOMPADDING", (0, 0), (-1, -1), 3),
+                ("BOX", (0, 0), (-1, -1), 1, colors.black),
+                ("INNERGRID", (0, 0), (-1, -1), 0.5, colors.grey),
+            ]
+        )
+    )
+    return resumo_table
+
+
+def _criar_tabela_observacao(transferencia, label_style, value_style):
+    observacao_table = Table(
+        [
+            [Paragraph("<b>OBSERVAÇÃO</b>", label_style)],
+            [Paragraph(str(transferencia.observacao or "-"), value_style)],
+        ],
+        colWidths=[18 * cm],
+    )
+    observacao_table.setStyle(
+        TableStyle(
+            [
+                ("BACKGROUND", (0, 0), (0, 0), PDFConfig.COR_CINZA_CLARO),
+                ("ALIGN", (0, 0), (-1, -1), "LEFT"),
+                ("VALIGN", (0, 0), (-1, -1), "TOP"),
+                ("LEFTPADDING", (0, 0), (-1, -1), 4),
+                ("RIGHTPADDING", (0, 0), (-1, -1), 4),
+                ("TOPPADDING", (0, 0), (-1, -1), 3),
+                ("BOTTOMPADDING", (0, 0), (-1, -1), 3),
+                ("BOX", (0, 0), (-1, -1), 1, colors.black),
+                ("INNERGRID", (0, 0), (-1, -1), 0.5, colors.grey),
+            ]
+        )
+    )
+    return observacao_table
 
 
 def _criar_informacoes_gerais(transferencia):
@@ -192,25 +296,21 @@ def _criar_informacoes_gerais(transferencia):
     )
 
     uo_origem = transferencia.unidade_orcamentaria_origem
-    ua_destino = transferencia.unidade_administrativa_destino
+    uo_destino = transferencia.unidade_orcamentaria_destino
 
-    info_data = [
-        [
-            Paragraph("<b>PREFIXO</b>", label_style),
-            Paragraph("<b>ÓRGÃO</b>", label_style),
-            Paragraph("<b>CÓDIGO</b>", label_style),
-        ],
-        [
-            Paragraph("SME", value_style),
-            Paragraph("SECRETARIA MUNICIPAL DE EDUCAÇÃO", value_style),
-            Paragraph("16", value_style),
-        ],
-    ]
-
+    info_data = []
     info_data.extend(
-        _criar_linha_ua(
-            uo_origem.nome,
-            "UNIDADE ORÇAMENTÁRIA DE ORIGEM",
+        _criar_linha_orgao(
+            getattr(uo_origem, "sigla_orgao", "-"),
+            getattr(uo_origem, "orgao", "-"),
+            getattr(uo_origem, "codigo_orgao", "-"),
+            label_style,
+            value_style,
+        )
+    )
+    info_data.extend(
+        _criar_linha_uo(
+            "UNIDADE ORÇAMENTÁRIA QUE TRANSFERE",
             getattr(uo_origem, "sigla", "-"),
             getattr(uo_origem, "nome", "-"),
             getattr(uo_origem, "codigo", "-"),
@@ -218,43 +318,38 @@ def _criar_informacoes_gerais(transferencia):
             value_style,
         )
     )
-
     info_data.extend(
-        _criar_linha_ua(
-            ua_destino.unidade_orcamentaria.nome,
-            "UNIDADE ORÇAMENTÁRIA / UNIDADE ADMINISTRATIVA DE DESTINO",
-            getattr(ua_destino, "sigla", "-"),
-            getattr(ua_destino, "nome", "-"),
-            getattr(ua_destino, "codigo", "-"),
+        _criar_linha_orgao(
+            getattr(uo_destino, "sigla_orgao", "-"),
+            getattr(uo_destino, "orgao", "-"),
+            getattr(uo_destino, "codigo_orgao", "-"),
+            label_style,
+            value_style,
+        )
+    )
+    info_data.extend(
+        _criar_linha_uo(
+            "UNIDADE ORÇAMENTÁRIA QUE RECEBE",
+            getattr(uo_destino, "sigla", "-"),
+            getattr(uo_destino, "nome", "-"),
+            getattr(uo_destino, "codigo", "-"),
             label_style,
             value_style,
         )
     )
 
-    info_data.extend(
-        [
-            [
-                Paragraph("<b>NÚMERO DO PROCESSO</b>", label_style),
-                Paragraph("<b>DATA DA TRANSFERÊNCIA</b>", label_style),
-                Paragraph("<b>STATUS</b>", label_style),
-            ],
-            [
-                Paragraph(str(transferencia.numero_processo or "-").upper(), value_style),
-                Paragraph(
-                    transferencia.efetivado_em.strftime(DATE_FMT_BR)
-                    if transferencia.efetivado_em
-                    else "-",
-                    value_style,
-                ),
-                Paragraph("TRANSFERIDO", value_style),
-            ],
-        ]
+    info_table = Table(info_data, colWidths=[4.0 * cm, 10.5 * cm, 3.5 * cm])
+    aplicar_estilo_tabela_info(
+        info_table,
+        linhas_cabecalho=[0, 2, 4, 6],
+        config_cls=PDFConfig,
     )
 
-    info_table = Table(info_data, colWidths=[5.0 * cm, 10.0 * cm, 3.0 * cm])
-    aplicar_estilo_tabela_info(info_table, linhas_cabecalho=[0, 2, 4], config_cls=PDFConfig)
-
-    return [info_table]
+    return [
+        info_table,
+        Spacer(1, 0.1 * cm),
+        _criar_tabela_resumo_transferencia(transferencia, label_style, value_style),
+    ]
 
 
 def _criar_tabela_bens(transferencia):
@@ -271,14 +366,39 @@ def _criar_total_bens(transferencia):
     return criar_tabela_total_bens(bens=bens, config_cls=PDFConfig)
 
 
+def _criar_informacoes_complementares(transferencia):
+    styles = getSampleStyleSheet()
+    label_style = criar_estilo_base(
+        "ComplementoLabelNTBPM",
+        styles,
+        config_cls=PDFConfig,
+        fontName="Helvetica-Bold",
+        alignment=TA_LEFT,
+    )
+    value_style = criar_estilo_base(
+        "ComplementoValueNTBPM",
+        styles,
+        config_cls=PDFConfig,
+        alignment=TA_LEFT,
+    )
+
+    return [
+        _criar_tabela_observacao(
+            transferencia,
+            label_style,
+            value_style,
+        )
+    ]
+
+
 def _criar_rodape_ntbpm(transferencia):
     responsavel_transferencia = obter_rf_usuario(getattr(transferencia, "criado_por", None))
-    unidade_destino = str(getattr(transferencia, "unidade_administrativa_destino", "-"))
+    responsavel_recebimento = obter_rf_usuario(getattr(transferencia, "criado_por", None))
 
     return criar_tabela_rodape_responsaveis(
         label_esquerda="RESPONSÁVEL DA UNIDADE ORÇAMENTÁRIA QUE TRANSFERE",
         label_direita="RESPONSÁVEL DA UNIDADE ORÇAMENTÁRIA QUE RECEBE",
         valor_esquerda=responsavel_transferencia,
-        valor_direita=unidade_destino,
+        valor_direita=responsavel_recebimento,
         config_cls=PDFConfig,
     )

--- a/bem_patrimonial/ntbpm.py
+++ b/bem_patrimonial/ntbpm.py
@@ -1,0 +1,284 @@
+from io import BytesIO
+
+from django.core.exceptions import ValidationError
+from django.db import transaction
+from django.db.models import IntegerField, Max
+from django.db.models.functions import Cast, Substr
+from django.utils import timezone
+
+from reportlab.lib.pagesizes import A4
+from reportlab.lib.units import cm
+from reportlab.lib.styles import getSampleStyleSheet
+from reportlab.lib.enums import TA_LEFT
+from reportlab.platypus import BaseDocTemplate, Frame, PageTemplate, Spacer, Paragraph, Table
+
+from bem_patrimonial.models import TransferenciaBemPatrimonial
+from bem_patrimonial.pdf_utils import (
+    PDFConfigBase as PDFConfig,
+    criar_estilo_base,
+    extrair_codigo_ua,
+    formatar_data,
+    obter_rf_usuario,
+)
+from bem_patrimonial.documentos_pdf_utils import (
+    aplicar_estilo_tabela_info,
+    criar_cabecalho_registro_documento,
+    criar_linha_ua_info,
+    criar_tabela_bens_padrao,
+    criar_tabela_rodape_responsaveis,
+    criar_tabela_total_bens,
+    desenhar_rodape_padrao,
+    desenhar_tabela_no_canvas,
+)
+
+DATE_FMT_BR = "%d/%m/%Y"
+
+
+def obter_bens_transferencia(transferencia):
+    itens = transferencia.itens.select_related("bem").all()
+    bens = [item.bem for item in itens]
+    return sorted(bens, key=lambda b: b.numero_patrimonial or "")
+
+
+def gerar_numero_ntbpm(transferencia):
+    if not isinstance(transferencia, TransferenciaBemPatrimonial):
+        raise ValidationError("Objeto inválido para geração de NTBPM.")
+
+    ano_transferencia = (
+        transferencia.efetivado_em.year
+        if transferencia.efetivado_em
+        else timezone.localdate().year
+    )
+    codigo_origem = extrair_codigo_ua(transferencia.unidade_orcamentaria_origem.codigo)
+    codigo_destino = extrair_codigo_ua(transferencia.unidade_orcamentaria_destino.codigo)
+
+    with transaction.atomic():
+        ultimo_sequencial = (
+            TransferenciaBemPatrimonial.objects.select_for_update()
+            .filter(
+                numero_ntbpm__endswith=f".{ano_transferencia}",
+                numero_ntbpm__isnull=False,
+            )
+            .exclude(numero_ntbpm__exact="")
+            .annotate(sequencial_str=Substr("numero_ntbpm", 9, 7))
+            .aggregate(max_seq=Max(Cast("sequencial_str", IntegerField())))
+        )["max_seq"]
+
+        numero_sequencial = (ultimo_sequencial or 0) + 1
+
+    return f"{codigo_origem}.{codigo_destino}.{numero_sequencial:07d}.{ano_transferencia}"
+
+
+def gerar_pdf_ntbpm(transferencia, usuario_gerador=None, data_geracao=None):
+    if not isinstance(transferencia, TransferenciaBemPatrimonial):
+        raise ValidationError("Objeto inválido para gerar NTBPM.")
+
+    if not transferencia.efetivado_em:
+        raise ValidationError("Só é possível gerar NTBPM para transferências efetivadas.")
+
+    if not getattr(transferencia, "numero_ntbpm", None):
+        transferencia.numero_ntbpm = gerar_numero_ntbpm(transferencia)
+        transferencia.save(update_fields=["numero_ntbpm"])
+
+    buffer = BytesIO()
+
+    doc = BaseDocTemplate(
+        buffer,
+        pagesize=A4,
+        leftMargin=PDFConfig.MARGEM_ESQUERDA,
+        rightMargin=PDFConfig.MARGEM_DIREITA,
+        topMargin=PDFConfig.MARGEM_SUPERIOR,
+        bottomMargin=PDFConfig.MARGEM_INFERIOR,
+        title=f"NTBPM {transferencia.numero_ntbpm}",
+        author="Sistema de Bens Físicos - SME",
+    )
+
+    frame = Frame(doc.leftMargin, doc.bottomMargin, doc.width, doc.height, id="normal")
+
+    def on_page(canvas, doc_):
+        canvas.saveState()
+        _desenhar_cabecalho_em_pagina(canvas, doc_, transferencia)
+        _desenhar_rodape_em_pagina(
+            canvas,
+            doc_,
+            transferencia,
+            usuario_gerador=usuario_gerador,
+            data_geracao=data_geracao,
+        )
+        canvas.restoreState()
+
+    template = PageTemplate(id="todas_paginas", frames=[frame], onPage=on_page)
+    doc.addPageTemplates([template])
+
+    elements = []
+    elements.extend(_criar_informacoes_gerais(transferencia))
+    elements.append(Spacer(1, 0.2 * cm))
+    elements.extend(_criar_tabela_bens(transferencia))
+    elements.append(Spacer(1, 0.1 * cm))
+    elements.extend(_criar_total_bens(transferencia))
+
+    doc.build(elements)
+    buffer.seek(0)
+    return buffer
+
+
+def _desenhar_cabecalho_em_pagina(canvas, doc, transferencia):
+    cabecalho = _criar_cabecalho_e_registro_ntbpm(transferencia)
+    if cabecalho:
+        desenhar_tabela_no_canvas(canvas, doc, cabecalho[0], A4[1] - 1.0 * cm)
+
+
+def _desenhar_rodape_em_pagina(
+    canvas,
+    doc,
+    transferencia,
+    usuario_gerador=None,
+    data_geracao=None,
+):
+    tabela_rodape = _criar_rodape_ntbpm(transferencia)
+    usuario = usuario_gerador or getattr(transferencia, "criado_por", None)
+
+    desenhar_rodape_padrao(
+        canvas,
+        doc,
+        tabela_rodape[0] if tabela_rodape else None,
+        usuario=usuario,
+        data_geracao=data_geracao,
+        config_cls=PDFConfig,
+    )
+
+
+def _criar_cabecalho_e_registro_ntbpm(transferencia):
+    return criar_cabecalho_registro_documento(
+        titulo_documento="NOTA DE TRANSFERÊNCIA DE BENS PATRIMONIAIS MÓVEIS E INTANGÍVEIS - NTBPM",
+        titulo_registro="REGISTRO DA NTBPM",
+        label_data_1="EMISSÃO",
+        label_data_2="ACEITE",
+        label_numero="NÚMERO NTBPM",
+        valor_data_1=formatar_data(transferencia.criado_em),
+        valor_data_2=formatar_data(transferencia.efetivado_em),
+        valor_numero=transferencia.numero_ntbpm or "",
+        config_cls=PDFConfig,
+    )
+
+
+def _criar_linha_ua(unidade_orcamentaria, label, sigla, nome, codigo, label_style, value_style):
+    return criar_linha_ua_info(
+        unidade_orcamentaria=unidade_orcamentaria,
+        label=label,
+        sigla=sigla,
+        nome=nome,
+        codigo=codigo,
+        label_style=label_style,
+        value_style=value_style,
+    )
+
+
+def _criar_informacoes_gerais(transferencia):
+    styles = getSampleStyleSheet()
+
+    label_style = criar_estilo_base(
+        "InfoLabelNTBPM",
+        styles,
+        config_cls=PDFConfig,
+        fontName="Helvetica-Bold",
+        alignment=TA_LEFT,
+    )
+    value_style = criar_estilo_base(
+        "InfoValueNTBPM",
+        styles,
+        config_cls=PDFConfig,
+        alignment=TA_LEFT,
+    )
+
+    uo_origem = transferencia.unidade_orcamentaria_origem
+    ua_destino = transferencia.unidade_administrativa_destino
+
+    info_data = [
+        [
+            Paragraph("<b>PREFIXO</b>", label_style),
+            Paragraph("<b>ÓRGÃO</b>", label_style),
+            Paragraph("<b>CÓDIGO</b>", label_style),
+        ],
+        [
+            Paragraph("SME", value_style),
+            Paragraph("SECRETARIA MUNICIPAL DE EDUCAÇÃO", value_style),
+            Paragraph("16", value_style),
+        ],
+    ]
+
+    info_data.extend(
+        _criar_linha_ua(
+            uo_origem.nome,
+            "UNIDADE ORÇAMENTÁRIA DE ORIGEM",
+            getattr(uo_origem, "sigla", "-"),
+            getattr(uo_origem, "nome", "-"),
+            getattr(uo_origem, "codigo", "-"),
+            label_style,
+            value_style,
+        )
+    )
+
+    info_data.extend(
+        _criar_linha_ua(
+            ua_destino.unidade_orcamentaria.nome,
+            "UNIDADE ORÇAMENTÁRIA / UNIDADE ADMINISTRATIVA DE DESTINO",
+            getattr(ua_destino, "sigla", "-"),
+            getattr(ua_destino, "nome", "-"),
+            getattr(ua_destino, "codigo", "-"),
+            label_style,
+            value_style,
+        )
+    )
+
+    info_data.extend(
+        [
+            [
+                Paragraph("<b>NÚMERO DO PROCESSO</b>", label_style),
+                Paragraph("<b>DATA DA TRANSFERÊNCIA</b>", label_style),
+                Paragraph("<b>STATUS</b>", label_style),
+            ],
+            [
+                Paragraph(str(transferencia.numero_processo or "-").upper(), value_style),
+                Paragraph(
+                    transferencia.efetivado_em.strftime(DATE_FMT_BR)
+                    if transferencia.efetivado_em
+                    else "-",
+                    value_style,
+                ),
+                Paragraph("TRANSFERIDO", value_style),
+            ],
+        ]
+    )
+
+    info_table = Table(info_data, colWidths=[5.0 * cm, 10.0 * cm, 3.0 * cm])
+    aplicar_estilo_tabela_info(info_table, linhas_cabecalho=[0, 2, 4], config_cls=PDFConfig)
+
+    return [info_table]
+
+
+def _criar_tabela_bens(transferencia):
+    bens = obter_bens_transferencia(transferencia)
+    return criar_tabela_bens_padrao(
+        bens=bens,
+        descricao_fn=lambda bem: str(getattr(bem, "descricao", "-") or "-").upper(),
+        config_cls=PDFConfig,
+    )
+
+
+def _criar_total_bens(transferencia):
+    bens = obter_bens_transferencia(transferencia)
+    return criar_tabela_total_bens(bens=bens, config_cls=PDFConfig)
+
+
+def _criar_rodape_ntbpm(transferencia):
+    responsavel_transferencia = obter_rf_usuario(getattr(transferencia, "criado_por", None))
+    unidade_destino = str(getattr(transferencia, "unidade_administrativa_destino", "-"))
+
+    return criar_tabela_rodape_responsaveis(
+        label_esquerda="RESPONSÁVEL DA UNIDADE ORÇAMENTÁRIA QUE TRANSFERE",
+        label_direita="RESPONSÁVEL DA UNIDADE ORÇAMENTÁRIA QUE RECEBE",
+        valor_esquerda=responsavel_transferencia,
+        valor_direita=unidade_destino,
+        config_cls=PDFConfig,
+    )

--- a/bem_patrimonial/serializers/bem_patrimonial_serializers.py
+++ b/bem_patrimonial/serializers/bem_patrimonial_serializers.py
@@ -302,9 +302,9 @@ class BemPatrimonialDetailSerializer(
             raise serializers.ValidationError(
                 "Este bem está excluído e não pode ser editado."
             )
-        if self.instance.status == constants.BAIXA_FISICA:
+        if self.instance.status in constants.STATUS_FINAIS_BEM:
             raise serializers.ValidationError(
-                "Este bem está com status 'Baixa Física' e não pode ser editado."
+                f"Este bem está com status '{self.instance.get_status_display()}' e não pode ser editado."
             )
         if "unidade_administrativa" in attrs and attrs["unidade_administrativa"] != self.instance.unidade_administrativa:
             raise serializers.ValidationError(

--- a/bem_patrimonial/tests/test_bem_patrimonial_admin.py
+++ b/bem_patrimonial/tests/test_bem_patrimonial_admin.py
@@ -23,6 +23,8 @@ from bem_patrimonial.models import (
     StatusBemPatrimonial,
     BaixaFisicaBemPatrimonial,
     BaixaFisicaBensItem,
+    TransferenciaBemPatrimonial,
+    TransferenciaBensItem,
 )
 from bem_patrimonial.admins.bem_patrimonial import (
     BemPatrimonialAdmin,
@@ -38,6 +40,7 @@ from bem_patrimonial.constants import (
     APROVADO,
     BAIXA_FISICA,
     ACEITA,
+    TRANSFERIDO,
 )
 from bem_patrimonial.formats import PDFFormat
 from dados_comuns.models import UnidadeAdministrativa
@@ -249,6 +252,11 @@ class BemPatrimonialAdminCoberturaTest(TestCase):
         bem = self._criar_bem(status=BAIXA_FISICA)
         self.assertFalse(self.admin.has_change_permission(request, obj=bem))
 
+    def test_has_change_permission_false_se_transferido(self):
+        request = _request_with_messages(self.factory, self.gestor)
+        bem = self._criar_bem(status=TRANSFERIDO)
+        self.assertFalse(self.admin.has_change_permission(request, obj=bem))
+
     # --- has_delete_permission ---
     def test_has_delete_permission_false_se_obj_none(self):
         request = _request_with_messages(self.factory, self.gestor)
@@ -270,6 +278,11 @@ class BemPatrimonialAdminCoberturaTest(TestCase):
         bem = self._criar_bem(status=BAIXA_FISICA)
         self.assertFalse(self.admin.has_delete_permission(request, obj=bem))
 
+    def test_has_delete_permission_false_se_transferido(self):
+        request = _request_with_messages(self.factory, self.gestor)
+        bem = self._criar_bem(status=TRANSFERIDO)
+        self.assertFalse(self.admin.has_delete_permission(request, obj=bem))
+
     def test_has_delete_permission_true_gestor_bem_normal(self):
         request = _request_with_messages(self.factory, self.gestor)
         bem = self._criar_bem()
@@ -284,6 +297,15 @@ class BemPatrimonialAdminCoberturaTest(TestCase):
         with self.assertRaises(ValidationError) as ctx:
             self.admin.save_model(request, bem, form, change=True)
         self.assertIn("Baixa Física", str(ctx.exception))
+
+    def test_save_model_raise_se_editar_bem_transferido(self):
+        bem = self._criar_bem(status=TRANSFERIDO)
+        request = _request_with_messages(self.factory, self.gestor, method="POST")
+        form = MagicMock()
+        form.cleaned_data = {}
+        with self.assertRaises(ValidationError) as ctx:
+            self.admin.save_model(request, bem, form, change=True)
+        self.assertIn("Transferido", str(ctx.exception))
 
     def test_save_model_criar_preenche_criado_por_e_status_default(self):
         bem = BemPatrimonial(
@@ -428,6 +450,192 @@ class BemPatrimonialAdminCoberturaTest(TestCase):
         result_qs, _ = self.admin.get_search_results(request, qs, "")
         self.assertNotIn(b1, result_qs)
         self.assertIn(b2, result_qs)
+
+    def test_get_search_results_transferencia_com_uo_origem_filtra_todas_uas_da_uo(self):
+        ua_2 = criar_ua(
+            uo=self.uo,
+            codigo="002",
+            sigla="UA2",
+            nome="UA 2",
+            status=UnidadeAdministrativa.ATIVA,
+        )
+        bem_ua1 = self._criar_bem(status=APROVADO, unidade_administrativa=self.ua)
+        bem_ua2 = self._criar_bem(status=APROVADO, unidade_administrativa=ua_2)
+        request = self.factory.get(
+            "/admin/",
+            {
+                "app_label": "bem_patrimonial",
+                "model_name": "transferenciabensitem",
+                "field_name": "bem",
+                "uo_origem": str(self.uo.pk),
+            },
+        )
+        request.path = "/admin/bem_patrimonial/bempatrimonial/autocomplete/"
+        request.user = self.gestor
+        qs = BemPatrimonial.objects.filter(pk__in=[bem_ua1.pk, bem_ua2.pk])
+
+        result_qs, _ = self.admin.get_search_results(request, qs, "")
+
+        self.assertIn(bem_ua1, result_qs)
+        self.assertIn(bem_ua2, result_qs)
+
+    def test_get_search_results_transferencia_com_ua_origem_filtra_ua_especifica(self):
+        ua_2 = criar_ua(
+            uo=self.uo,
+            codigo="003",
+            sigla="UA3",
+            nome="UA 3",
+            status=UnidadeAdministrativa.ATIVA,
+        )
+        bem_ua1 = self._criar_bem(status=APROVADO, unidade_administrativa=self.ua)
+        bem_ua2 = self._criar_bem(status=APROVADO, unidade_administrativa=ua_2)
+        request = self.factory.get(
+            "/admin/",
+            {
+                "app_label": "bem_patrimonial",
+                "model_name": "transferenciabensitem",
+                "field_name": "bem",
+                "uo_origem": str(self.uo.pk),
+                "ua_origem": str(ua_2.pk),
+            },
+        )
+        request.path = "/admin/bem_patrimonial/bempatrimonial/autocomplete/"
+        request.user = self.gestor
+        qs = BemPatrimonial.objects.filter(pk__in=[bem_ua1.pk, bem_ua2.pk])
+
+        result_qs, _ = self.admin.get_search_results(request, qs, "")
+
+        self.assertNotIn(bem_ua1, result_qs)
+        self.assertIn(bem_ua2, result_qs)
+
+    def test_get_search_results_transferencia_anota_rotulo_com_ua_e_bem(self):
+        bem = self._criar_bem(status=APROVADO, unidade_administrativa=self.ua)
+        request = self.factory.get(
+            "/admin/",
+            {
+                "app_label": "bem_patrimonial",
+                "model_name": "transferenciabensitem",
+                "field_name": "bem",
+                "uo_origem": str(self.uo.pk),
+            },
+        )
+        request.path = "/admin/bem_patrimonial/bempatrimonial/autocomplete/"
+        request.user = self.gestor
+
+        result_qs, _ = self.admin.get_search_results(
+            request,
+            BemPatrimonial.objects.filter(pk=bem.pk),
+            "",
+        )
+        result = result_qs.get(pk=bem.pk)
+
+        self.assertEqual(
+            str(result),
+            f"{self.ua} | {bem.numero_patrimonial} - {bem.nome}",
+        )
+
+    def test_get_queryset_inclui_bem_transferido_para_uo_origem(self):
+        uo_destino = criar_uo(codigo="210", nome="UO 210")
+        ua_destino = criar_ua(
+            uo=uo_destino,
+            codigo="210.001",
+            sigla="UD1",
+            nome="UA Destino 1",
+            status=UnidadeAdministrativa.ATIVA,
+        )
+        bem = self._criar_bem(status=APROVADO)
+        transferencia = TransferenciaBemPatrimonial.objects.create(
+            unidade_orcamentaria_origem=self.uo,
+            unidade_orcamentaria_destino=uo_destino,
+            unidade_administrativa_destino=ua_destino,
+            numero_processo="SEI-ORIGEM",
+            criado_por=self.gestor,
+        )
+        TransferenciaBensItem.objects.create(transferencia=transferencia, bem=bem)
+        transferencia.efetivar_transferencia(self.gestor)
+
+        request = _request_with_messages(self.factory, self.gestor)
+
+        queryset = self.admin.get_queryset(request)
+
+        self.assertIn(bem, queryset)
+
+    def test_get_queryset_inclui_bem_transferido_para_uo_destino_mesmo_fora_da_ua(self):
+        uo_destino = criar_uo(codigo="220", nome="UO 220")
+        ua_destino_transferencia = criar_ua(
+            uo=uo_destino,
+            codigo="220.001",
+            sigla="UD1",
+            nome="UA Destino Transferencia",
+            status=UnidadeAdministrativa.ATIVA,
+        )
+        ua_destino_usuario = criar_ua(
+            uo=uo_destino,
+            codigo="220.002",
+            sigla="UD2",
+            nome="UA Destino Usuario",
+            status=UnidadeAdministrativa.ATIVA,
+        )
+        gestor_destino = Usuario.objects.create_user(
+            username="gestor_destino_bem_admin",
+            **auth_kwargs("x"),
+            unidade_administrativa=ua_destino_usuario,
+            unidade_orcamentaria=uo_destino,
+            is_staff=True,
+        )
+        gestor_destino.groups.add(self.grupo_gestor)
+
+        bem = self._criar_bem(status=APROVADO)
+        transferencia = TransferenciaBemPatrimonial.objects.create(
+            unidade_orcamentaria_origem=self.uo,
+            unidade_orcamentaria_destino=uo_destino,
+            unidade_administrativa_destino=ua_destino_transferencia,
+            numero_processo="SEI-DESTINO",
+            criado_por=self.gestor,
+        )
+        TransferenciaBensItem.objects.create(transferencia=transferencia, bem=bem)
+        transferencia.efetivar_transferencia(self.gestor)
+
+        request = _request_with_messages(self.factory, gestor_destino)
+
+        queryset = self.admin.get_queryset(request)
+
+        self.assertIn(bem, queryset)
+
+    def test_get_search_results_mantem_bem_transferido_visivel_na_busca_textual(self):
+        uo_destino = criar_uo(codigo="230", nome="UO 230")
+        ua_destino = criar_ua(
+            uo=uo_destino,
+            codigo="230.001",
+            sigla="UD1",
+            nome="UA Destino",
+            status=UnidadeAdministrativa.ATIVA,
+        )
+        bem = self._criar_bem(
+            status=APROVADO,
+            numero_patrimonial="000.000009999-0",
+            nome="Bem buscavel transferido",
+        )
+        transferencia = TransferenciaBemPatrimonial.objects.create(
+            unidade_orcamentaria_origem=self.uo,
+            unidade_orcamentaria_destino=uo_destino,
+            unidade_administrativa_destino=ua_destino,
+            numero_processo="SEI-BUSCA",
+            criado_por=self.gestor,
+        )
+        TransferenciaBensItem.objects.create(transferencia=transferencia, bem=bem)
+        transferencia.efetivar_transferencia(self.gestor)
+
+        request = self._request_changelist()
+        queryset = self.admin.get_queryset(request)
+
+        result_qs, _ = self.admin.get_search_results(
+            request,
+            queryset,
+            "000.000009999-0",
+        )
+
+        self.assertIn(bem, result_qs)
 
     # --- add_view modo multi: linhas vazias; sucesso (Client + gestor com UA no escopo) ---
     def test_add_view_multi_linhas_vazias_retorna_super_com_erro(self):

--- a/bem_patrimonial/tests/test_serializers.py
+++ b/bem_patrimonial/tests/test_serializers.py
@@ -74,6 +74,19 @@ class BemPatrimonialSerializerTest(TestCase):
         self.assertFalse(serializer.is_valid())
         self.assertIn("Baixa Física", str(serializer.errors))
 
+    def test_nao_permite_editar_transferido(self):
+        bem = self._mk_bem(status=constants.TRANSFERIDO)
+
+        serializer = BemPatrimonialDetailSerializer(
+            instance=bem,
+            data={"nome": "Novo Nome"},
+            context={"request": self._get_request()},
+            partial=True,
+        )
+
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("Transferido", str(serializer.errors))
+
     def test_nao_permite_alterar_unidade(self):
         outra_uo = criar_uo(codigo="999", nome="UO 999")
         outra_ua = criar_ua(nome="Outra UA", uo=outra_uo)

--- a/bem_patrimonial/tests/test_viewset.py
+++ b/bem_patrimonial/tests/test_viewset.py
@@ -2,11 +2,18 @@ from dados_comuns.tests.auth_test_utils import auth_kwargs
 from django.test import TestCase
 from django.urls import reverse
 from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
 from rest_framework.test import APIClient
 
 from bem_patrimonial.models import BemPatrimonial
+from bem_patrimonial.models import (
+    TransferenciaBemPatrimonial,
+    TransferenciaBensItem,
+)
 from bem_patrimonial import constants
+from dados_comuns.context import audit_as
 from dados_comuns.tests.factories import criar_ua, criar_uo
+from usuario.constants import GRUPO_GESTOR_PATRIMONIO
 
 
 class BemPatrimonialViewSetTest(TestCase):
@@ -336,3 +343,89 @@ class CreateMultiViewSetTest(TestCase):
         response = self.client.post(self._url(), payload, format="json")
         self.assertEqual(response.status_code, 400)
         self.assertIn("nome", response.data)
+
+
+class BemPatrimonialTransferidoHistoricoViewSetTest(TestCase):
+    def setUp(self):
+        user_model = get_user_model()
+        grupo_gestor = Group.objects.get_or_create(name=GRUPO_GESTOR_PATRIMONIO)[0]
+
+        self.uo_origem = criar_uo(codigo="410", nome="UO Origem")
+        self.ua_origem = criar_ua(nome="UA Origem", uo=self.uo_origem, codigo="410.001")
+
+        self.uo_destino = criar_uo(codigo="420", nome="UO Destino")
+        self.ua_destino_transferencia = criar_ua(
+            nome="UA Destino Transferencia",
+            uo=self.uo_destino,
+            codigo="420.001",
+        )
+        self.ua_destino_usuario = criar_ua(
+            nome="UA Destino Usuario",
+            uo=self.uo_destino,
+            codigo="420.002",
+        )
+
+        self.gestor_origem = user_model.objects.create_user(
+            username="gestor_origem_viewset",
+            email="gestor.origem.viewset@test.com",
+            **auth_kwargs("123456"),
+            unidade_orcamentaria=self.uo_origem,
+            unidade_administrativa=self.ua_origem,
+            is_staff=True,
+        )
+        self.gestor_origem.groups.add(grupo_gestor)
+
+        self.gestor_destino = user_model.objects.create_user(
+            username="gestor_destino_viewset",
+            email="gestor.destino.viewset@test.com",
+            **auth_kwargs("123456"),
+            unidade_orcamentaria=self.uo_destino,
+            unidade_administrativa=self.ua_destino_usuario,
+            is_staff=True,
+        )
+        self.gestor_destino.groups.add(grupo_gestor)
+
+        self.bem = BemPatrimonial.objects.create(
+            nome="Bem transferido API",
+            numero_patrimonial="000.000000901-0",
+            descricao="Desc",
+            valor_unitario=1.00,
+            marca="M",
+            modelo="X",
+            numero_processo="PROC-T",
+            numero_formato_antigo=False,
+            sem_numeracao=False,
+            criado_por=self.gestor_origem,
+            unidade_administrativa=self.ua_origem,
+            status=constants.APROVADO,
+        )
+        self.transferencia = TransferenciaBemPatrimonial.objects.create(
+            unidade_orcamentaria_origem=self.uo_origem,
+            unidade_orcamentaria_destino=self.uo_destino,
+            unidade_administrativa_destino=self.ua_destino_transferencia,
+            numero_processo="SEI-VIEWSET",
+            criado_por=self.gestor_origem,
+        )
+        TransferenciaBensItem.objects.create(
+            transferencia=self.transferencia,
+            bem=self.bem,
+        )
+        with audit_as(self.gestor_origem):
+            self.transferencia.efetivar_transferencia(self.gestor_origem)
+
+    def test_origem_pode_consultar_detalhe_de_bem_transferido(self):
+        client = APIClient()
+        client.force_authenticate(self.gestor_origem)
+
+        response = client.get(reverse("bens-detail", args=[self.bem.pk]))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["id"], self.bem.pk)
+
+    def test_destino_pode_consultar_historico_de_bem_transferido(self):
+        client = APIClient()
+        client.force_authenticate(self.gestor_destino)
+
+        response = client.get(reverse("bens-historico", args=[self.bem.pk]))
+
+        self.assertEqual(response.status_code, 200)

--- a/bem_patrimonial/tests/tests_ntbpm.py
+++ b/bem_patrimonial/tests/tests_ntbpm.py
@@ -2,6 +2,11 @@ from django.test import Client, TestCase
 from django.urls import reverse
 
 from bem_patrimonial import constants
+from bem_patrimonial.ntbpm import (
+    _criar_informacoes_complementares,
+    _criar_informacoes_gerais,
+    _criar_rodape_ntbpm,
+)
 from bem_patrimonial.models import (
     BemPatrimonial,
     TransferenciaBemPatrimonial,
@@ -16,7 +21,14 @@ from django.contrib.auth.models import Group
 
 class NTBPMTestCase(TestCase):
     def setUp(self):
-        self.uo_origem = criar_uo(codigo=codigo_uo(1, 16, 80), nome="SME", sigla="SME")
+        self.uo_origem = criar_uo(
+            codigo=codigo_uo(1, 16, 80),
+            nome="SME",
+            sigla="SME",
+            sigla_orgao="PMSP",
+            orgao="Secretaria Municipal de Educação",
+            codigo_orgao="01.16",
+        )
         self.ua_origem = criar_ua(
             uo=self.uo_origem,
             codigo=f"{self.uo_origem.codigo}.001",
@@ -27,6 +39,9 @@ class NTBPMTestCase(TestCase):
             codigo=codigo_uo(4, 40, 40),
             nome="Secretaria Externa",
             sigla="EXT",
+            sigla_orgao="ORGEXT",
+            orgao="Órgão Externo",
+            codigo_orgao="40.40",
         )
         self.ua_destino = criar_ua(
             uo=self.uo_destino,
@@ -58,6 +73,7 @@ class NTBPMTestCase(TestCase):
             email="gestor.ntbpm@test.com",
             **auth_kwargs("senha123"),
             nome="Gestor NTBPM",
+            rf="123456",
             is_staff=True,
             unidade_orcamentaria=self.uo_origem,
             unidade_administrativa=self.ua_origem,
@@ -69,6 +85,7 @@ class NTBPMTestCase(TestCase):
             email="gestor.destino.ntbpm@test.com",
             **auth_kwargs("senha123"),
             nome="Gestor Destino NTBPM",
+            rf="654321",
             is_staff=True,
             unidade_orcamentaria=self.uo_destino,
             unidade_administrativa=self.ua_destino_2,
@@ -113,6 +130,7 @@ class NTBPMTestCase(TestCase):
             unidade_orcamentaria_destino=self.uo_destino,
             unidade_administrativa_destino=self.ua_destino,
             numero_processo="SEI-987654/2026",
+            observacao="Observação da transferência externa.",
             criado_por=self.gestor,
         )
         TransferenciaBensItem.objects.create(
@@ -131,11 +149,11 @@ class NTBPMTestCase(TestCase):
     def test_numero_ntbpm_gerado_na_efetivacao(self):
         partes = self.transferencia.numero_ntbpm.split(".")
 
-        self.assertEqual(len(partes), 4)
+        self.assertEqual(len(partes), 3)
         self.assertEqual(len(partes[0]), 3)
-        self.assertEqual(len(partes[1]), 3)
-        self.assertEqual(len(partes[2]), 7)
-        self.assertEqual(len(partes[3]), 4)
+        self.assertEqual(partes[0], "001")
+        self.assertEqual(len(partes[1]), 7)
+        self.assertEqual(len(partes[2]), 4)
 
     def test_gestor_pode_baixar_documento_ntbpm(self):
         self.client.login(username="gestor_ntbpm", **auth_kwargs("senha123"))
@@ -176,3 +194,77 @@ class NTBPMTestCase(TestCase):
         content = b"".join(response.streaming_content)
         self.assertTrue(content.startswith(b"%PDF"))
         self.assertGreater(len(content), 1000)
+
+    def test_informacoes_gerais_exibem_uos_de_origem_e_destino(self):
+        tabela = _criar_informacoes_gerais(self.transferencia)[0]
+        linhas = [
+            [celula.getPlainText() for celula in linha]
+            for linha in tabela._cellvalues
+        ]
+
+        self.assertEqual(
+            linhas[0],
+            ["PREFIXO", "ÓRGÃO", "CÓDIGO"],
+        )
+        self.assertEqual(
+            linhas[1],
+            ["PMSP", "SECRETARIA MUNICIPAL DE EDUCAÇÃO", "01.16"],
+        )
+        self.assertEqual(
+            linhas[2],
+            ["PREFIXO", "UNIDADE ORÇAMENTÁRIA QUE TRANSFERE", "CÓDIGO"],
+        )
+        self.assertEqual(
+            linhas[3],
+            ["SME", "SME", self.uo_origem.codigo],
+        )
+        self.assertEqual(
+            linhas[4],
+            ["PREFIXO", "ÓRGÃO", "CÓDIGO"],
+        )
+        self.assertEqual(
+            linhas[5],
+            ["ORGEXT", "ÓRGÃO EXTERNO", "40.40"],
+        )
+        self.assertEqual(
+            linhas[6],
+            ["PREFIXO", "UNIDADE ORÇAMENTÁRIA QUE RECEBE", "CÓDIGO"],
+        )
+        self.assertEqual(
+            linhas[7],
+            ["EXT", "SECRETARIA EXTERNA", self.uo_destino.codigo],
+        )
+
+    def test_informacoes_complementares_exibem_apenas_observacao(self):
+        tabela = _criar_informacoes_complementares(self.transferencia)[0]
+        linhas = [
+            [celula.getPlainText() for celula in linha]
+            for linha in tabela._cellvalues
+        ]
+
+        self.assertEqual(linhas[0], ["OBSERVAÇÃO"])
+        self.assertEqual(linhas[1], ["Observação da transferência externa."])
+
+    def test_resumo_transferencia_exibe_processo_data_e_status(self):
+        tabela = _criar_informacoes_gerais(self.transferencia)[2]
+        linhas = [
+            [celula.getPlainText() for celula in linha]
+            for linha in tabela._cellvalues
+        ]
+
+        self.assertEqual(
+            linhas[0],
+            ["NÚMERO DO PROCESSO", "DATA DA TRANSFERÊNCIA", "STATUS"],
+        )
+        self.assertEqual(linhas[1][0], "SEI-987654/2026")
+        self.assertEqual(linhas[1][2], "TRANSFERIDO")
+
+    def test_rodape_ntbpm_exibe_usuario_como_responsavel_do_recebimento(self):
+        tabela = _criar_rodape_ntbpm(self.transferencia)[0]
+        linhas = [
+            [celula.getPlainText() for celula in linha]
+            for linha in tabela._cellvalues
+        ]
+
+        self.assertEqual(linhas[1][0], "123456")
+        self.assertEqual(linhas[1][1], "123456")

--- a/bem_patrimonial/tests/tests_ntbpm.py
+++ b/bem_patrimonial/tests/tests_ntbpm.py
@@ -1,0 +1,178 @@
+from django.test import Client, TestCase
+from django.urls import reverse
+
+from bem_patrimonial import constants
+from bem_patrimonial.models import (
+    BemPatrimonial,
+    TransferenciaBemPatrimonial,
+    TransferenciaBensItem,
+)
+from dados_comuns.tests.auth_test_utils import auth_kwargs, codigo_ua, codigo_uo
+from dados_comuns.tests.factories import criar_ua, criar_uo
+from usuario.constants import GRUPO_GESTOR_PATRIMONIO
+from usuario.models import Usuario
+from django.contrib.auth.models import Group
+
+
+class NTBPMTestCase(TestCase):
+    def setUp(self):
+        self.uo_origem = criar_uo(codigo=codigo_uo(1, 16, 80), nome="SME", sigla="SME")
+        self.ua_origem = criar_ua(
+            uo=self.uo_origem,
+            codigo=f"{self.uo_origem.codigo}.001",
+            sigla="UA1",
+            nome="Unidade 1",
+        )
+        self.uo_destino = criar_uo(
+            codigo=codigo_uo(4, 40, 40),
+            nome="Secretaria Externa",
+            sigla="EXT",
+        )
+        self.ua_destino = criar_ua(
+            uo=self.uo_destino,
+            codigo=codigo_ua(4, 40, 40, 1),
+            sigla="PC",
+            nome="Ponto Central",
+        )
+        self.ua_destino_2 = criar_ua(
+            uo=self.uo_destino,
+            codigo=codigo_ua(4, 40, 40, 2),
+            sigla="DST2",
+            nome="Destino 2",
+        )
+        self.uo_terceira = criar_uo(
+            codigo=codigo_uo(5, 50, 50),
+            nome="Secretaria Terceira",
+            sigla="TER",
+        )
+        self.ua_terceira = criar_ua(
+            uo=self.uo_terceira,
+            codigo=codigo_ua(5, 50, 50, 1),
+            sigla="TER1",
+            nome="Terceira 1",
+        )
+
+        grupo_gestor = Group.objects.get_or_create(name=GRUPO_GESTOR_PATRIMONIO)[0]
+        self.gestor = Usuario.objects.create_user(
+            username="gestor_ntbpm",
+            email="gestor.ntbpm@test.com",
+            **auth_kwargs("senha123"),
+            nome="Gestor NTBPM",
+            is_staff=True,
+            unidade_orcamentaria=self.uo_origem,
+            unidade_administrativa=self.ua_origem,
+        )
+        self.gestor.groups.add(grupo_gestor)
+
+        self.gestor_destino = Usuario.objects.create_user(
+            username="gestor_destino_ntbpm",
+            email="gestor.destino.ntbpm@test.com",
+            **auth_kwargs("senha123"),
+            nome="Gestor Destino NTBPM",
+            is_staff=True,
+            unidade_orcamentaria=self.uo_destino,
+            unidade_administrativa=self.ua_destino_2,
+        )
+        self.gestor_destino.groups.add(grupo_gestor)
+
+        self.gestor_terceiro = Usuario.objects.create_user(
+            username="gestor_terceiro_ntbpm",
+            email="gestor.terceiro.ntbpm@test.com",
+            **auth_kwargs("senha123"),
+            nome="Gestor Terceiro NTBPM",
+            is_staff=True,
+            unidade_orcamentaria=self.uo_terceira,
+            unidade_administrativa=self.ua_terceira,
+        )
+        self.gestor_terceiro.groups.add(grupo_gestor)
+
+        self.operador = Usuario.objects.create_user(
+            username="operador_ntbpm",
+            email="operador.ntbpm@test.com",
+            **auth_kwargs("senha123"),
+            nome="Operador NTBPM",
+            is_staff=True,
+            unidade_orcamentaria=self.uo_origem,
+            unidade_administrativa=self.ua_origem,
+        )
+
+        self.bem = BemPatrimonial.objects.create(
+            numero_patrimonial="001.000000050-0",
+            nome="Bem NTBPM",
+            descricao="Descrição",
+            valor_unitario=100,
+            marca="Marca",
+            modelo="Modelo",
+            numero_processo="PROC-BASE",
+            status=constants.APROVADO,
+            unidade_administrativa=self.ua_origem,
+            criado_por=self.gestor,
+        )
+        self.transferencia = TransferenciaBemPatrimonial.objects.create(
+            unidade_orcamentaria_origem=self.uo_origem,
+            unidade_orcamentaria_destino=self.uo_destino,
+            unidade_administrativa_destino=self.ua_destino,
+            numero_processo="SEI-987654/2026",
+            criado_por=self.gestor,
+        )
+        TransferenciaBensItem.objects.create(
+            transferencia=self.transferencia,
+            bem=self.bem,
+        )
+        self.transferencia.efetivar_transferencia(self.gestor)
+        self.transferencia.refresh_from_db()
+
+        self.client = Client()
+        self.url = reverse(
+            "download_documento_ntbpm",
+            kwargs={"pk": self.transferencia.pk},
+        )
+
+    def test_numero_ntbpm_gerado_na_efetivacao(self):
+        partes = self.transferencia.numero_ntbpm.split(".")
+
+        self.assertEqual(len(partes), 4)
+        self.assertEqual(len(partes[0]), 3)
+        self.assertEqual(len(partes[1]), 3)
+        self.assertEqual(len(partes[2]), 7)
+        self.assertEqual(len(partes[3]), 4)
+
+    def test_gestor_pode_baixar_documento_ntbpm(self):
+        self.client.login(username="gestor_ntbpm", **auth_kwargs("senha123"))
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "application/pdf")
+        self.assertIn("attachment", response["Content-Disposition"])
+        self.assertIn(
+            f"NTBPM_{self.transferencia.numero_ntbpm.replace('.', '_')}.pdf",
+            response["Content-Disposition"],
+        )
+
+    def test_gestor_destino_pode_baixar_documento_ntbpm(self):
+        self.client.login(username="gestor_destino_ntbpm", **auth_kwargs("senha123"))
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "application/pdf")
+
+    def test_usuario_sem_grupo_gestor_nao_pode_baixar_documento_ntbpm(self):
+        self.client.login(username="operador_ntbpm", **auth_kwargs("senha123"))
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_gestor_sem_relacao_com_transferencia_nao_pode_baixar_documento_ntbpm(self):
+        self.client.login(username="gestor_terceiro_ntbpm", **auth_kwargs("senha123"))
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_conteudo_pdf_ntbpm_valido(self):
+        self.client.login(username="gestor_ntbpm", **auth_kwargs("senha123"))
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        content = b"".join(response.streaming_content)
+        self.assertTrue(content.startswith(b"%PDF"))
+        self.assertGreater(len(content), 1000)

--- a/bem_patrimonial/tests/tests_transferencia_admin.py
+++ b/bem_patrimonial/tests/tests_transferencia_admin.py
@@ -111,6 +111,20 @@ class TransferenciaBemPatrimonialAdminTestCase(TestCase):
         )
         self.operador.groups.add(grupo_operador)
 
+    def test_list_display_exibe_ntbpm_logo_apos_id(self):
+        self.assertEqual(
+            self.admin.list_display,
+            (
+                "id",
+                "numero_ntbpm",
+                "numero_processo",
+                "unidade_orcamentaria_origem",
+                "unidade_orcamentaria_destino",
+                "criado_por",
+                "criado_em",
+            ),
+        )
+
     def test_form_resolve_ua_destino_001_automaticamente(self):
         form = TransferenciaBemPatrimonialForm(
             data={
@@ -141,6 +155,27 @@ class TransferenciaBemPatrimonialAdminTestCase(TestCase):
             list(queryset.values_list("id", flat=True)),
             [self.ua_origem.id, self.ua_origem_2.id],
         )
+
+    def test_form_rejeita_numero_processo_duplicado(self):
+        TransferenciaBemPatrimonial.objects.create(
+            unidade_orcamentaria_origem=self.uo_origem,
+            unidade_orcamentaria_destino=self.uo_destino,
+            unidade_administrativa_destino=self.ua_destino,
+            numero_processo="SEI-123/2026",
+            criado_por=self.gestor,
+        )
+
+        form = TransferenciaBemPatrimonialForm(
+            data={
+                "unidade_orcamentaria_destino": self.uo_destino.pk,
+                "numero_processo": "SEI-123/2026",
+                "observacao": "Teste duplicado",
+            },
+            request=type("obj", (object,), {"user": self.gestor})(),
+        )
+
+        self.assertFalse(form.is_valid())
+        self.assertIn("numero_processo", form.errors)
 
     def test_change_form_nao_quebra_quando_campos_model_sao_readonly(self):
         transferencia = TransferenciaBemPatrimonial.objects.create(
@@ -338,6 +373,12 @@ class TransferenciaBemPatrimonialAdminTestCase(TestCase):
         self.assertFalse(context["show_save_and_continue"])
         self.assertFalse(context["show_save_and_add_another"])
         self.assertTrue(context["show_close"])
+
+    def test_admin_media_inclui_css_especifico_da_transferencia(self):
+        self.assertIn(
+            "css/transferencia_bem_patrimonial.css",
+            self.admin.media._css.get("all", []),
+        )
 
     def test_change_view_rejeita_post_em_registro_existente(self):
         request = self.factory.post("/admin/bem_patrimonial/transferenciabempatrimonial/1/change/")

--- a/bem_patrimonial/tests/tests_transferencia_admin.py
+++ b/bem_patrimonial/tests/tests_transferencia_admin.py
@@ -1,0 +1,378 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from django.test import Client
+from django.forms import modelform_factory
+from django.core.exceptions import PermissionDenied
+from django.core.exceptions import ValidationError
+from django.contrib.admin.sites import AdminSite
+from django.contrib.auth.models import Group
+from django.test import RequestFactory, TestCase
+from django.urls import reverse
+
+from bem_patrimonial.admins.inlines.inlines import (
+    TransferenciaBensItemInline,
+    TransferenciaBensItemInlineForm,
+    TransferenciaBensItemInlineFormSet,
+)
+from bem_patrimonial.admins.transferencia_bem_patrimonial import (
+    TransferenciaBemPatrimonialAdmin,
+)
+from bem_patrimonial.admins.forms.transferencia_bem_patrimonial_form import (
+    TransferenciaBemPatrimonialForm,
+)
+from bem_patrimonial import constants
+from bem_patrimonial.models import (
+    BemPatrimonial,
+    TransferenciaBemPatrimonial,
+    TransferenciaBensItem,
+)
+from dados_comuns.tests.auth_test_utils import auth_kwargs, codigo_ua, codigo_uo
+from dados_comuns.tests.factories import criar_ua, criar_uo
+from usuario.constants import GRUPO_GESTOR_PATRIMONIO, GRUPO_OPERADOR_INVENTARIO
+from usuario.models import Usuario
+
+
+class TransferenciaBemPatrimonialAdminTestCase(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.site = AdminSite()
+        self.admin = TransferenciaBemPatrimonialAdmin(
+            TransferenciaBemPatrimonial,
+            self.site,
+        )
+
+        self.uo_origem = criar_uo(codigo=codigo_uo(1, 16, 70), nome="SME", sigla="SME")
+        self.ua_origem = criar_ua(
+            uo=self.uo_origem,
+            codigo=f"{self.uo_origem.codigo}.001",
+            sigla="UA1",
+            nome="Unidade 1",
+        )
+        self.ua_origem_2 = criar_ua(
+            uo=self.uo_origem,
+            codigo=f"{self.uo_origem.codigo}.002",
+            sigla="UA2",
+            nome="Unidade 2",
+        )
+        self.uo_destino = criar_uo(
+            codigo=codigo_uo(3, 30, 30),
+            nome="Secretaria Externa",
+            sigla="EXT",
+        )
+        self.ua_destino = criar_ua(
+            uo=self.uo_destino,
+            codigo=codigo_ua(3, 30, 30, 1),
+            sigla="PC",
+            nome="Ponto Central",
+        )
+        self.ua_destino_2 = criar_ua(
+            uo=self.uo_destino,
+            codigo=codigo_ua(3, 30, 30, 2),
+            sigla="DST2",
+            nome="Destino 2",
+        )
+
+        grupo_gestor = Group.objects.get_or_create(name=GRUPO_GESTOR_PATRIMONIO)[0]
+        grupo_operador = Group.objects.get_or_create(name=GRUPO_OPERADOR_INVENTARIO)[0]
+
+        self.gestor = Usuario.objects.create_user(
+            username="gestor_transfer_admin",
+            email="gestor.transfer.admin@test.com",
+            **auth_kwargs("123456"),
+            nome="Gestor",
+            is_staff=True,
+            unidade_orcamentaria=self.uo_origem,
+            unidade_administrativa=self.ua_origem,
+        )
+        self.gestor.groups.add(grupo_gestor)
+        self.gestor.must_change_password = False
+        self.gestor.save(update_fields=["must_change_password"])
+
+        self.gestor_destino = Usuario.objects.create_user(
+            username="gestor_transfer_destino",
+            email="gestor.transfer.destino@test.com",
+            **auth_kwargs("123456"),
+            nome="Gestor Destino",
+            is_staff=True,
+            unidade_orcamentaria=self.uo_destino,
+            unidade_administrativa=self.ua_destino_2,
+        )
+        self.gestor_destino.groups.add(grupo_gestor)
+
+        self.operador = Usuario.objects.create_user(
+            username="operador_transfer_admin",
+            email="operador.transfer.admin@test.com",
+            **auth_kwargs("123456"),
+            nome="Operador",
+            is_staff=True,
+            unidade_orcamentaria=self.uo_origem,
+            unidade_administrativa=self.ua_origem,
+        )
+        self.operador.groups.add(grupo_operador)
+
+    def test_form_resolve_ua_destino_001_automaticamente(self):
+        form = TransferenciaBemPatrimonialForm(
+            data={
+                "unidade_orcamentaria_destino": self.uo_destino.pk,
+                "numero_processo": "SEI-123/2026",
+                "observacao": "Teste",
+            },
+            request=type("obj", (object,), {"user": self.gestor})(),
+        )
+
+        self.assertTrue(form.is_valid(), form.errors)
+        self.assertEqual(
+            form.cleaned_data["unidade_orcamentaria_origem"],
+            self.uo_origem,
+        )
+        self.assertEqual(
+            form.cleaned_data["unidade_administrativa_destino"],
+            self.ua_destino,
+        )
+
+    def test_form_expoe_filtro_por_ua_da_uo_origem(self):
+        form = TransferenciaBemPatrimonialForm(
+            request=type("obj", (object,), {"user": self.gestor})(),
+        )
+
+        queryset = form.fields["unidade_administrativa_filtro"].queryset
+        self.assertEqual(
+            list(queryset.values_list("id", flat=True)),
+            [self.ua_origem.id, self.ua_origem_2.id],
+        )
+
+    def test_change_form_nao_quebra_quando_campos_model_sao_readonly(self):
+        transferencia = TransferenciaBemPatrimonial.objects.create(
+            unidade_orcamentaria_origem=self.uo_origem,
+            unidade_orcamentaria_destino=self.uo_destino,
+            unidade_administrativa_destino=self.ua_destino,
+            numero_processo="SEI-123/2026",
+            criado_por=self.gestor,
+        )
+        request = self.factory.get(
+            f"/admin/bem_patrimonial/transferenciabempatrimonial/{transferencia.pk}/change/"
+        )
+        request.user = self.gestor
+
+        form_class = self.admin.get_form(request, obj=transferencia)
+        form = form_class(instance=transferencia)
+
+        self.assertNotIn("unidade_orcamentaria_origem", form.fields)
+
+    def test_queryset_admin_exibe_transferencia_para_uo_destino(self):
+        transferencia = TransferenciaBemPatrimonial.objects.create(
+            unidade_orcamentaria_origem=self.uo_origem,
+            unidade_orcamentaria_destino=self.uo_destino,
+            unidade_administrativa_destino=self.ua_destino,
+            numero_processo="SEI-123/2026",
+            criado_por=self.gestor,
+        )
+        request = self.factory.get("/admin/bem_patrimonial/transferenciabempatrimonial/")
+        request.user = self.gestor_destino
+
+        queryset = self.admin.get_queryset(request)
+
+        self.assertIn(transferencia, queryset)
+
+    def test_change_form_remove_bloco_redundante_bens_transferidos(self):
+        request = self.factory.get("/admin/bem_patrimonial/transferenciabempatrimonial/1/change/")
+        request.user = self.gestor
+
+        fields = self.admin.get_fields(
+            request,
+            obj=TransferenciaBemPatrimonial(
+                unidade_orcamentaria_origem=self.uo_origem,
+                unidade_orcamentaria_destino=self.uo_destino,
+                unidade_administrativa_destino=self.ua_destino,
+                numero_processo="SEI-123/2026",
+                criado_por=self.gestor,
+            ),
+        )
+
+        self.assertNotIn("get_bens_transferidos_links", fields)
+
+    def test_create_form_posiciona_filtro_perto_dos_itens(self):
+        request = self.factory.get("/admin/bem_patrimonial/transferenciabempatrimonial/add/")
+        request.user = self.gestor
+
+        fields = self.admin.get_fields(request)
+
+        self.assertEqual(fields[-1], "unidade_administrativa_filtro")
+
+    def test_inline_formset_exige_ao_menos_um_bem(self):
+        formset = TransferenciaBensItemInlineFormSet.__new__(
+            TransferenciaBensItemInlineFormSet
+        )
+        formset.forms = [SimpleNamespace(cleaned_data={"bem": None, "DELETE": False})]
+        formset._errors = []
+
+        with patch("django.forms.models.BaseInlineFormSet.clean", return_value=None):
+            with self.assertRaises(ValidationError) as ctx:
+                formset.clean()
+
+        self.assertIn("ao menos um bem", str(ctx.exception))
+
+    def test_inline_formset_ignora_validacao_quando_ha_erros(self):
+        formset = TransferenciaBensItemInlineFormSet.__new__(
+            TransferenciaBensItemInlineFormSet
+        )
+        formset.forms = []
+        formset._errors = [{"bem": ["erro"]}]
+
+        with patch("django.forms.models.BaseInlineFormSet.clean", return_value=None):
+            formset.clean()
+
+    def test_inline_form_personaliza_label_do_bem(self):
+        form = TransferenciaBensItemInlineForm()
+        bem = BemPatrimonial.objects.create(
+            numero_patrimonial="001.000000091-0",
+            nome="Bem label inline",
+            descricao="Descricao",
+            valor_unitario=100,
+            marca="Marca",
+            modelo="Modelo",
+            numero_processo="PROC-2",
+            status=constants.APROVADO,
+            unidade_administrativa=self.ua_origem,
+            criado_por=self.gestor,
+        )
+
+        label = form.fields["bem"].label_from_instance(bem)
+
+        self.assertIn(f"{self.ua_origem.codigo} - {self.ua_origem.sigla}", label)
+        self.assertIn("001.000000091-0", label)
+        self.assertIn("Bem label inline", label)
+
+    def test_inline_form_nao_quebra_sem_campo_bem_no_change_view(self):
+        form_class = modelform_factory(
+            TransferenciaBensItem,
+            form=TransferenciaBensItemInlineForm,
+            fields=(),
+        )
+
+        form = form_class()
+
+        self.assertNotIn("bem", form.fields)
+
+    def test_inline_change_view_exibe_ua_e_link_do_bem(self):
+        transferencia = TransferenciaBemPatrimonial.objects.create(
+            unidade_orcamentaria_origem=self.uo_origem,
+            unidade_orcamentaria_destino=self.uo_destino,
+            unidade_administrativa_destino=self.ua_destino,
+            numero_processo="SEI-123/2026",
+            criado_por=self.gestor,
+        )
+        bem = BemPatrimonial.objects.create(
+            numero_patrimonial="001.000000092-0",
+            nome="Bem detalhado inline",
+            descricao="Descricao",
+            valor_unitario=100,
+            marca="Marca",
+            modelo="Modelo",
+            numero_processo="PROC-3",
+            status=constants.APROVADO,
+            unidade_administrativa=self.ua_origem_2,
+            criado_por=self.gestor,
+        )
+        item = TransferenciaBensItem.objects.create(transferencia=transferencia, bem=bem)
+        transferencia.efetivar_transferencia(self.gestor)
+        item.refresh_from_db()
+        inline = TransferenciaBensItemInline(TransferenciaBemPatrimonial, self.site)
+
+        html = inline.bem_detalhado(item)
+
+        self.assertIn(f"{self.ua_origem_2.codigo} - {self.ua_origem_2.sigla}", html)
+        self.assertIn("001.000000092-0 - Bem detalhado inline", html)
+        self.assertNotIn(str(self.ua_destino), html)
+        self.assertIn(
+            reverse("admin:bem_patrimonial_bempatrimonial_change", args=[bem.pk]),
+            html,
+        )
+
+    def test_inline_nao_permita_exclusao(self):
+        inline = TransferenciaBensItemInline(TransferenciaBemPatrimonial, self.site)
+
+        self.assertFalse(inline.can_delete)
+
+    def test_change_view_nao_exibe_texto_original_nem_controles_de_apagar(self):
+        transferencia = TransferenciaBemPatrimonial.objects.create(
+            unidade_orcamentaria_origem=self.uo_origem,
+            unidade_orcamentaria_destino=self.uo_destino,
+            unidade_administrativa_destino=self.ua_destino,
+            numero_processo="SEI-HTML-1",
+            criado_por=self.gestor,
+        )
+        bem = BemPatrimonial.objects.create(
+            numero_patrimonial="001.000000093-0",
+            nome="Bem template inline",
+            descricao="Descricao",
+            valor_unitario=100,
+            marca="Marca",
+            modelo="Modelo",
+            numero_processo="PROC-HTML-1",
+            status=constants.APROVADO,
+            unidade_administrativa=self.ua_origem_2,
+            criado_por=self.gestor,
+        )
+        TransferenciaBensItem.objects.create(transferencia=transferencia, bem=bem)
+
+        client = Client()
+        client.force_login(self.gestor)
+        response = client.get(
+            reverse(
+                "admin:bem_patrimonial_transferenciabempatrimonial_change",
+                args=[transferencia.pk],
+            )
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "Transf#")
+        self.assertNotContains(response, "Apagar?")
+        self.assertNotContains(response, "deletelink")
+
+    def test_changeform_extra_context_oculta_botoes_de_salvar(self):
+        context = self.admin._get_changeform_extra_context(object_id="1")
+
+        self.assertFalse(context["show_save"])
+        self.assertFalse(context["show_save_and_continue"])
+        self.assertFalse(context["show_save_and_add_another"])
+        self.assertTrue(context["show_close"])
+
+    def test_change_view_rejeita_post_em_registro_existente(self):
+        request = self.factory.post("/admin/bem_patrimonial/transferenciabempatrimonial/1/change/")
+        request.user = self.gestor
+
+        with self.assertRaises(PermissionDenied):
+            self.admin.changeform_view(request, object_id="1")
+
+    def test_inline_has_add_permission_apenas_na_criacao(self):
+        inline = TransferenciaBensItemInline(TransferenciaBemPatrimonial, self.site)
+        request = self.factory.get("/admin/")
+        request.user = self.gestor
+
+        self.assertTrue(inline.has_add_permission(request, obj=None))
+        self.assertFalse(
+            inline.has_add_permission(
+                request,
+                obj=TransferenciaBemPatrimonial(
+                    unidade_orcamentaria_origem=self.uo_origem,
+                    unidade_orcamentaria_destino=self.uo_destino,
+                    unidade_administrativa_destino=self.ua_destino,
+                    numero_processo="SEI-OBJ",
+                    criado_por=self.gestor,
+                ),
+            )
+        )
+
+    def test_admin_modulo_restrito_a_gestor(self):
+        request_gestor = self.factory.get("/admin/bem_patrimonial/transferenciabempatrimonial/")
+        request_gestor.user = self.gestor
+
+        request_operador = self.factory.get("/admin/bem_patrimonial/transferenciabempatrimonial/")
+        request_operador.user = self.operador
+
+        self.assertTrue(self.admin.has_module_permission(request_gestor))
+        self.assertTrue(self.admin.has_view_permission(request_gestor))
+        self.assertFalse(self.admin.has_module_permission(request_operador))
+        self.assertFalse(self.admin.has_view_permission(request_operador))

--- a/bem_patrimonial/tests/tests_transferencia_bem_patrimonial.py
+++ b/bem_patrimonial/tests/tests_transferencia_bem_patrimonial.py
@@ -1,0 +1,150 @@
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+
+from bem_patrimonial import constants
+from bem_patrimonial.models import (
+    BemPatrimonial,
+    StatusBemPatrimonial,
+    TransferenciaBemPatrimonial,
+    TransferenciaBensItem,
+)
+from dados_comuns.tests.auth_test_utils import auth_kwargs, codigo_ua, codigo_uo
+from dados_comuns.tests.factories import criar_ua, criar_uo
+from usuario.models import Usuario
+
+
+class TransferenciaBemPatrimonialModelTestCase(TestCase):
+    def setUp(self):
+        self.uo_origem = criar_uo(
+            codigo=codigo_uo(1, 16, 28),
+            nome="SME",
+            sigla="SME",
+        )
+        self.ua_origem_1 = criar_ua(
+            uo=self.uo_origem,
+            codigo=f"{self.uo_origem.codigo}.001",
+            sigla="UA1",
+            nome="Unidade 1",
+        )
+        self.ua_origem_2 = criar_ua(
+            uo=self.uo_origem,
+            codigo=f"{self.uo_origem.codigo}.002",
+            sigla="UA2",
+            nome="Unidade 2",
+        )
+        self.uo_destino = criar_uo(
+            codigo=codigo_uo(2, 20, 30),
+            nome="Secretaria Externa",
+            sigla="EXT",
+        )
+        self.ua_destino = criar_ua(
+            uo=self.uo_destino,
+            codigo=codigo_ua(2, 20, 30, 1),
+            sigla="PC",
+            nome="Ponto Central",
+        )
+        self.gestor = Usuario.objects.create_user(
+            username="gestor_transferencia",
+            email="gestor.transferencia@test.com",
+            **auth_kwargs("123456"),
+            nome="Gestor",
+            is_staff=True,
+            unidade_orcamentaria=self.uo_origem,
+            unidade_administrativa=self.ua_origem_1,
+        )
+
+    def _criar_bem(self, numero, ua, status=constants.APROVADO):
+        return BemPatrimonial.objects.create(
+            numero_patrimonial=numero,
+            nome=f"Bem {numero}",
+            descricao="Descrição",
+            valor_unitario=100,
+            marca="Marca",
+            modelo="Modelo",
+            numero_processo="PROC-BASE",
+            status=status,
+            unidade_administrativa=ua,
+            criado_por=self.gestor,
+        )
+
+    def _criar_transferencia(self):
+        return TransferenciaBemPatrimonial.objects.create(
+            unidade_orcamentaria_origem=self.uo_origem,
+            unidade_orcamentaria_destino=self.uo_destino,
+            unidade_administrativa_destino=self.ua_destino,
+            numero_processo="SEI-123456/2026",
+            observacao="Transferência externa",
+            criado_por=self.gestor,
+        )
+
+    def test_efetivar_transferencia_move_bens_e_registra_status(self):
+        bem1 = self._criar_bem("001.000000001-1", self.ua_origem_1)
+        bem2 = self._criar_bem("001.000000002-2", self.ua_origem_2)
+        transferencia = self._criar_transferencia()
+
+        TransferenciaBensItem.objects.create(transferencia=transferencia, bem=bem1)
+        TransferenciaBensItem.objects.create(transferencia=transferencia, bem=bem2)
+
+        transferencia.efetivar_transferencia(self.gestor)
+
+        bem1.refresh_from_db()
+        bem2.refresh_from_db()
+        transferencia.refresh_from_db()
+
+        self.assertEqual(bem1.unidade_administrativa, self.ua_destino)
+        self.assertEqual(bem2.unidade_administrativa, self.ua_destino)
+        self.assertEqual(bem1.status, constants.TRANSFERIDO)
+        self.assertEqual(bem2.status, constants.TRANSFERIDO)
+        self.assertEqual(transferencia.efetivado_por, self.gestor)
+        self.assertIsNotNone(transferencia.efetivado_em)
+        self.assertTrue(transferencia.numero_ntbpm)
+        self.assertEqual(
+            StatusBemPatrimonial.objects.filter(
+                bem_patrimonial=bem1,
+                status=constants.TRANSFERIDO,
+            ).count(),
+            1,
+        )
+
+    def test_efetivar_transferencia_exige_bens(self):
+        transferencia = self._criar_transferencia()
+
+        with self.assertRaises(ValidationError) as ctx:
+            transferencia.efetivar_transferencia(self.gestor)
+
+        self.assertIn("sem bens", str(ctx.exception))
+
+    def test_efetivar_transferencia_rejeita_bem_fora_da_uo_origem(self):
+        outra_uo = criar_uo(
+            codigo=codigo_uo(9, 9, 9),
+            nome="Outra UO",
+            sigla="OUT",
+        )
+        outra_ua = criar_ua(
+            uo=outra_uo,
+            codigo=codigo_ua(9, 9, 9, 1),
+            sigla="OUT1",
+            nome="Outra UA",
+        )
+        bem = self._criar_bem("001.000000003-3", outra_ua)
+        transferencia = self._criar_transferencia()
+        TransferenciaBensItem.objects.create(transferencia=transferencia, bem=bem)
+
+        with self.assertRaises(ValidationError) as ctx:
+            transferencia.efetivar_transferencia(self.gestor)
+
+        self.assertIn("não pertence à UO de origem", str(ctx.exception))
+
+    def test_efetivar_transferencia_rejeita_bem_nao_aprovado(self):
+        bem = self._criar_bem(
+            "001.000000004-4",
+            self.ua_origem_1,
+            status=constants.BLOQUEADO,
+        )
+        transferencia = self._criar_transferencia()
+        TransferenciaBensItem.objects.create(transferencia=transferencia, bem=bem)
+
+        with self.assertRaises(ValidationError) as ctx:
+            transferencia.efetivar_transferencia(self.gestor)
+
+        self.assertIn("status 'Aprovado'", str(ctx.exception))

--- a/bem_patrimonial/tests/tests_transferencia_bem_patrimonial.py
+++ b/bem_patrimonial/tests/tests_transferencia_bem_patrimonial.py
@@ -95,8 +95,6 @@ class TransferenciaBemPatrimonialModelTestCase(TestCase):
         self.assertEqual(bem2.unidade_administrativa, self.ua_destino)
         self.assertEqual(bem1.status, constants.TRANSFERIDO)
         self.assertEqual(bem2.status, constants.TRANSFERIDO)
-        self.assertEqual(transferencia.efetivado_por, self.gestor)
-        self.assertIsNotNone(transferencia.efetivado_em)
         self.assertTrue(transferencia.numero_ntbpm)
         self.assertEqual(
             StatusBemPatrimonial.objects.filter(
@@ -148,3 +146,35 @@ class TransferenciaBemPatrimonialModelTestCase(TestCase):
             transferencia.efetivar_transferencia(self.gestor)
 
         self.assertIn("status 'Aprovado'", str(ctx.exception))
+
+    def test_efetivar_transferencia_revalida_bem_antes_de_gravar(self):
+        bem = self._criar_bem("001.000000005-5", self.ua_origem_1)
+        transferencia = self._criar_transferencia()
+        TransferenciaBensItem.objects.create(transferencia=transferencia, bem=bem)
+
+        bem.unidade_administrativa = self.ua_destino
+        bem.status = constants.TRANSFERIDO
+        bem.save(update_fields=["unidade_administrativa", "status", "atualizado_em"])
+
+        with self.assertRaises(ValidationError) as ctx:
+            transferencia.efetivar_transferencia(self.gestor)
+
+        transferencia.refresh_from_db()
+        self.assertIn("status 'Aprovado'", str(ctx.exception))
+        self.assertFalse(transferencia.numero_ntbpm)
+
+    def test_numero_processo_da_transferencia_deve_ser_unico(self):
+        self._criar_transferencia()
+        transferencia = TransferenciaBemPatrimonial(
+            unidade_orcamentaria_origem=self.uo_origem,
+            unidade_orcamentaria_destino=self.uo_destino,
+            unidade_administrativa_destino=self.ua_destino,
+            numero_processo="SEI-123456/2026",
+            observacao="Outra transferência",
+            criado_por=self.gestor,
+        )
+
+        with self.assertRaises(ValidationError) as ctx:
+            transferencia.full_clean()
+
+        self.assertIn("numero_processo", ctx.exception.message_dict)

--- a/bem_patrimonial/views.py
+++ b/bem_patrimonial/views.py
@@ -33,10 +33,16 @@ from bem_patrimonial.models import (
     BaixaFisicaBensItem,
     BemPatrimonial,
     MovimentacaoBemPatrimonial,
+    TransferenciaBemPatrimonial,
 )
 from dados_comuns.models import HistoricoGeral
 from dados_comuns.context import audit_as
-from dados_comuns.escopo import filtrar_queryset_por_escopo, validar_objeto_no_escopo
+from dados_comuns.escopo import (
+    filtrar_queryset_bem_por_escopo_com_transferencia,
+    filtrar_queryset_por_escopo,
+    filtrar_queryset_transferencia_por_escopo,
+    validar_bem_no_escopo_com_transferencia,
+)
 
 
 @login_required
@@ -77,6 +83,47 @@ def download_documento_cimbpm(request, pk):
         raise Http404(f"Erro ao gerar documento: {str(e)}")
 
     filename = f"CIMBPM_{movimentacao.numero_cimbpm.replace('.', '_')}.pdf"
+
+    return FileResponse(
+        pdf_buffer,
+        as_attachment=True,
+        filename=filename,
+        content_type="application/pdf",
+    )
+
+
+@login_required
+@require_GET
+def download_documento_ntbpm(request, pk):
+    if not request.user.is_gestor_patrimonio:
+        raise PermissionDenied(
+            "Você não tem permissão para acessar este documento. "
+            "Apenas Gestor de Patrimônio pode baixar documentos de transferência."
+        )
+
+    transferencia = get_object_or_404(
+        filtrar_queryset_transferencia_por_escopo(
+            request.user,
+            TransferenciaBemPatrimonial.objects.all(),
+        ),
+        pk=pk,
+    )
+
+    if not transferencia.numero_ntbpm:
+        raise Http404("Erro: Número NTBPM não foi gerado para esta transferência")
+
+    from bem_patrimonial.ntbpm import gerar_pdf_ntbpm
+
+    try:
+        pdf_buffer = gerar_pdf_ntbpm(
+            transferencia,
+            usuario_gerador=request.user,
+            data_geracao=timezone.now(),
+        )
+    except Exception as e:
+        raise Http404(f"Erro ao gerar documento: {str(e)}")
+
+    filename = f"NTBPM_{transferencia.numero_ntbpm.replace('.', '_')}.pdf"
 
     return FileResponse(
         pdf_buffer,
@@ -134,11 +181,7 @@ class BemPatrimonialViewSet(viewsets.ModelViewSet):
             "criado_por",
         )
 
-        qs = filtrar_queryset_por_escopo(
-            usuario=self.request.user,
-            queryset=qs,
-            campo_ua="unidade_administrativa",
-        )
+        qs = filtrar_queryset_bem_por_escopo_com_transferencia(self.request.user, qs)
 
         baixa_data_sq = (
             BaixaFisicaBensItem.objects.filter(bem_id=OuterRef("pk"))
@@ -171,11 +214,7 @@ class BemPatrimonialViewSet(viewsets.ModelViewSet):
     def get_object(self):
         obj = super().get_object()
 
-        if not validar_objeto_no_escopo(
-            usuario=self.request.user,
-            objeto=obj,
-            campo_ua="unidade_administrativa",
-        ):
+        if not validar_bem_no_escopo_com_transferencia(self.request.user, obj):
             from rest_framework.exceptions import NotFound
 
             raise NotFound()

--- a/config/templates/admin/edit_inline/transferencia_bens_tabular.html
+++ b/config/templates/admin/edit_inline/transferencia_bens_tabular.html
@@ -1,0 +1,55 @@
+{% load i18n admin_urls static admin_modify %}
+<div class="js-inline-admin-formset inline-group" id="{{ inline_admin_formset.formset.prefix }}-group"
+     data-inline-type="tabular"
+     data-inline-formset="{{ inline_admin_formset.inline_formset_data }}">
+  <div class="tabular inline-related {% if forloop.last %}last-related{% endif %}">
+{{ inline_admin_formset.formset.management_form }}
+<fieldset class="module {{ inline_admin_formset.classes }}">
+   {% if inline_admin_formset.formset.max_num == 1 %}
+     <h2>{{ inline_admin_formset.opts.verbose_name|capfirst }}</h2>
+   {% else %}
+     <h2>{{ inline_admin_formset.opts.verbose_name_plural|capfirst }}</h2>
+   {% endif %}
+   {{ inline_admin_formset.formset.non_form_errors }}
+   <table>
+     <thead><tr>
+       <th class="original hidden"></th>
+     {% for field in inline_admin_formset.fields %}
+       <th class="column-{{ field.name }}{% if field.required %} required{% endif %}{% if field.widget.is_hidden %} hidden{% endif %}">{{ field.label|capfirst }}
+       {% if field.help_text %}<img src="{% static "admin/img/icon-unknown.svg" %}" class="help help-tooltip" width="10" height="10" alt="({{ field.help_text|striptags }})" title="{{ field.help_text|striptags }}">{% endif %}
+       </th>
+     {% endfor %}
+     </tr></thead>
+
+     <tbody>
+     {% for inline_admin_form in inline_admin_formset %}
+        {% if inline_admin_form.form.non_field_errors %}
+        <tr class="row-form-errors"><td colspan="{{ inline_admin_form|cell_count }}">{{ inline_admin_form.form.non_field_errors }}</td></tr>
+        {% endif %}
+        <tr class="form-row {% if inline_admin_form.original or inline_admin_form.show_url %}has_original{% endif %}{% if forloop.last and inline_admin_formset.has_add_permission %} empty-form{% endif %}"
+             id="{{ inline_admin_formset.formset.prefix }}-{% if forloop.last and inline_admin_formset.has_add_permission %}empty{% else %}{{ forloop.counter0 }}{% endif %}">
+        <td class="original hidden">
+          {% if inline_admin_form.needs_explicit_pk_field %}{{ inline_admin_form.pk_field.field }}{% endif %}
+          {% if inline_admin_form.fk_field %}{{ inline_admin_form.fk_field.field }}{% endif %}
+        </td>
+        {% for fieldset in inline_admin_form %}
+          {% for line in fieldset %}
+            {% for field in line %}
+              <td class="{% if field.field.name %}field-{{ field.field.name }}{% endif %}{% if field.field.is_hidden %} hidden{% endif %}">
+              {% if field.is_readonly %}
+                  <p>{{ field.contents }}</p>
+              {% else %}
+                  {{ field.field.errors.as_ul }}
+                  {{ field.field }}
+              {% endif %}
+              </td>
+            {% endfor %}
+          {% endfor %}
+        {% endfor %}
+        </tr>
+     {% endfor %}
+     </tbody>
+   </table>
+</fieldset>
+  </div>
+</div>

--- a/config/urls.py
+++ b/config/urls.py
@@ -14,7 +14,7 @@ from usuario.views import (
     PasswordRecoveryCompleteView,
     SelecionarUAView,
 )
-from bem_patrimonial.views import download_documento_cimbpm
+from bem_patrimonial.views import download_documento_cimbpm, download_documento_ntbpm
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.conf.urls.static import static
@@ -71,6 +71,11 @@ urlpatterns = [
         "documento-cimbpm/<int:pk>/download/",
         download_documento_cimbpm,
         name="download_documento_cimbpm",
+    ),
+    path(
+        "documento-ntbpm/<int:pk>/download/",
+        download_documento_ntbpm,
+        name="download_documento_ntbpm",
     ),
     path("", include("inventario.urls")),
     # Recuperação de senha

--- a/dados_comuns/admin.py
+++ b/dados_comuns/admin.py
@@ -13,6 +13,7 @@ from dados_comuns.forms.unidade_administrativa_admin_form import (
 from dados_comuns.models import UnidadeAdministrativa, UnidadeOrcamentaria
 from dados_comuns.resources import UnidadeAdministrativaResource
 from dados_comuns.formats import UnidadeAdministrativaPDFFormat
+from dados_comuns.utils import garantir_ua_ponto_central_externa
 
 
 UNIDADE_ADMINISTRATIVA_ORIGEM_AUTOCOMPLETE = "unidade_administrativa_origem"
@@ -84,18 +85,22 @@ class UnidadeOrcamentariaAdmin(ImportExportModelAdmin):
     list_display = (
         "codigo",
         "nome",
+        "orgao",
+        "codigo_orgao",
         "ativa",
     )
     search_fields = (
         "codigo",
         "nome",
+        "orgao",
+        "codigo_orgao",
     )
-    search_help_text = "Pesquise por código ou nome."
+    search_help_text = "Pesquise por código, nome, órgão ou código do órgão."
     ordering = ("codigo", "nome")
 
     list_filter = (AtivaFilter,)
 
-    fields = ("codigo", "nome", "ativa", "sigla")
+    fields = ("codigo", "nome", "sigla", "orgao", "codigo_orgao", "ativa")
 
     def get_form(self, request, obj=None, **kwargs):
         form = super().get_form(request, obj, **kwargs)
@@ -105,6 +110,8 @@ class UnidadeOrcamentariaAdmin(ImportExportModelAdmin):
             cleaned_data = original_clean(form_self)
             codigo = (cleaned_data.get("codigo") or "").strip()
             nome = (cleaned_data.get("nome") or "").strip()
+            orgao = (cleaned_data.get("orgao") or "").strip()
+            codigo_orgao = (cleaned_data.get("codigo_orgao") or "").strip()
 
             if not codigo:
                 raise ValidationError({"codigo": "Código é obrigatório."})
@@ -113,6 +120,8 @@ class UnidadeOrcamentariaAdmin(ImportExportModelAdmin):
 
             cleaned_data["codigo"] = codigo
             cleaned_data["nome"] = nome
+            cleaned_data["orgao"] = orgao
+            cleaned_data["codigo_orgao"] = codigo_orgao
 
             return cleaned_data
 
@@ -121,6 +130,14 @@ class UnidadeOrcamentariaAdmin(ImportExportModelAdmin):
 
     def save_model(self, request, obj, form, change):
         super().save_model(request, obj, form, change)
+
+        _, ua_criada = garantir_ua_ponto_central_externa(obj)
+
+        if ua_criada:
+            messages.success(
+                request,
+                "UA 001 'Ponto Central' criada automaticamente para a UO externa.",
+            )
 
         if change:
             messages.success(request, "Unidade Orçamentária atualizada com sucesso.")

--- a/dados_comuns/admin.py
+++ b/dados_comuns/admin.py
@@ -12,7 +12,10 @@ from dados_comuns.forms.unidade_administrativa_admin_form import (
 )
 from dados_comuns.models import UnidadeAdministrativa, UnidadeOrcamentaria
 from dados_comuns.resources import UnidadeAdministrativaResource
-from dados_comuns.formats import UnidadeAdministrativaPDFFormat
+from dados_comuns.formats import (
+    UnidadeAdministrativaPDFFormat,
+    UnidadeOrcamentariaPDFFormat,
+)
 from dados_comuns.utils import garantir_ua_ponto_central_externa
 
 
@@ -100,16 +103,34 @@ class UnidadeOrcamentariaAdmin(ImportExportModelAdmin):
 
     list_filter = (AtivaFilter,)
 
-    fields = ("codigo", "nome", "sigla", "orgao", "codigo_orgao", "ativa")
+    fields = (
+        "codigo",
+        "nome",
+        "sigla",
+        "codigo_orgao",
+        "sigla_orgao",
+        "orgao",
+        "ativa",
+    )
 
     def get_form(self, request, obj=None, **kwargs):
         form = super().get_form(request, obj, **kwargs)
+        field_labels = {
+            "codigo_orgao": "Código do Orgão",
+            "sigla_orgao": "Sigla do Orgão",
+            "orgao": "Nome do Orgão",
+        }
+        for field_name, label in field_labels.items():
+            if field_name in form.base_fields:
+                form.base_fields[field_name].label = label
+
         original_clean = form.clean
 
         def custom_clean(form_self):
             cleaned_data = original_clean(form_self)
             codigo = (cleaned_data.get("codigo") or "").strip()
             nome = (cleaned_data.get("nome") or "").strip()
+            sigla_orgao = (cleaned_data.get("sigla_orgao") or "").strip()
             orgao = (cleaned_data.get("orgao") or "").strip()
             codigo_orgao = (cleaned_data.get("codigo_orgao") or "").strip()
 
@@ -120,6 +141,7 @@ class UnidadeOrcamentariaAdmin(ImportExportModelAdmin):
 
             cleaned_data["codigo"] = codigo
             cleaned_data["nome"] = nome
+            cleaned_data["sigla_orgao"] = sigla_orgao
             cleaned_data["orgao"] = orgao
             cleaned_data["codigo_orgao"] = codigo_orgao
 
@@ -145,7 +167,14 @@ class UnidadeOrcamentariaAdmin(ImportExportModelAdmin):
             messages.success(request, "Unidade Orçamentária criada com sucesso.")
 
     def get_export_formats(self):
-        return [CSV, XLSX, XLS]
+        return [CSV, XLSX, XLS, UnidadeOrcamentariaPDFFormat]
+
+    def get_export_data(self, file_format, queryset, *args, **kwargs):
+        if isinstance(file_format, UnidadeOrcamentariaPDFFormat):
+            request = kwargs.get("request")
+            file_format._export_request = request
+            file_format._export_queryset = queryset
+        return super().get_export_data(file_format, queryset, *args, **kwargs)
 
 
 @admin.register(UnidadeAdministrativa)

--- a/dados_comuns/api_serializers.py
+++ b/dados_comuns/api_serializers.py
@@ -15,8 +15,9 @@ class UnidadeOrcamentariaListSerializer(serializers.ModelSerializer):
             "codigo",
             "sigla",
             "nome",
-            "orgao",
             "codigo_orgao",
+            "sigla_orgao",
+            "orgao",
             "ativa",
             "ativa_display",
         ]
@@ -35,6 +36,9 @@ class UnidadeOrcamentariaDetailSerializer(UnidadeOrcamentariaListSerializer):
             },
             "codigo_orgao": {
                 "help_text": "Código do Órgão no padrão NN.NN."
+            },
+            "sigla_orgao": {
+                "help_text": "Sigla do Orgão vinculada à Unidade Orçamentária."
             }
         }
 

--- a/dados_comuns/api_serializers.py
+++ b/dados_comuns/api_serializers.py
@@ -15,6 +15,8 @@ class UnidadeOrcamentariaListSerializer(serializers.ModelSerializer):
             "codigo",
             "sigla",
             "nome",
+            "orgao",
+            "codigo_orgao",
             "ativa",
             "ativa_display",
         ]
@@ -30,6 +32,9 @@ class UnidadeOrcamentariaDetailSerializer(UnidadeOrcamentariaListSerializer):
         extra_kwargs = {
             "codigo": {
                 "help_text": "Código da Unidade Orçamentária no padrão do projeto (ex.: 01.16.10)."
+            },
+            "codigo_orgao": {
+                "help_text": "Código do Órgão no padrão NN.NN."
             }
         }
 

--- a/dados_comuns/api_views.py
+++ b/dados_comuns/api_views.py
@@ -47,7 +47,7 @@ from dados_comuns.resources import (
     UnidadeAdministrativaResource,
     UnidadeOrcamentariaResource,
 )
-from dados_comuns.utils import dict_changes
+from dados_comuns.utils import dict_changes, garantir_ua_ponto_central_externa
 
 
 UA_ID_PATH_PARAM = OpenApiParameter(
@@ -325,7 +325,7 @@ class UnidadeOrcamentariaViewSet(AuditHistoryExportMixin, viewsets.ModelViewSet)
 
     filter_backends = [DjangoFilterBackend, SearchFilter, OrderingFilter]
     filterset_fields = ["ativa"]
-    search_fields = ["codigo", "sigla", "nome"]
+    search_fields = ["codigo", "sigla", "nome", "orgao", "codigo_orgao"]
     ordering_fields = ["id", "codigo", "sigla", "nome", "ativa"]
     ordering = ["codigo", "nome"]
 
@@ -333,6 +333,8 @@ class UnidadeOrcamentariaViewSet(AuditHistoryExportMixin, viewsets.ModelViewSet)
         "codigo",
         "sigla",
         "nome",
+        "orgao",
+        "codigo_orgao",
         "ativa",
     )
 
@@ -362,6 +364,7 @@ class UnidadeOrcamentariaViewSet(AuditHistoryExportMixin, viewsets.ModelViewSet)
         with transaction.atomic():
             with audit_as(self.request.user):
                 obj = serializer.save()
+                garantir_ua_ponto_central_externa(obj)
             self._audit_changes(obj, operation="create")
 
     def perform_update(self, serializer):
@@ -370,6 +373,7 @@ class UnidadeOrcamentariaViewSet(AuditHistoryExportMixin, viewsets.ModelViewSet)
         with transaction.atomic():
             with audit_as(self.request.user):
                 obj = serializer.save()
+                garantir_ua_ponto_central_externa(obj)
             self._audit_changes(obj, original=original, operation="update")
 
     def perform_destroy(self, instance):

--- a/dados_comuns/api_views.py
+++ b/dados_comuns/api_views.py
@@ -325,7 +325,7 @@ class UnidadeOrcamentariaViewSet(AuditHistoryExportMixin, viewsets.ModelViewSet)
 
     filter_backends = [DjangoFilterBackend, SearchFilter, OrderingFilter]
     filterset_fields = ["ativa"]
-    search_fields = ["codigo", "sigla", "nome", "orgao", "codigo_orgao"]
+    search_fields = ["codigo", "sigla", "nome", "codigo_orgao", "sigla_orgao", "orgao"]
     ordering_fields = ["id", "codigo", "sigla", "nome", "ativa"]
     ordering = ["codigo", "nome"]
 
@@ -333,8 +333,9 @@ class UnidadeOrcamentariaViewSet(AuditHistoryExportMixin, viewsets.ModelViewSet)
         "codigo",
         "sigla",
         "nome",
-        "orgao",
         "codigo_orgao",
+        "sigla_orgao",
+        "orgao",
         "ativa",
     )
 

--- a/dados_comuns/escopo.py
+++ b/dados_comuns/escopo.py
@@ -144,3 +144,75 @@ def filtrar_queryset_movimentacao_por_escopo(usuario, queryset):
         )
 
     return queryset.none()
+
+
+def filtrar_queryset_transferencia_por_escopo(usuario, queryset):
+    """
+    Transferências visíveis:
+    - Gestor vê registros em que sua UO participa como origem OU destino.
+    - Demais usuários não acessam esse módulo.
+    """
+    _is_super, is_gestor, _ua_id, uo_id = resolver_ids_escopo(usuario)
+
+    if not (is_gestor and uo_id):
+        return queryset.none()
+
+    return queryset.filter(
+        Q(unidade_orcamentaria_origem_id=uo_id)
+        | Q(unidade_orcamentaria_destino_id=uo_id)
+    )
+
+
+def filtrar_queryset_bem_por_escopo_com_transferencia(usuario, queryset):
+    """
+    Para bens patrimoniais:
+    - mantém o escopo atual por UA/UO;
+    - adiciona leitura de bens com status transferido quando a UO do gestor
+      participou da transferência como origem ou destino.
+    """
+    from bem_patrimonial import constants as bem_constants
+
+    _is_super, is_gestor, ua_id, uo_id = resolver_ids_escopo(usuario)
+
+    if ua_id:
+        filtro_base = Q(unidade_administrativa_id=ua_id)
+    elif is_gestor and uo_id:
+        filtro_base = Q(unidade_administrativa__unidade_orcamentaria_id=uo_id)
+    else:
+        return queryset.none()
+
+    if not (is_gestor and uo_id):
+        return queryset.filter(filtro_base)
+
+    filtro_transferencia = Q(
+        status=bem_constants.TRANSFERIDO,
+        transferencias__unidade_orcamentaria_origem_id=uo_id,
+    ) | Q(
+        status=bem_constants.TRANSFERIDO,
+        transferencias__unidade_orcamentaria_destino_id=uo_id,
+    )
+
+    return queryset.filter(filtro_base | filtro_transferencia).distinct()
+
+
+def validar_bem_no_escopo_com_transferencia(usuario, bem):
+    """
+    Validação objeto-a-objeto equivalente ao filtro de bens com transparência
+    para histórico de itens transferidos.
+    """
+    from bem_patrimonial import constants as bem_constants
+
+    if validar_objeto_no_escopo(usuario, bem, campo_ua="unidade_administrativa"):
+        return True
+
+    _is_super, is_gestor, _ua_id, uo_id = resolver_ids_escopo(usuario)
+    if not (is_gestor and uo_id):
+        return False
+
+    if getattr(bem, "status", None) != bem_constants.TRANSFERIDO:
+        return False
+
+    return bem.transferencias.filter(
+        Q(unidade_orcamentaria_origem_id=uo_id)
+        | Q(unidade_orcamentaria_destino_id=uo_id)
+    ).exists()

--- a/dados_comuns/formats.py
+++ b/dados_comuns/formats.py
@@ -46,6 +46,9 @@ class BaseUnidadePDFFormat(Format):
     def get_table_col_widths(self):
         return self.TABLE_COL_WIDTHS
 
+    def get_table_headers(self):
+        return ["Código", "Sigla", "Nome", "Status"]
+
     def get_status_text(self, unidade):
         raise NotImplementedError("Subclasses devem implementar get_status_text().")
 
@@ -185,7 +188,7 @@ class BaseUnidadePDFFormat(Format):
             ]
 
         cell_style, cell_style_center = self._criar_estilos_celula(styles)
-        data = [["Código", "Sigla", "Nome", "Status"]]
+        data = [self.get_table_headers()]
 
         for unidade in unidades:
             data.append(self._criar_linha_unidade(unidade, cell_style, cell_style_center))
@@ -280,7 +283,31 @@ class UnidadeOrcamentariaPDFFormat(BaseUnidadePDFFormat):
     EMPTY_MESSAGE = (
         "<i>Nenhuma unidade orçamentária encontrada com os filtros aplicados.</i>"
     )
-    TABLE_COL_WIDTHS = [3 * cm, 4 * cm, 10.5 * cm, 2.5 * cm]
+    TABLE_FONT_SIZE = 6
+    TABLE_COL_WIDTHS = [2.1 * cm, 4.1 * cm, 4.7 * cm, 2.1 * cm, 4.7 * cm, 2.3 * cm]
+
+    def get_table_headers(self):
+        return [
+            "Código UO",
+            "Sigla UO",
+            "Nome UO",
+            "Código Órgão",
+            "Nome Órgão",
+            "Status",
+        ]
+
+    def _criar_linha_unidade(self, unidade, cell_style, cell_style_center):
+        return [
+            Paragraph(str(unidade.codigo) if unidade.codigo else "-", cell_style_center),
+            Paragraph(str(unidade.sigla) if unidade.sigla else "-", cell_style_center),
+            Paragraph(str(unidade.nome) if unidade.nome else "-", cell_style),
+            Paragraph(
+                str(unidade.codigo_orgao) if unidade.codigo_orgao else "-",
+                cell_style_center,
+            ),
+            Paragraph(str(unidade.orgao) if unidade.orgao else "-", cell_style),
+            Paragraph(self.get_status_text(unidade), cell_style_center),
+        ]
 
     def get_status_text(self, unidade):
         return "Ativa" if unidade.ativa else "Inativa"

--- a/dados_comuns/migrations/0012_unidadeorcamentaria_orgao_codigo_orgao.py
+++ b/dados_comuns/migrations/0012_unidadeorcamentaria_orgao_codigo_orgao.py
@@ -1,0 +1,39 @@
+from django.core.validators import RegexValidator
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("dados_comuns", "0011_remove_legacy_agendamento_suporte"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="unidadeorcamentaria",
+            name="codigo_orgao",
+            field=models.CharField(
+                blank=True,
+                default="",
+                help_text="Informe no padrão NN.NN.",
+                max_length=5,
+                validators=[
+                    RegexValidator(
+                        message="Código do Órgão deve seguir o padrão NN.NN.",
+                        regex="^\\d{2}\\.\\d{2}$",
+                    )
+                ],
+                verbose_name="Código do Órgão",
+            ),
+        ),
+        migrations.AddField(
+            model_name="unidadeorcamentaria",
+            name="orgao",
+            field=models.CharField(
+                blank=True,
+                default="",
+                max_length=255,
+                verbose_name="Órgão",
+            ),
+        ),
+    ]

--- a/dados_comuns/migrations/0013_unidadeorcamentaria_sigla_orgao.py
+++ b/dados_comuns/migrations/0013_unidadeorcamentaria_sigla_orgao.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("dados_comuns", "0012_unidadeorcamentaria_orgao_codigo_orgao"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="unidadeorcamentaria",
+            name="sigla_orgao",
+            field=models.CharField(
+                blank=True,
+                default="",
+                max_length=255,
+                verbose_name="Sigla do Órgão",
+            ),
+        ),
+    ]

--- a/dados_comuns/models.py
+++ b/dados_comuns/models.py
@@ -5,9 +5,15 @@ from django.contrib.contenttypes.fields import GenericForeignKey
 from django.utils import timezone
 from django.conf import settings
 from django.core.exceptions import ValidationError
+from django.core.validators import RegexValidator
 
 
 class UnidadeOrcamentaria(models.Model):
+    codigo_orgao_validator = RegexValidator(
+        regex=r"^\d{2}\.\d{2}$",
+        message="Código do Órgão deve seguir o padrão NN.NN.",
+    )
+
     codigo = models.CharField(
         "Código",
         max_length=20,
@@ -20,6 +26,16 @@ class UnidadeOrcamentaria(models.Model):
     )
 
     sigla = models.CharField("sigla", max_length=255, blank=True, default="")
+
+    orgao = models.CharField("Órgão", max_length=255, blank=True, default="")
+    codigo_orgao = models.CharField(
+        "Código do Órgão",
+        max_length=5,
+        blank=True,
+        default="",
+        validators=[codigo_orgao_validator],
+        help_text="Informe no padrão NN.NN.",
+    )
 
     ativa = models.BooleanField(
         "Ativa",

--- a/dados_comuns/models.py
+++ b/dados_comuns/models.py
@@ -26,6 +26,12 @@ class UnidadeOrcamentaria(models.Model):
     )
 
     sigla = models.CharField("sigla", max_length=255, blank=True, default="")
+    sigla_orgao = models.CharField(
+        "Sigla do Órgão",
+        max_length=255,
+        blank=True,
+        default="",
+    )
 
     orgao = models.CharField("Órgão", max_length=255, blank=True, default="")
     codigo_orgao = models.CharField(

--- a/dados_comuns/permissions.py
+++ b/dados_comuns/permissions.py
@@ -6,8 +6,8 @@ class BemPatrimonialPermission(BasePermission):
     """
     Espelha o admin:
     - Acesso ao módulo: gestor patrimônio OU operador inventário (ou superuser).
-    - Change: bloqueia se excluido ou BAIXA_FISICA (igual has_change_permission).
-    - Delete: só gestor, e bloqueia se excluido ou BAIXA_FISICA (igual has_delete_permission).
+    - Change: bloqueia se excluido ou status final (igual has_change_permission).
+    - Delete: só gestor, e bloqueia se excluido ou status final (igual has_delete_permission).
     """
 
     def _pode_acessar_modulo(self, user):
@@ -47,10 +47,11 @@ class BemPatrimonialPermission(BasePermission):
         if getattr(obj, "excluido", False):
             return False
 
-        if getattr(obj, "status", None) == getattr(
-            __import__("bem_patrimonial.constants", fromlist=["BAIXA_FISICA"]),
-            "BAIXA_FISICA",
-        ):
+        status_finais = getattr(
+            __import__("bem_patrimonial.constants", fromlist=["STATUS_FINAIS_BEM"]),
+            "STATUS_FINAIS_BEM",
+        )
+        if getattr(obj, "status", None) in status_finais:
             if getattr(view, "action", None) in ("retrieve", "list", "historico"):
                 return True
             return False

--- a/dados_comuns/resources.py
+++ b/dados_comuns/resources.py
@@ -12,8 +12,22 @@ class UnidadeOrcamentariaResource(resources.ModelResource):
 
     class Meta:
         model = UnidadeOrcamentaria
-        fields = ("codigo", "sigla", "nome", "ativa_display")
-        export_order = ("codigo", "sigla", "nome", "ativa_display")
+        fields = (
+            "codigo",
+            "sigla",
+            "nome",
+            "orgao",
+            "codigo_orgao",
+            "ativa_display",
+        )
+        export_order = (
+            "codigo",
+            "sigla",
+            "nome",
+            "orgao",
+            "codigo_orgao",
+            "ativa_display",
+        )
 
     def dehydrate_ativa_display(self, uo):
         return "Ativa" if uo.ativa else "Inativa"

--- a/dados_comuns/tests/tests_exportacao_unidades.py
+++ b/dados_comuns/tests/tests_exportacao_unidades.py
@@ -253,6 +253,7 @@ class ExportacaoUnidadeOrcamentariaTestCase(TestCase):
         resource = UnidadeOrcamentariaResource()
         dataset = resource.export(UnidadeOrcamentaria.objects.all())
 
-        status_values = [row[3] for row in dataset]
+        status_index = dataset.headers.index("Status")
+        status_values = [row[status_index] for row in dataset]
         self.assertIn("Ativa", status_values)
         self.assertIn("Inativa", status_values)

--- a/dados_comuns/tests/tests_exportacao_unidades.py
+++ b/dados_comuns/tests/tests_exportacao_unidades.py
@@ -198,8 +198,22 @@ class ExportacaoUnidadeAdministrativaTestCase(TestCase):
 class ExportacaoUnidadeOrcamentariaTestCase(TestCase):
 
     def setUp(self):
-        criar_uo(codigo=codigo_uo(10, 10, 10), nome="UO Ativa", sigla="ATV", ativa=True)
-        criar_uo(codigo=codigo_uo(20, 20, 20), nome="UO Inativa", sigla="INA", ativa=False)
+        self.uo_ativa = criar_uo(
+            codigo=codigo_uo(10, 10, 10),
+            nome="UO Ativa",
+            sigla="ATV",
+            orgao="Órgão Ativo",
+            codigo_orgao="10.10",
+            ativa=True,
+        )
+        self.uo_inativa = criar_uo(
+            codigo=codigo_uo(20, 20, 20),
+            nome="UO Inativa",
+            sigla="INA",
+            orgao="Órgão Inativo",
+            codigo_orgao="20.20",
+            ativa=False,
+        )
 
         grupo_gestor, _ = Group.objects.get_or_create(name=GRUPO_GESTOR_PATRIMONIO)
         self.superuser = Usuario.objects.create_user(
@@ -257,3 +271,34 @@ class ExportacaoUnidadeOrcamentariaTestCase(TestCase):
         status_values = [row[status_index] for row in dataset]
         self.assertIn("Ativa", status_values)
         self.assertIn("Inativa", status_values)
+
+    def test_pdf_uo_tabela_exibe_colunas_na_ordem_nova(self):
+        pdf_format = UnidadeOrcamentariaPDFFormat()
+        tabela = pdf_format._criar_tabela_unidades([self.uo_ativa, self.uo_inativa])[0]
+        linhas = [
+            [celula.getPlainText() if hasattr(celula, "getPlainText") else celula for celula in linha]
+            for linha in tabela._cellvalues
+        ]
+
+        self.assertEqual(
+            linhas[0],
+            [
+                "Código UO",
+                "Sigla UO",
+                "Nome UO",
+                "Código Órgão",
+                "Nome Órgão",
+                "Status",
+            ],
+        )
+        self.assertEqual(
+            linhas[1],
+            [
+                self.uo_ativa.codigo,
+                self.uo_ativa.sigla,
+                self.uo_ativa.nome,
+                self.uo_ativa.codigo_orgao,
+                self.uo_ativa.orgao,
+                "Ativa",
+            ],
+        )

--- a/dados_comuns/tests/tests_models.py
+++ b/dados_comuns/tests/tests_models.py
@@ -9,7 +9,10 @@ from dados_comuns.models import UnidadeAdministrativa, UnidadeOrcamentaria
 from dados_comuns.admin import UnidadeAdministrativaAdmin, UnidadeOrcamentariaAdmin
 from dados_comuns.formats import UnidadeOrcamentariaPDFFormat
 from dados_comuns.tests.factories import criar_ua, criar_uo
-from dados_comuns.utils import garantir_ua_ponto_central_externa
+from dados_comuns.utils import (
+    PREFIXO_CODIGO_UO_SME,
+    garantir_ua_ponto_central_externa,
+)
 from inventario.models import ParametroConciliacaoAnual
 from usuario.models import Usuario
 
@@ -400,7 +403,7 @@ class UnidadeOrcamentariaAdminTestCase(TestCase):
     def test_save_model_nao_cria_ua_001_para_uo_sme(self):
         request = self._request_com_messages()
         uo = UnidadeOrcamentaria(
-            codigo="01.16.10.99",
+            codigo=f"{PREFIXO_CODIGO_UO_SME}.99",
             nome="SME",
             sigla="SME",
             sigla_orgao="PMSP",

--- a/dados_comuns/tests/tests_models.py
+++ b/dados_comuns/tests/tests_models.py
@@ -4,9 +4,11 @@ from dados_comuns.tests.auth_test_utils import auth_kwargs, codigo_ua, codigo_uo
 from django.test import TestCase
 from django.test import RequestFactory
 from django.contrib.admin.sites import AdminSite
+from django.contrib.messages.storage.fallback import FallbackStorage
 from dados_comuns.models import UnidadeAdministrativa, UnidadeOrcamentaria
 from dados_comuns.admin import UnidadeAdministrativaAdmin, UnidadeOrcamentariaAdmin
 from dados_comuns.tests.factories import criar_ua, criar_uo
+from dados_comuns.utils import garantir_ua_ponto_central_externa
 from inventario.models import ParametroConciliacaoAnual
 from usuario.models import Usuario
 
@@ -219,6 +221,13 @@ class UnidadeOrcamentariaAdminTestCase(TestCase):
             is_staff=True,
         )
 
+    def _request_com_messages(self, path="/admin/dados_comuns/unidadeorcamentaria/add/"):
+        request = self.factory.post(path)
+        request.user = self.superuser
+        setattr(request, "session", "session")
+        setattr(request, "_messages", FallbackStorage(request))
+        return request
+
     def test_permissoes_admin_somente_superuser(self):
         request_super = self.factory.get("/admin/dados_comuns/unidadeorcamentaria/")
         request_super.user = self.superuser
@@ -276,3 +285,137 @@ class UnidadeOrcamentariaAdminTestCase(TestCase):
         )
         self.assertFalse(form_sem_nome.is_valid())
         self.assertIn("nome", form_sem_nome.errors)
+
+    def test_form_admin_aceita_campos_novos_e_valida_codigo_orgao(self):
+        request = self.factory.get("/admin/dados_comuns/unidadeorcamentaria/add/")
+        request.user = self.superuser
+
+        form_class = self.admin.get_form(request)
+
+        form_valido = form_class(
+            data={
+                "codigo": codigo_uo(55, 55, 55),
+                "nome": "UO com órgão",
+                "sigla": "ORG",
+                "orgao": "Secretaria Externa",
+                "codigo_orgao": "12.34",
+                "ativa": True,
+            }
+        )
+
+        self.assertTrue(form_valido.is_valid(), form_valido.errors)
+
+        form_invalido = form_class(
+            data={
+                "codigo": codigo_uo(56, 56, 56),
+                "nome": "UO inválida",
+                "sigla": "INV",
+                "orgao": "Secretaria Externa",
+                "codigo_orgao": "1234",
+                "ativa": True,
+            }
+        )
+
+        self.assertFalse(form_invalido.is_valid())
+        self.assertIn("codigo_orgao", form_invalido.errors)
+
+    def test_model_permite_campos_novos_em_branco_para_legado(self):
+        uo = criar_uo(codigo=codigo_uo(57, 57, 57), nome="UO Legado")
+
+        self.assertEqual(uo.orgao, "")
+        self.assertEqual(uo.codigo_orgao, "")
+
+    def test_save_model_cria_ua_001_para_uo_externa(self):
+        request = self._request_com_messages()
+        uo = UnidadeOrcamentaria(
+            codigo=codigo_uo(57, 57, 57),
+            nome="UO Externa",
+            sigla="EXT",
+            orgao="Órgão externo",
+            codigo_orgao="11.22",
+            ativa=True,
+        )
+
+        form_class = self.admin.get_form(request)
+        form = form_class(
+            data={
+                "codigo": uo.codigo,
+                "nome": uo.nome,
+                "sigla": uo.sigla,
+                "orgao": uo.orgao,
+                "codigo_orgao": uo.codigo_orgao,
+                "ativa": True,
+            },
+            instance=uo,
+        )
+
+        self.assertTrue(form.is_valid(), form.errors)
+
+        self.admin.save_model(request, uo, form, change=False)
+
+        ua = UnidadeAdministrativa.objects.get(
+            unidade_orcamentaria=uo,
+            codigo=f"{uo.codigo}.001",
+        )
+        self.assertEqual(ua.nome, "Ponto Central")
+        self.assertEqual(ua.sigla, "PC")
+
+    def test_save_model_nao_cria_ua_001_para_uo_sme(self):
+        request = self._request_com_messages()
+        uo = UnidadeOrcamentaria(
+            codigo="01.16.10.99",
+            nome="SME",
+            sigla="SME",
+            orgao="Órgão SME",
+            codigo_orgao="01.16",
+            ativa=True,
+        )
+
+        form_class = self.admin.get_form(request)
+        form = form_class(
+            data={
+                "codigo": uo.codigo,
+                "nome": uo.nome,
+                "sigla": uo.sigla,
+                "orgao": uo.orgao,
+                "codigo_orgao": uo.codigo_orgao,
+                "ativa": True,
+            },
+            instance=uo,
+        )
+
+        self.assertTrue(form.is_valid(), form.errors)
+
+        self.admin.save_model(request, uo, form, change=False)
+
+        self.assertFalse(
+            UnidadeAdministrativa.objects.filter(
+                unidade_orcamentaria=uo,
+                codigo=f"{uo.codigo}.001",
+            ).exists()
+        )
+
+    def test_helper_normaliza_ua_001_existente_em_uo_externa(self):
+        uo = criar_uo(
+            codigo=codigo_uo(58, 58, 58),
+            nome="UO Externa Existente",
+            sigla="EXT58",
+            orgao="Orgao 58",
+            codigo_orgao="58.58",
+        )
+        ua = UnidadeAdministrativa.objects.create(
+            unidade_orcamentaria=uo,
+            codigo="001",
+            sigla="",
+            nome="",
+            status=UnidadeAdministrativa.ATIVA,
+        )
+
+        ua_atualizada, criada = garantir_ua_ponto_central_externa(uo)
+
+        ua.refresh_from_db()
+        self.assertFalse(criada)
+        self.assertEqual(ua_atualizada.pk, ua.pk)
+        self.assertEqual(ua.codigo, f"{uo.codigo}.001")
+        self.assertEqual(ua.sigla, "PC")
+        self.assertEqual(ua.nome, "Ponto Central")

--- a/dados_comuns/tests/tests_models.py
+++ b/dados_comuns/tests/tests_models.py
@@ -7,6 +7,7 @@ from django.contrib.admin.sites import AdminSite
 from django.contrib.messages.storage.fallback import FallbackStorage
 from dados_comuns.models import UnidadeAdministrativa, UnidadeOrcamentaria
 from dados_comuns.admin import UnidadeAdministrativaAdmin, UnidadeOrcamentariaAdmin
+from dados_comuns.formats import UnidadeOrcamentariaPDFFormat
 from dados_comuns.tests.factories import criar_ua, criar_uo
 from dados_comuns.utils import garantir_ua_ponto_central_externa
 from inventario.models import ParametroConciliacaoAnual
@@ -297,6 +298,7 @@ class UnidadeOrcamentariaAdminTestCase(TestCase):
                 "codigo": codigo_uo(55, 55, 55),
                 "nome": "UO com órgão",
                 "sigla": "ORG",
+                "sigla_orgao": "PMSP",
                 "orgao": "Secretaria Externa",
                 "codigo_orgao": "12.34",
                 "ativa": True,
@@ -310,6 +312,7 @@ class UnidadeOrcamentariaAdminTestCase(TestCase):
                 "codigo": codigo_uo(56, 56, 56),
                 "nome": "UO inválida",
                 "sigla": "INV",
+                "sigla_orgao": "INVORG",
                 "orgao": "Secretaria Externa",
                 "codigo_orgao": "1234",
                 "ativa": True,
@@ -322,8 +325,40 @@ class UnidadeOrcamentariaAdminTestCase(TestCase):
     def test_model_permite_campos_novos_em_branco_para_legado(self):
         uo = criar_uo(codigo=codigo_uo(57, 57, 57), nome="UO Legado")
 
+        self.assertEqual(uo.sigla_orgao, "")
         self.assertEqual(uo.orgao, "")
         self.assertEqual(uo.codigo_orgao, "")
+
+    def test_admin_uo_expoe_campo_sigla_orgao_no_cadastro(self):
+        self.assertIn("sigla_orgao", self.admin.fields)
+
+    def test_admin_uo_ordena_e_renomeia_campos_de_orgao(self):
+        request = self.factory.get("/admin/dados_comuns/unidadeorcamentaria/add/")
+        request.user = self.superuser
+
+        form_class = self.admin.get_form(request)
+
+        self.assertEqual(
+            list(form_class.base_fields)[3:6],
+            ["codigo_orgao", "sigla_orgao", "orgao"],
+        )
+        self.assertEqual(
+            form_class.base_fields["codigo_orgao"].label,
+            "Código do Orgão",
+        )
+        self.assertEqual(
+            form_class.base_fields["sigla_orgao"].label,
+            "Sigla do Orgão",
+        )
+        self.assertEqual(
+            form_class.base_fields["orgao"].label,
+            "Nome do Orgão",
+        )
+
+    def test_admin_uo_inclui_exportacao_pdf(self):
+        formatos = self.admin.get_export_formats()
+
+        self.assertIn(UnidadeOrcamentariaPDFFormat, formatos)
 
     def test_save_model_cria_ua_001_para_uo_externa(self):
         request = self._request_com_messages()
@@ -331,6 +366,7 @@ class UnidadeOrcamentariaAdminTestCase(TestCase):
             codigo=codigo_uo(57, 57, 57),
             nome="UO Externa",
             sigla="EXT",
+            sigla_orgao="PMSP",
             orgao="Órgão externo",
             codigo_orgao="11.22",
             ativa=True,
@@ -342,6 +378,7 @@ class UnidadeOrcamentariaAdminTestCase(TestCase):
                 "codigo": uo.codigo,
                 "nome": uo.nome,
                 "sigla": uo.sigla,
+                "sigla_orgao": uo.sigla_orgao,
                 "orgao": uo.orgao,
                 "codigo_orgao": uo.codigo_orgao,
                 "ativa": True,
@@ -366,6 +403,7 @@ class UnidadeOrcamentariaAdminTestCase(TestCase):
             codigo="01.16.10.99",
             nome="SME",
             sigla="SME",
+            sigla_orgao="PMSP",
             orgao="Órgão SME",
             codigo_orgao="01.16",
             ativa=True,
@@ -377,6 +415,7 @@ class UnidadeOrcamentariaAdminTestCase(TestCase):
                 "codigo": uo.codigo,
                 "nome": uo.nome,
                 "sigla": uo.sigla,
+                "sigla_orgao": uo.sigla_orgao,
                 "orgao": uo.orgao,
                 "codigo_orgao": uo.codigo_orgao,
                 "ativa": True,
@@ -400,6 +439,7 @@ class UnidadeOrcamentariaAdminTestCase(TestCase):
             codigo=codigo_uo(58, 58, 58),
             nome="UO Externa Existente",
             sigla="EXT58",
+            sigla_orgao="ORG58",
             orgao="Orgao 58",
             codigo_orgao="58.58",
         )

--- a/dados_comuns/tests/tests_permissions_api.py
+++ b/dados_comuns/tests/tests_permissions_api.py
@@ -76,6 +76,14 @@ class PermissionsAPITestCase(SimpleTestCase):
             perm.has_object_permission(self._request(user_gestor), self._view("update"), baixa)
         )
 
+        transferido = SimpleNamespace(excluido=False, status=bem_constants.TRANSFERIDO)
+        self.assertTrue(
+            perm.has_object_permission(self._request(user_gestor), self._view("retrieve"), transferido)
+        )
+        self.assertFalse(
+            perm.has_object_permission(self._request(user_gestor), self._view("update"), transferido)
+        )
+
         normal = SimpleNamespace(excluido=False, status="ativo")
         self.assertFalse(
             perm.has_object_permission(self._request(user_operador), self._view("destroy"), normal)

--- a/dados_comuns/tests/tests_unidade_orcamentaria_api.py
+++ b/dados_comuns/tests/tests_unidade_orcamentaria_api.py
@@ -19,21 +19,33 @@ class UnidadeOrcamentariaAPITestCase(APITestCase):
         "codigo",
         "sigla",
         "nome",
-        "orgao",
         "codigo_orgao",
+        "sigla_orgao",
+        "orgao",
         "ativa",
         "ativa_display",
     }
 
     def setUp(self):
-        self.uo1 = criar_uo(codigo=codigo_uo(10, 10, 10), nome="UO 1", sigla="UO1")
+        self.uo1 = criar_uo(
+            codigo=codigo_uo(10, 10, 10),
+            nome="UO 1",
+            sigla="UO1",
+            sigla_orgao="ORG1",
+        )
         self.uo2 = criar_uo(
             codigo=codigo_uo(20, 20, 20),
             nome="UO 2",
             sigla="UO2",
+            sigla_orgao="ORG2",
             ativa=False,
         )
-        self.uo3 = criar_uo(codigo=codigo_uo(30, 30, 30), nome="UO 3", sigla="UO3")
+        self.uo3 = criar_uo(
+            codigo=codigo_uo(30, 30, 30),
+            nome="UO 3",
+            sigla="UO3",
+            sigla_orgao="ORG3",
+        )
 
         self.uo_com_ua = criar_uo(
             codigo=codigo_uo(40, 40, 40),
@@ -99,6 +111,7 @@ class UnidadeOrcamentariaAPITestCase(APITestCase):
             "codigo": codigo_uo(60, 60, 60),
             "sigla": "UO60",
             "nome": "UO 60",
+            "sigla_orgao": "ORG60",
             "orgao": "Órgão 60",
             "codigo_orgao": "60.60",
             "ativa": True,
@@ -160,6 +173,12 @@ class UnidadeOrcamentariaAPITestCase(APITestCase):
         self.assertEqual(len(response.data["results"]), 1)
         self.assertEqual(response.data["results"][0]["id"], self.uo2.id)
         self.assertEqual(set(response.data["results"][0].keys()), self.LIST_FIELDS)
+        self.assertEqual(response.data["results"][0]["sigla_orgao"], "ORG2")
+
+        response_sigla_orgao = self.client.get(self.list_url, {"search": "ORG3"})
+        self.assertEqual(response_sigla_orgao.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response_sigla_orgao.data["results"]), 1)
+        self.assertEqual(response_sigla_orgao.data["results"][0]["id"], self.uo3.id)
 
         response_id = self.client.get(self.list_url, {"ordering": "-id"})
         ids = [row["id"] for row in response_id.data["results"]]
@@ -172,6 +191,7 @@ class UnidadeOrcamentariaAPITestCase(APITestCase):
         self.assertEqual(detail.status_code, status.HTTP_200_OK)
         self.assertEqual(detail.data["id"], self.uo1.id)
         self.assertEqual(detail.data["ativa_display"], "Ativa")
+        self.assertEqual(detail.data["sigla_orgao"], "ORG1")
         self.assertEqual(set(detail.data.keys()), self.LIST_FIELDS)
 
         create_response = self.client.post(
@@ -195,6 +215,14 @@ class UnidadeOrcamentariaAPITestCase(APITestCase):
         self.assertEqual(patch_response.status_code, status.HTTP_200_OK)
         self.assertEqual(patch_response.data["nome"], "UO 1 Alterada")
 
+        patch_sigla_orgao = self.client.patch(
+            self._detail_url(self.uo1.id),
+            {"sigla_orgao": "ORG1-ALT"},
+            format="json",
+        )
+        self.assertEqual(patch_sigla_orgao.status_code, status.HTTP_200_OK)
+        self.assertEqual(patch_sigla_orgao.data["sigla_orgao"], "ORG1-ALT")
+
         historico_response = self.client.get(
             reverse("unidades-orcamentarias-historico", args=[self.uo1.id]),
             {"search": "ignorar", "page": 99},
@@ -205,7 +233,7 @@ class UnidadeOrcamentariaAPITestCase(APITestCase):
         self.assertIn("acoes", historico_response.data[0])
         self.assertTrue(
             any(
-                acao["campo"] == "nome"
+                acao["campo"] in {"nome", "sigla_orgao"}
                 for grupo in historico_response.data
                 for acao in grupo["acoes"]
             )

--- a/dados_comuns/tests/tests_unidade_orcamentaria_api.py
+++ b/dados_comuns/tests/tests_unidade_orcamentaria_api.py
@@ -6,6 +6,7 @@ from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
 
+from dados_comuns.models import UnidadeAdministrativa
 from dados_comuns.tests.auth_test_utils import auth_kwargs, codigo_ua, codigo_uo
 from dados_comuns.tests.factories import criar_ua, criar_uo
 from usuario.constants import GRUPO_GESTOR_PATRIMONIO, GRUPO_OPERADOR_INVENTARIO
@@ -18,6 +19,8 @@ class UnidadeOrcamentariaAPITestCase(APITestCase):
         "codigo",
         "sigla",
         "nome",
+        "orgao",
+        "codigo_orgao",
         "ativa",
         "ativa_display",
     }
@@ -96,6 +99,8 @@ class UnidadeOrcamentariaAPITestCase(APITestCase):
             "codigo": codigo_uo(60, 60, 60),
             "sigla": "UO60",
             "nome": "UO 60",
+            "orgao": "Órgão 60",
+            "codigo_orgao": "60.60",
             "ativa": True,
         }
         payload.update(overrides)
@@ -175,6 +180,12 @@ class UnidadeOrcamentariaAPITestCase(APITestCase):
             format="json",
         )
         self.assertEqual(create_response.status_code, status.HTTP_201_CREATED)
+        self.assertTrue(
+            UnidadeAdministrativa.objects.filter(
+                unidade_orcamentaria_id=create_response.data["id"],
+                codigo=f"{create_response.data['codigo']}.001",
+            ).exists()
+        )
 
         patch_response = self.client.patch(
             self._detail_url(self.uo1.id),
@@ -207,6 +218,7 @@ class UnidadeOrcamentariaAPITestCase(APITestCase):
             ({"codigo": "", "sigla": "UO", "nome": "Nome", "ativa": True}, "codigo"),
             ({"codigo": codigo_uo(70, 70, 70), "sigla": "UO", "nome": "", "ativa": True}, "nome"),
             ({"codigo": self.uo1.codigo, "sigla": "UO", "nome": "Duplicada", "ativa": True}, "codigo"),
+            ({"codigo": codigo_uo(70, 70, 71), "sigla": "UO", "nome": "Inválida", "ativa": True, "codigo_orgao": "7071"}, "codigo_orgao"),
         ]
 
         for payload, campo in cenarios:

--- a/dados_comuns/utils.py
+++ b/dados_comuns/utils.py
@@ -1,6 +1,12 @@
 from django.db import models
 
 
+PREFIXO_CODIGO_UO_SME = "01.16.10"
+CODIGO_UA_PONTO_CENTRAL = "001"
+NOME_UA_PONTO_CENTRAL = "Ponto Central"
+SIGLA_UA_PONTO_CENTRAL = "PC"
+
+
 def repr_value(value):
     if value is None:
         return ""
@@ -28,3 +34,62 @@ def dict_changes(original, updated, fields, only=None, ignore=None):
         if repr_value(old) != repr_value(new):
             changes[f] = (repr_value(old), repr_value(new))
     return changes
+
+
+def unidade_orcamentaria_eh_externa(unidade_orcamentaria):
+    codigo = ((getattr(unidade_orcamentaria, "codigo", None) or "").strip())
+    return bool(codigo) and not codigo.startswith(PREFIXO_CODIGO_UO_SME)
+
+
+def garantir_ua_ponto_central_externa(unidade_orcamentaria):
+    if not getattr(unidade_orcamentaria, "pk", None):
+        return None, False
+
+    if not unidade_orcamentaria_eh_externa(unidade_orcamentaria):
+        return None, False
+
+    from django.db.models import Q
+
+    from dados_comuns.models import UnidadeAdministrativa
+
+    codigo_esperado = (
+        f"{unidade_orcamentaria.codigo.strip()}.{CODIGO_UA_PONTO_CENTRAL}"
+    )
+    ua = (
+        UnidadeAdministrativa.objects.filter(
+            unidade_orcamentaria=unidade_orcamentaria,
+        )
+        .filter(
+            Q(codigo=codigo_esperado)
+            | Q(codigo=CODIGO_UA_PONTO_CENTRAL)
+            | Q(codigo__endswith=f".{CODIGO_UA_PONTO_CENTRAL}")
+        )
+        .order_by("id")
+        .first()
+    )
+
+    if ua is None:
+        ua = UnidadeAdministrativa.objects.create(
+            unidade_orcamentaria=unidade_orcamentaria,
+            codigo=codigo_esperado,
+            sigla=SIGLA_UA_PONTO_CENTRAL,
+            nome=NOME_UA_PONTO_CENTRAL,
+            status=UnidadeAdministrativa.ATIVA,
+        )
+        return ua, True
+
+    update_fields = []
+    if ua.codigo != codigo_esperado:
+        ua.codigo = codigo_esperado
+        update_fields.append("codigo")
+    if not ua.sigla:
+        ua.sigla = SIGLA_UA_PONTO_CENTRAL
+        update_fields.append("sigla")
+    if not ua.nome:
+        ua.nome = NOME_UA_PONTO_CENTRAL
+        update_fields.append("nome")
+
+    if update_fields:
+        ua.save(update_fields=update_fields)
+
+    return ua, False

--- a/inventario/conciliacao.py
+++ b/inventario/conciliacao.py
@@ -18,7 +18,7 @@ def _recalcular_bloqueio_bem_por_inventario(bem: BemPatrimonial):
 
     novo_valor = bool(existe_bloqueio_em_aberto)
 
-    if bem.status == bem_constants.BAIXA_FISICA:
+    if bem.status in bem_constants.STATUS_FINAIS_BEM:
         novo_valor = False
 
     if bem.bloqueado_conciliacao != novo_valor:

--- a/inventario/services/conciliacao_sync.py
+++ b/inventario/services/conciliacao_sync.py
@@ -103,6 +103,13 @@ def sync_bem_pos_save(bem, old_ua_id=None):
         remover_bem_de_conciliacoes_em_aberto(bem.pk, new_ua_id)
         return
 
+    if bem.status == bem_constants.TRANSFERIDO:
+        if old_ua_id and old_ua_id != new_ua_id:
+            remover_bem_de_conciliacoes_em_aberto(bem.pk, old_ua_id)
+        remover_bem_de_conciliacoes_em_aberto(bem.pk, new_ua_id)
+        bem.__class__.objects.filter(pk=bem.pk).update(bloqueado_conciliacao=False)
+        return
+
     if old_ua_id and old_ua_id != new_ua_id:
         remover_bem_de_conciliacoes_em_aberto(bem.pk, old_ua_id)
 

--- a/inventario/tests/test_conciliacao_sync.py
+++ b/inventario/tests/test_conciliacao_sync.py
@@ -243,6 +243,37 @@ class ConciliacaoSyncTest(TestCase):
             conciliacao_sync.sync_bem_pos_save(bem)
         self.assertEqual(ItemConciliacao.objects.count(), 0)
 
+    def test_sync_bem_transferido_remove_da_antiga_e_nao_inclui_na_nova(self):
+        ua2 = criar_ua(
+            uo=self.ua.unidade_orcamentaria,
+            codigo="001.0004",
+            sigla="UA4",
+            nome="Unidade 4",
+        )
+        conciliacao_antiga = self._criar_conciliacao_aberta()
+        conciliacao_nova = self._criar_conciliacao_aberta(ua=ua2)
+        bem = self._criar_bem(ua=self.ua, status=bem_constants.TRANSFERIDO)
+        ItemConciliacao.objects.create(
+            conciliacao=conciliacao_antiga,
+            bem=bem,
+            situacao=inv_constants.ENCONTRADO_SEM_DIVERGENCIA,
+        )
+
+        bem.unidade_administrativa = ua2
+        bem.unidade_administrativa_id = ua2.pk
+
+        with audit_as(self.usuario):
+            conciliacao_sync.sync_bem_pos_save(bem, old_ua_id=self.ua.pk)
+
+        self.assertEqual(
+            ItemConciliacao.objects.filter(conciliacao=conciliacao_antiga, bem=bem).count(),
+            0,
+        )
+        self.assertEqual(
+            ItemConciliacao.objects.filter(conciliacao=conciliacao_nova, bem=bem).count(),
+            0,
+        )
+
     # --- Cobertura de funções internas (linhas que só são atingidas por elas) ---
 
     def test_conciliacoes_em_aberto_retorna_none_quando_ua_id_vazio(self):

--- a/inventario/utils_conciliacao/conciliacao_utils.py
+++ b/inventario/utils_conciliacao/conciliacao_utils.py
@@ -177,6 +177,7 @@ def criar_itens_conciliacao(conciliacao):
         status__in=[
             bem_constants.BAIXA_FISICA,
             bem_constants.AGUARDANDO_APROVACAO,
+            bem_constants.TRANSFERIDO,
         ]
     )
 

--- a/static/admin/transferencia_filtra_bens_por_uo.js
+++ b/static/admin/transferencia_filtra_bens_por_uo.js
@@ -1,0 +1,58 @@
+(function() {
+    function wrapAjaxWithUoFilter(jq, oldAjax, $uo, $ua) {
+        return function(options) {
+            const isStringUrl = typeof options === 'string';
+            const opts = isStringUrl ? options : { ...options };
+            const url = isStringUrl ? opts : opts.url;
+
+            if (!url || url.indexOf('/admin/autocomplete/') === -1) {
+                return oldAjax.apply(this, arguments);
+            }
+
+            const params = [];
+            const uoVal = $uo.val();
+            const uaVal = $ua.val();
+            if (uaVal) {
+                params.push('ua_origem=' + encodeURIComponent(uaVal));
+            } else if (uoVal) {
+                params.push('uo_origem=' + encodeURIComponent(uoVal));
+            }
+
+            const ids = [];
+            jq('select[name^="itens-"][name$="-bem"]').each(function() {
+                const prefix = this.name.replace('-bem', '');
+                const deleteFlag = jq('input[name="' + prefix + '-DELETE"]').prop('checked');
+                if (!deleteFlag) {
+                    const val = jq(this).val();
+                    if (val) ids.push(val);
+                }
+            });
+            if (ids.length > 0) {
+                params.push('exclude_bens=' + encodeURIComponent(ids.join(',')));
+            }
+
+            if (params.length) {
+                const sep = url.indexOf('?') === -1 ? '?' : '&';
+                const newUrl = url + sep + params.join('&');
+                return oldAjax.apply(this, [isStringUrl ? newUrl : { ...opts, url: newUrl }]);
+            }
+            return oldAjax.apply(this, [opts]);
+        };
+    }
+
+    function startWhenReady() {
+        if (!window.django || !django.jQuery) {
+            return setTimeout(startWhenReady, 100);
+        }
+
+        const jq = django.jQuery;
+        jq(function() {
+            const $uo = jq('#id_unidade_orcamentaria_origem');
+            const $ua = jq('#id_unidade_administrativa_filtro');
+            const oldAjax = jq.ajax;
+            jq.ajax = wrapAjaxWithUoFilter(jq, oldAjax, $uo, $ua);
+        });
+    }
+
+    startWhenReady();
+})();

--- a/static/css/transferencia_bem_patrimonial.css
+++ b/static/css/transferencia_bem_patrimonial.css
@@ -1,0 +1,28 @@
+body.app-bem_patrimonial.model-transferenciabempatrimonial #itens-group .tabular {
+    overflow-x: auto;
+}
+
+body.app-bem_patrimonial.model-transferenciabempatrimonial #itens-group .tabular table {
+    min-width: 60rem;
+}
+
+body.app-bem_patrimonial.model-transferenciabempatrimonial #itens-group th.column-bem,
+body.app-bem_patrimonial.model-transferenciabempatrimonial #itens-group td.field-bem {
+    min-width: 60rem;
+}
+
+body.app-bem_patrimonial.model-transferenciabempatrimonial #itens-group .field-bem .select2-container,
+body.app-bem_patrimonial.model-transferenciabempatrimonial #itens-group .field-bem .related-widget-wrapper,
+body.app-bem_patrimonial.model-transferenciabempatrimonial #itens-group .field-bem .admin-autocomplete,
+body.app-bem_patrimonial.model-transferenciabempatrimonial #itens-group .field-bem select {
+    width: 100% !important;
+    min-width: 60rem;
+    max-width: 100%;
+}
+
+body.app-bem_patrimonial.model-transferenciabempatrimonial #itens-group .field-bem .select2-selection__rendered,
+body.app-bem_patrimonial.model-transferenciabempatrimonial .select2-results__option {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}


### PR DESCRIPTION
## 🎯 Objetivo

Implementar o fluxo de transferência externa de bens patrimoniais entre UOs, com efetivação em lote, geração de NTBPM, ajustes de escopo/permissão e suporte operacional no Django Admin.

## 🧩 Resumo do que entra neste PR

- Criação do módulo de `TransferenciaBemPatrimonial`, com itens múltiplos via `TransferenciaBensItem`.
- Inclusão do status final `TRANSFERIDO` no domínio de bens patrimoniais.
- Efetivação da transferência movendo os bens para a UA de destino, registrando histórico de status e gerando `numero_ntbpm`.
- Uso de `criado_em` como data de referência da transferência e da emissão do NTBPM.
- Geração e download protegido do documento NTBPM.
- Inclusão dos campos `orgao`, `codigo_orgao` e `sigla_orgao` em Unidade Orçamentária.
- Criação automática e normalização da UA `001 - Ponto Central` para UOs externas.
- Ajustes no Django Admin, API, escopo, permissões e inventário para refletir o novo fluxo.

## 🔄 Fluxo de transferência externa

- O modelo `TransferenciaBemPatrimonial` passou a concentrar o fluxo de transferência entre secretarias, com origem em uma UO e destino em outra UO externa.
- O relacionamento com os bens foi modelado por tabela intermediária (`TransferenciaBensItem`), permitindo transferir múltiplos bens na mesma solicitação.
- `numero_processo` passou a ser único no banco para evitar duplicidade operacional.
- A validação de destino exige UO externa ativa, UA de destino associada a essa UO e uso da UA ativa de código `001` como ponto central.
- A efetivação revalida os bens dentro de transação, com `select_for_update`, garantindo que cada item ainda pertença à UO de origem e esteja com status `APROVADO` no momento da gravação.
- Ao efetivar, cada bem:
  - troca para a UA de destino;
  - recebe status `TRANSFERIDO`;
  - registra histórico em `StatusBemPatrimonial`;
  - passa a compor a transferência concluída por meio do `numero_ntbpm`.

## 🧾 NTBPM

- O número NTBPM foi padronizado no mesmo estilo do NBBPM: `<COD_UA_DESTINO>.<SEQUENCIAL_7_DIGITOS>.<ANO>`.
- O código da UA de destino usado na composição é o da UA `001` da UO externa.
- O documento passou a usar `criado_em` como data da transferência.
- O layout do PDF separa as informações de órgão e unidade orçamentária em linhas distintas para origem e destino.
- O `PREFIXO` do órgão no NTBPM passa a usar `UnidadeOrcamentaria.sigla_orgao`.
- A seção complementar foi simplificada para exibir apenas a observação.
- O download do NTBPM foi exposto em rota própria e protegido por escopo: gestores da UO de origem ou da UO de destino podem acessar; usuários fora do fluxo não acessam.

## 🧑‍💼 Ajustes no Django Admin

- O admin de transferência foi registrado e preparado para uso operacional completo.
- A listagem da transferência passou a exibir: `id`, `numero_ntbpm`, `numero_processo`, UO de origem, UO de destino, `criado_por` e `criado_em`.
- O formulário resolve automaticamente a UA `001` da UO externa e restringe o filtro de origem ao escopo correto do usuário.
- Registros já criados ficam essencialmente em modo de visualização:
  - sem botões de salvar tradicionais;
  - sem permissão de adicionar itens no inline depois da criação;
  - sem permissão de excluir itens;
  - rejeitando `POST` em edição de registro já existente.
- O inline da transferência recebeu template customizado para remover o bloco redundante de “original”, esconder controles de apagar e exibir o bem com link administrativo e indicação da UA de origem.
- O CSS do admin ampliou a largura da coluna do bem para acomodar o autocomplete com rótulos mais descritivos.
- O JavaScript do admin passou a enviar `uo_origem`, `ua_origem` e `exclude_bens` no autocomplete, filtrando os bens disponíveis conforme origem e evitando seleção duplicada no mesmo formulário.
- O admin de bem patrimonial foi ajustado para tratar `TRANSFERIDO` como status final, bloqueando edição/exclusão e preservando a visibilidade do bem para gestores da UO de origem e da UO de destino.

## 🏢 Unidade Orçamentária e dados compartilhados

- `UnidadeOrcamentaria` passou a ter os campos:
  - `codigo_orgao`
  - `sigla_orgao`
  - `orgao`
- O admin de UO teve a ordem dos campos reorganizada para o bloco de órgão: `codigo_orgao`, `sigla_orgao`, `orgao`.
- Os labels foram ajustados para o cadastro administrativo:
  - `Código do Orgão`
  - `Sigla do Orgão`
  - `Nome do Orgão`
- A criação/edição de UO continua restrita a superusuário.
- Ao salvar uma UO externa, o sistema garante a existência da UA `Ponto Central` (`.001`) e normaliza registros legados quando já existe uma UA `001` incompleta.
- A exportação PDF de UO foi preservada no admin e atualizada para o layout com as colunas:
  - `Código UO`
  - `Sigla UO`
  - `Nome UO`
  - `Código Órgão`
  - `Nome Órgão`
  - `Status`

## 🔐 API, escopo e permissões

- `dados_comuns/escopo.py` passou a incluir regras específicas para transferência:
  - `filtrar_queryset_transferencia_por_escopo()` restringe transferências às UOs participantes.
  - `filtrar_queryset_bem_por_escopo_com_transferencia()` mantém o escopo tradicional e adiciona leitura de bens `TRANSFERIDO` para gestores das UOs envolvidas.
  - `validar_bem_no_escopo_com_transferencia()` espelha essa mesma lógica em validação objeto a objeto.
- `BemPatrimonialPermission` passou a tratar `TRANSFERIDO` como status final somente leitura na API, assim como já ocorre com outros estados finais.
- O viewset de bens passou a permitir que:
  - o gestor da origem consulte o detalhe de bem transferido;
  - o gestor do destino consulte o histórico do bem transferido.
- A API de UO foi atualizada para incluir `sigla_orgao` no contrato, busca, auditoria e respostas de listagem/detalhe.
- A criação e atualização de UO via API também garantem a UA `.001` para UOs externas.

## 📦 Inventário e conciliação

- O inventário deixou de considerar bens `TRANSFERIDO` como bens ativos elegíveis para criação de itens de conciliação.
- O sincronismo de conciliação (`conciliacao_sync`) agora remove o bem transferido das conciliações em aberto da UA antiga e não o reinsere automaticamente na nova UA após transferência externa.
- Nessa transição, `bloqueado_conciliacao` é forçado para `False`, evitando que a conciliação mantenha bloqueio indevido em bem já transferido.

## 🗃️ Migrações incluídas

- `bem_patrimonial/migrations/0034_bempatrimonial_status_transferido.py`
  - adiciona o status `transferido` em `BemPatrimonial` e `StatusBemPatrimonial`.
- `bem_patrimonial/migrations/0035_transferenciabempatrimonial_and_more.py`
  - cria `TransferenciaBemPatrimonial`, `TransferenciaBensItem` e o relacionamento M2M entre transferência e bens.
- `bem_patrimonial/migrations/0036_transferenciabempatrimonial_numero_ntbpm.py`
  - adiciona o campo `numero_ntbpm` com `unique=True`.
- `bem_patrimonial/migrations/0037_alter_baixafisicabempatrimonial_criado_por_and_more.py`
  - ajusta metadados de baixa física relacionados a usuário e datas exibidas na solicitação/aprovação.
- `bem_patrimonial/migrations/0038_alter_transferenciabempatrimonial_numero_processo.py`
  - torna `numero_processo` único.
- `bem_patrimonial/migrations/0039_remove_transferenciabempatrimonial_efetivado_por.py`
  - remove `efetivado_por`.
- `bem_patrimonial/migrations/0040_remove_transferenciabempatrimonial_efetivado_em.py`
  - remove `efetivado_em`.
- `dados_comuns/migrations/0012_unidadeorcamentaria_orgao_codigo_orgao.py`
  - adiciona `orgao` e `codigo_orgao` em Unidade Orçamentária.
- `dados_comuns/migrations/0013_unidadeorcamentaria_sigla_orgao.py`
  - adiciona `sigla_orgao` em Unidade Orçamentária.

## 🧪 Testes criados e alterados

### 🆕 Novos testes adicionados na branch

#### 🧪 `bem_patrimonial/tests/test_bem_patrimonial_admin.py`

- garante que bens `TRANSFERIDO` não possam ser editados, excluídos ou salvos novamente no admin.
- cobre o autocomplete da transferência filtrando bens por UO de origem, por UA específica e exibindo o rótulo no formato `UA | número - nome`.
- garante que bens transferidos continuem visíveis no queryset e na busca textual para gestores da UO de origem e da UO de destino.

#### 🧪 `bem_patrimonial/tests/test_serializers.py`

- impede alteração via serializer quando o bem está com status `TRANSFERIDO`.

#### 🧪 `bem_patrimonial/tests/test_viewset.py`

- valida acesso ao detalhe do bem transferido pelo gestor da origem e ao histórico pelo gestor do destino.

#### 🧪 `bem_patrimonial/tests/tests_ntbpm.py`

- valida a geração e o formato do número NTBPM na efetivação.
- garante o download do documento por gestores vinculados à transferência e bloqueia usuários sem permissão ou sem relação com o fluxo.
- valida que o arquivo gerado é um PDF consistente.
- valida o conteúdo do documento, incluindo órgãos/UOs de origem e destino, observação, resumo da transferência e rodapé com RF.

#### 🧪 `bem_patrimonial/tests/tests_transferencia_admin.py`

- valida a listagem do admin com `numero_ntbpm` logo após `id`.
- garante que o formulário resolva automaticamente a UA `.001` da UO externa, exponha o filtro correto de origem e rejeite número de processo duplicado.
- garante estabilidade do change form com campos readonly, visibilidade da transferência para a UO destino e posicionamento do filtro próximo aos itens.
- valida o inline da transferência, cobrindo exigência de ao menos um bem, tolerância a erros prévios, rótulo detalhado, comportamento em modo somente leitura e exibição de UA/link do bem.
- garante que o template e as customizações do admin removam o bloco “original” e os controles de apagar, ocultem os botões de salvar e carreguem o CSS específico da tela.
- garante que registros existentes não aceitem `POST`, que a inclusão de itens ocorra apenas na criação e que o módulo permaneça restrito a gestores.

#### 🧪 `bem_patrimonial/tests/tests_transferencia_bem_patrimonial.py`

- valida a efetivação movendo os bens para a UA de destino, alterando o status para `TRANSFERIDO`, registrando histórico e gerando NTBPM.
- impede efetivação sem itens.
- bloqueia efetivação com bem fora da UO de origem ou fora do status esperado para transferência.
- garante revalidação dos bens no momento da efetivação e unicidade de `numero_processo`.

#### 🧪 `dados_comuns/tests/tests_exportacao_unidades.py` (ajustes)

- valida a nova ordem de colunas da exportação PDF de UO.

#### 🧪 `dados_comuns/tests/tests_models.py`

- valida os novos campos de órgão no cadastro de UO, incluindo a regra de formato `NN.NN` para `codigo_orgao`.
- garante compatibilidade com dados legados e a exposição/ordem corretas dos campos no admin.
- garante permanência da exportação PDF de UO e a criação/normalização automática da UA `.001` para UOs externas, sem aplicar essa regra às UOs da SME.

#### 🧪 `inventario/tests/test_conciliacao_sync.py`

- garante que a transferência externa remove o bem das conciliações abertas e não o reinsere na nova UA.

### ♻️ Testes existentes ajustados na branch

#### 🧪 `dados_comuns/tests/tests_permissions_api.py`

- amplia a cobertura de permissões para tratar `TRANSFERIDO` como status final somente leitura na API de bens.

#### 🧪 `dados_comuns/tests/tests_unidade_orcamentaria_api.py`

- valida `sigla_orgao` na listagem, no detalhe e na busca.
- garante criação automática da UA `.001`, atualização auditável de `sigla_orgao` e validação de formato para `codigo_orgao`.

#### 🧪 `dados_comuns/tests/tests_exportacao_unidades.py`

- ajusta a validação da exportação Excel para localizar a coluna `Status` pelo cabeçalho depois da mudança de layout da exportação de UO.

## ✅ Validações executadas

### 🎯 Validações focadas no escopo alterado

- `docker compose -f docker-compose-dev.yml exec web python manage.py test bem_patrimonial.tests.tests_transferencia_bem_patrimonial`
    - 6 testes OK, cobrindo o modelo e a efetivação da transferência externa.
- `docker compose -f docker-compose-dev.yml exec web python manage.py test bem_patrimonial.tests.tests_ntbpm bem_patrimonial.tests.tests_transferencia_admin`
    - 30 testes OK, cobrindo geração/download do NTBPM e comportamento do admin da transferência.
- `docker compose -f docker-compose-dev.yml exec web python manage.py test dados_comuns.tests.tests_models dados_comuns.tests.tests_exportacao_unidades`
    - 39 testes OK, cobrindo cadastro de UO, criação automática da UA `.001` e exportação de unidades.
- `docker compose -f docker-compose-dev.yml exec web python manage.py test dados_comuns.tests.tests_models dados_comuns.tests.tests_unidade_orcamentaria_api`
    - 34 testes OK, cobrindo modelo/admin de UO e contrato da API com `sigla_orgao`.

### 🧪 Regressão geral do sistema

- `docker compose -f docker-compose-dev.yml exec web python manage.py test`
    - 860 testes executados com sucesso.

## 📌 Observações finais

O escopo do trabalho não ficou restrito ao novo modelo de transferência: ele também inclui os ajustes necessários em admin, documento NTBPM, UO/UAs, API, permissões, escopo e inventário para manter o comportamento consistente de ponta a ponta.
