### PR TITLE
Fix: Remove Dependência Inválida python-environ do Build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,6 @@ openpyxl==3.0.10
 Pillow==9.4.0
 psycopg2-binary==2.9.9
 pycodestyle==2.10.0
-python-environ==0.4.54
 python-monkey-business==1.0.0
 pytz==2022.6
 PyYAML==6.0


### PR DESCRIPTION
## Contexto
O arquivo requirements.txt contém duas dependências relacionadas a configuração por variáveis de ambiente: django-environ e python-environ. O código da aplicação utiliza somente a API exposta pelo módulo environ nas settings, compatível com django-environ, em base.py e local.py.

## Problema
A dependência python-environ 0.4.54 não está sendo resolvida durante o build da imagem, o que interrompe a instalação das dependências e quebra o build do Docker. Não há uso direto dessa dependência no código.

## Solução
Remover apenas a linha python-environ 0.4.54 de requirements.txt:28, mantendo django-environ 0.4.5 em requirements.txt.

## Impacto
Não há mudança esperada de comportamento em runtime da aplicação. A alteração atua somente na etapa de instalação de dependências e elimina uma entrada inválida ou residual do requirements.

## Risco
Baixo. A aplicação continua usando django-environ, que já está declarado no projeto e cobre toda a API atualmente utilizada nas settings.

## Validação realizada

- Busca no repositório confirmando ausência de uso de python-environ fora do requirements.
- Validação isolada da API de django-environ 0.4.5 compatível com o uso atual do projeto.