### PR TITLE
Feature(147325): Amplia Ordering e Exportação de Unidades Orçamentárias

### DIFF
--- a/dados_comuns/admin.py
+++ b/dados_comuns/admin.py
@@ -116,9 +116,9 @@ class UnidadeOrcamentariaAdmin(ImportExportModelAdmin):
     def get_form(self, request, obj=None, **kwargs):
         form = super().get_form(request, obj, **kwargs)
         field_labels = {
-            "codigo_orgao": "Código do Orgão",
-            "sigla_orgao": "Sigla do Orgão",
-            "orgao": "Nome do Orgão",
+            "codigo_orgao": "Código do Órgão",
+            "sigla_orgao": "Sigla do Órgão",
+            "orgao": "Nome do Órgão",
         }
         for field_name, label in field_labels.items():
             if field_name in form.base_fields:

--- a/dados_comuns/api_serializers.py
+++ b/dados_comuns/api_serializers.py
@@ -38,7 +38,7 @@ class UnidadeOrcamentariaDetailSerializer(UnidadeOrcamentariaListSerializer):
                 "help_text": "Código do Órgão no padrão NN.NN."
             },
             "sigla_orgao": {
-                "help_text": "Sigla do Orgão vinculada à Unidade Orçamentária."
+                "help_text": "Sigla do Órgão vinculada à Unidade Orçamentária."
             }
         }
 

--- a/dados_comuns/api_views.py
+++ b/dados_comuns/api_views.py
@@ -326,7 +326,16 @@ class UnidadeOrcamentariaViewSet(AuditHistoryExportMixin, viewsets.ModelViewSet)
     filter_backends = [DjangoFilterBackend, SearchFilter, OrderingFilter]
     filterset_fields = ["ativa"]
     search_fields = ["codigo", "sigla", "nome", "codigo_orgao", "sigla_orgao", "orgao"]
-    ordering_fields = ["id", "codigo", "sigla", "nome", "ativa"]
+    ordering_fields = [
+        "id",
+        "codigo",
+        "sigla",
+        "nome",
+        "codigo_orgao",
+        "sigla_orgao",
+        "orgao",
+        "ativa",
+    ]
     ordering = ["codigo", "nome"]
 
     AUDIT_TRACK_FIELDS = (

--- a/dados_comuns/formats.py
+++ b/dados_comuns/formats.py
@@ -284,7 +284,7 @@ class UnidadeOrcamentariaPDFFormat(BaseUnidadePDFFormat):
         "<i>Nenhuma unidade orçamentária encontrada com os filtros aplicados.</i>"
     )
     TABLE_FONT_SIZE = 6
-    TABLE_COL_WIDTHS = [2.1 * cm, 4.1 * cm, 4.7 * cm, 2.1 * cm, 4.7 * cm, 2.3 * cm]
+    TABLE_COL_WIDTHS = [1.9 * cm, 3.3 * cm, 3.9 * cm, 1.9 * cm, 2.9 * cm, 4.0 * cm, 2.1 * cm]
 
     def get_table_headers(self):
         return [
@@ -292,6 +292,7 @@ class UnidadeOrcamentariaPDFFormat(BaseUnidadePDFFormat):
             "Sigla UO",
             "Nome UO",
             "Código Órgão",
+            "Sigla Órgão",
             "Nome Órgão",
             "Status",
         ]
@@ -303,6 +304,10 @@ class UnidadeOrcamentariaPDFFormat(BaseUnidadePDFFormat):
             Paragraph(str(unidade.nome) if unidade.nome else "-", cell_style),
             Paragraph(
                 str(unidade.codigo_orgao) if unidade.codigo_orgao else "-",
+                cell_style_center,
+            ),
+            Paragraph(
+                str(unidade.sigla_orgao) if unidade.sigla_orgao else "-",
                 cell_style_center,
             ),
             Paragraph(str(unidade.orgao) if unidade.orgao else "-", cell_style),

--- a/dados_comuns/resources.py
+++ b/dados_comuns/resources.py
@@ -16,16 +16,18 @@ class UnidadeOrcamentariaResource(resources.ModelResource):
             "codigo",
             "sigla",
             "nome",
