### PR TITLE
Refactor(147325): Remove Exibição do Usuário Responsável do Rodapé NTBPM

### DIFF
--- a/bem_patrimonial/ntbpm.py
+++ b/bem_patrimonial/ntbpm.py
@@ -27,7 +27,6 @@ from bem_patrimonial.pdf_utils import (
     criar_estilo_base,
     extrair_codigo_ua,
     formatar_data,
-    obter_rf_usuario,
 )
 from bem_patrimonial.documentos_pdf_utils import (
     aplicar_estilo_tabela_info,
@@ -392,13 +391,10 @@ def _criar_informacoes_complementares(transferencia):
 
 
 def _criar_rodape_ntbpm(transferencia):
-    responsavel_transferencia = obter_rf_usuario(getattr(transferencia, "criado_por", None))
-    responsavel_recebimento = obter_rf_usuario(getattr(transferencia, "criado_por", None))
-
     return criar_tabela_rodape_responsaveis(
         label_esquerda="RESPONSÁVEL DA UNIDADE ORÇAMENTÁRIA QUE TRANSFERE",
         label_direita="RESPONSÁVEL DA UNIDADE ORÇAMENTÁRIA QUE RECEBE",
-        valor_esquerda=responsavel_transferencia,
-        valor_direita=responsavel_recebimento,
+        valor_esquerda="",
+        valor_direita="",
         config_cls=PDFConfig,
     )

--- a/bem_patrimonial/tests/tests_ntbpm.py
+++ b/bem_patrimonial/tests/tests_ntbpm.py
@@ -259,12 +259,12 @@ class NTBPMTestCase(TestCase):
         self.assertEqual(linhas[1][0], "SEI-987654/2026")
         self.assertEqual(linhas[1][2], "TRANSFERIDO")
 
-    def test_rodape_ntbpm_exibe_usuario_como_responsavel_do_recebimento(self):
+    def test_rodape_ntbpm_deixa_campos_de_responsaveis_em_branco(self):
         tabela = _criar_rodape_ntbpm(self.transferencia)[0]
         linhas = [
             [celula.getPlainText() for celula in linha]
             for linha in tabela._cellvalues
         ]
 
-        self.assertEqual(linhas[1][0], "123456")
-        self.assertEqual(linhas[1][1], "123456")
+        self.assertEqual(linhas[1][0], "")
+        self.assertEqual(linhas[1][1], "")


### PR DESCRIPTION
Este pull request altera a forma como as informações do usuário responsável são exibidas no rodapé da NTBPM, garantindo que os campos de responsáveis permaneçam em branco em vez de serem preenchidos com dados do usuário. Também foram atualizados os testes relacionados para validar esse novo comportamento.

### Alterações na exibição de responsáveis

* Removida a chamada para `obter_rf_usuario` em `_criar_rodape_ntbpm`, e os campos de responsáveis (`valor_esquerda` e `valor_direita`) agora são definidos como strings vazias, fazendo com que o rodapé não exiba mais identificadores de usuários.

### Atualizações de testes

* O teste `test_rodape_ntbpm_exibe_usuario_como_responsavel_do_recebimento` foi renomeado para `test_rodape_ntbpm_deixa_campos_de_responsaveis_em_branco` e atualizado para validar que os campos de responsáveis permanecem vazios.

### Exemplo do Documento Alterado

<img width="990" height="244" alt="image" src="https://github.com/user-attachments/assets/29674f66-156f-49ed-957b-cd341851f887" />

### Testes Executados

<img width="967" height="222" alt="image" src="https://github.com/user-attachments/assets/5e528003-6202-4155-9257-9b0eed011e80" />