-            "orgao",
             "codigo_orgao",
+            "sigla_orgao",
+            "orgao",
             "ativa_display",
         )
         export_order = (
             "codigo",
             "sigla",
             "nome",
-            "orgao",
             "codigo_orgao",
+            "sigla_orgao",
+            "orgao",
             "ativa_display",
         )
 

--- a/dados_comuns/tests/tests_exportacao_unidades.py
+++ b/dados_comuns/tests/tests_exportacao_unidades.py
@@ -202,16 +202,18 @@ class ExportacaoUnidadeOrcamentariaTestCase(TestCase):
             codigo=codigo_uo(10, 10, 10),
             nome="UO Ativa",
             sigla="ATV",
-            orgao="Órgão Ativo",
             codigo_orgao="10.10",
+            sigla_orgao="ORGAT",
+            orgao="Órgão Ativo",
             ativa=True,
         )
         self.uo_inativa = criar_uo(
             codigo=codigo_uo(20, 20, 20),
             nome="UO Inativa",
             sigla="INA",
-            orgao="Órgão Inativo",
             codigo_orgao="20.20",
+            sigla_orgao="ORGIN",
+            orgao="Órgão Inativo",
             ativa=False,
         )
 
@@ -267,10 +269,36 @@ class ExportacaoUnidadeOrcamentariaTestCase(TestCase):
         resource = UnidadeOrcamentariaResource()
         dataset = resource.export(UnidadeOrcamentaria.objects.all())
 
+        self.assertEqual(
+            dataset.headers,
+            [
+                "codigo",
+                "sigla",
+                "nome",
+                "codigo_orgao",
+                "sigla_orgao",
+                "orgao",
+                "Status",
+            ],
+        )
+
         status_index = dataset.headers.index("Status")
         status_values = [row[status_index] for row in dataset]
         self.assertIn("Ativa", status_values)
         self.assertIn("Inativa", status_values)
+
+        linha_uo_ativa = next(row for row in dataset if row[0] == self.uo_ativa.codigo)
+        self.assertEqual(
+            list(linha_uo_ativa[:6]),
+            [
+                self.uo_ativa.codigo,
+                self.uo_ativa.sigla,
+                self.uo_ativa.nome,
+                self.uo_ativa.codigo_orgao,
+                self.uo_ativa.sigla_orgao,
+                self.uo_ativa.orgao,
+            ],
+        )
 
     def test_pdf_uo_tabela_exibe_colunas_na_ordem_nova(self):
         pdf_format = UnidadeOrcamentariaPDFFormat()
@@ -287,6 +315,7 @@ class ExportacaoUnidadeOrcamentariaTestCase(TestCase):
                 "Sigla UO",
                 "Nome UO",
                 "Código Órgão",
+                "Sigla Órgão",
                 "Nome Órgão",
                 "Status",
             ],
@@ -298,6 +327,7 @@ class ExportacaoUnidadeOrcamentariaTestCase(TestCase):
                 self.uo_ativa.sigla,
                 self.uo_ativa.nome,
                 self.uo_ativa.codigo_orgao,
+                self.uo_ativa.sigla_orgao,
                 self.uo_ativa.orgao,
                 "Ativa",
             ],

--- a/dados_comuns/tests/tests_models.py
+++ b/dados_comuns/tests/tests_models.py
@@ -347,15 +347,15 @@ class UnidadeOrcamentariaAdminTestCase(TestCase):
         )
         self.assertEqual(
             form_class.base_fields["codigo_orgao"].label,
-            "Código do Orgão",
+            "Código do Órgão",
         )
         self.assertEqual(
             form_class.base_fields["sigla_orgao"].label,
-            "Sigla do Orgão",
+            "Sigla do Órgão",
         )
         self.assertEqual(
             form_class.base_fields["orgao"].label,
-            "Nome do Orgão",
+            "Nome do Órgão",
         )
 
     def test_admin_uo_inclui_exportacao_pdf(self):

--- a/dados_comuns/tests/tests_unidade_orcamentaria_api.py
+++ b/dados_comuns/tests/tests_unidade_orcamentaria_api.py
@@ -31,20 +31,26 @@ class UnidadeOrcamentariaAPITestCase(APITestCase):
             codigo=codigo_uo(10, 10, 10),
             nome="UO 1",
             sigla="UO1",
+            codigo_orgao="10.10",
             sigla_orgao="ORG1",
+            orgao="Órgão 1",
         )
         self.uo2 = criar_uo(
             codigo=codigo_uo(20, 20, 20),
             nome="UO 2",
             sigla="UO2",
+            codigo_orgao="20.20",
             sigla_orgao="ORG2",
+            orgao="Órgão 2",
             ativa=False,
         )
         self.uo3 = criar_uo(
             codigo=codigo_uo(30, 30, 30),
             nome="UO 3",
             sigla="UO3",
+            codigo_orgao="30.30",
             sigla_orgao="ORG3",
+            orgao="Órgão 3",
         )
 
         self.uo_com_ua = criar_uo(
@@ -183,6 +189,27 @@ class UnidadeOrcamentariaAPITestCase(APITestCase):
         response_id = self.client.get(self.list_url, {"ordering": "-id"})
         ids = [row["id"] for row in response_id.data["results"]]
         self.assertEqual(ids, sorted(ids, reverse=True))
+
+        response_ord_sigla_orgao = self.client.get(
+            self.list_url,
+            {"search": "ORG", "ordering": "-sigla_orgao"},
+        )
+        ids_sigla_orgao = [row["id"] for row in response_ord_sigla_orgao.data["results"]]
+        self.assertEqual(ids_sigla_orgao[:3], [self.uo3.id, self.uo2.id, self.uo1.id])
+
+        response_ord_codigo_orgao = self.client.get(
+            self.list_url,
+            {"search": "ORG", "ordering": "codigo_orgao"},
+        )
+        ids_codigo_orgao = [row["id"] for row in response_ord_codigo_orgao.data["results"]]
+        self.assertEqual(ids_codigo_orgao[:3], [self.uo1.id, self.uo2.id, self.uo3.id])
+
+        response_ord_orgao = self.client.get(
+            self.list_url,
+            {"search": "Órgão", "ordering": "-orgao"},
+        )
+        ids_orgao = [row["id"] for row in response_ord_orgao.data["results"]]
+        self.assertEqual(ids_orgao[:3], [self.uo3.id, self.uo2.id, self.uo1.id])
 
     def test_retrieve_criacao_atualizacao_e_historico(self):
         self._auth(self.superuser)


### PR DESCRIPTION
## Objetivo

Ajustar o módulo de Unidades Orçamentárias para expor ordenação completa pelos campos de órgao e alinhar a exportação de UO com o contrato atual consumido pelo frontend.

## O que mudou

- adicionados `codigo_orgao`, `sigla_orgao` e `orgao` aos campos aceitos em `ordering` na API de Unidades Orcamentarias
- corrigido o texto de interface de `Orgão` para `Órgão`
- atualizada a exportacao tabular de UO (`csv`, `xls`, `xlsx`) para incluir os novos campos na ordem:
  - `codigo`
  - `sigla`
  - `nome`
  - `codigo_orgao`
  - `sigla_orgao`
  - `orgao`
  - `Status`
- atualizada a exportacao PDF de UO para incluir:
  - `Código UO`
  - `Sigla UO`
  - `Nome UO`
  - `Código Órgão`
  - `Sigla Órgão`
  - `Nome Órgão`
  - `Status`

## Impacto no frontend

- a UI pode ordenar a listagem por `codigo_orgao`, `sigla_orgao` e `orgao`
- a UI deve considerar `sigla_orgao` na listagem, nos tipos e na leitura de arquivos exportados
- qualquer consumo da exportacao de UO precisa considerar a nova ordem de colunas

## Validacao

- `docker compose -f docker-compose-dev.yml exec web python manage.py test dados_comuns.tests.tests_models dados_comuns.tests.tests_unidade_orcamentaria_api dados_comuns.tests.tests_exportacao_unidades`
- resultado: 51 testes OK