### PR TITLE
Feature(150275): Remove Unique do Número do Processo de Transferência

### DIFF
--- a/bem_patrimonial/migrations/0041_remove_unique_numero_processo.py
+++ b/bem_patrimonial/migrations/0041_remove_unique_numero_processo.py
@@ -1,0 +1,32 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("bem_patrimonial", "0040_remove_transferenciabempatrimonial_efetivado_em"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="transferenciabempatrimonial",
+            name="numero_ntbpm",
+            field=models.CharField(
+                blank=True,
+                db_index=True,
+                max_length=30,
+                null=True,
+                unique=True,
+                verbose_name="Número NTBPM",
+            ),
+        ),
+        migrations.AlterField(
+            model_name="transferenciabempatrimonial",
+            name="numero_processo",
+            field=models.CharField(
+                max_length=64,
+                unique=False,
+                verbose_name="Número do processo",
+            ),
+        ),
+    ]

--- a/bem_patrimonial/models.py
+++ b/bem_patrimonial/models.py
@@ -633,7 +633,7 @@ class TransferenciaBemPatrimonial(models.Model):
     numero_processo = models.CharField(
         "Número do processo",
         max_length=64,
-        unique=True,
+        unique=False,
         null=False,
         blank=False,
     )
@@ -642,7 +642,7 @@ class TransferenciaBemPatrimonial(models.Model):
         max_length=30,
         unique=True,
         blank=True,
-        default="",
+        null=True,
         db_index=True,
     )
     observacao = models.TextField("Observação", blank=True)

--- a/bem_patrimonial/ntbpm.py
+++ b/bem_patrimonial/ntbpm.py
@@ -390,7 +390,7 @@ def _criar_informacoes_complementares(transferencia):
     ]
 
 
-def _criar_rodape_ntbpm(transferencia):
+def _criar_rodape_ntbpm():
     return criar_tabela_rodape_responsaveis(
         label_esquerda="RESPONSÁVEL DA UNIDADE ORÇAMENTÁRIA QUE TRANSFERE",
         label_direita="RESPONSÁVEL DA UNIDADE ORÇAMENTÁRIA QUE RECEBE",

--- a/bem_patrimonial/ntbpm.py
+++ b/bem_patrimonial/ntbpm.py
@@ -390,7 +390,8 @@ def _criar_informacoes_complementares(transferencia):
     ]
 
 
-def _criar_rodape_ntbpm():
+def _criar_rodape_ntbpm(transferencia=None):
+    _ = transferencia
     return criar_tabela_rodape_responsaveis(
         label_esquerda="RESPONSÁVEL DA UNIDADE ORÇAMENTÁRIA QUE TRANSFERE",
         label_direita="RESPONSÁVEL DA UNIDADE ORÇAMENTÁRIA QUE RECEBE",

--- a/bem_patrimonial/tests/tests_transferencia_admin.py
+++ b/bem_patrimonial/tests/tests_transferencia_admin.py
@@ -156,7 +156,7 @@ class TransferenciaBemPatrimonialAdminTestCase(TestCase):
             [self.ua_origem.id, self.ua_origem_2.id],
         )
 
-    def test_form_rejeita_numero_processo_duplicado(self):
+    def test_form_aceita_numero_processo_duplicado(self):
         TransferenciaBemPatrimonial.objects.create(
             unidade_orcamentaria_origem=self.uo_origem,
             unidade_orcamentaria_destino=self.uo_destino,
@@ -174,8 +174,28 @@ class TransferenciaBemPatrimonialAdminTestCase(TestCase):
             request=type("obj", (object,), {"user": self.gestor})(),
         )
 
-        self.assertFalse(form.is_valid())
-        self.assertIn("numero_processo", form.errors)
+        self.assertTrue(form.is_valid(), form.errors)
+        self.assertNotIn("numero_processo", form.errors)
+
+    def test_admin_list_exibe_multiplas_transferencias_mesmo_processo(self):
+        TransferenciaBemPatrimonial.objects.create(
+            unidade_orcamentaria_origem=self.uo_origem,
+            unidade_orcamentaria_destino=self.uo_destino,
+            unidade_administrativa_destino=self.ua_destino,
+            numero_processo="SEI-MULT/2026",
+            criado_por=self.gestor,
+        )
+        TransferenciaBemPatrimonial.objects.create(
+            unidade_orcamentaria_origem=self.uo_origem,
+            unidade_orcamentaria_destino=self.uo_destino,
+            unidade_administrativa_destino=self.ua_destino_2,
+            numero_processo="SEI-MULT/2026",
+            criado_por=self.gestor,
+        )
+
+        qs = TransferenciaBemPatrimonial.objects.filter(numero_processo="SEI-MULT/2026")
+
+        self.assertEqual(qs.count(), 2)
 
     def test_change_form_nao_quebra_quando_campos_model_sao_readonly(self):
         transferencia = TransferenciaBemPatrimonial.objects.create(

--- a/bem_patrimonial/tests/tests_transferencia_bem_patrimonial.py
+++ b/bem_patrimonial/tests/tests_transferencia_bem_patrimonial.py
@@ -163,7 +163,7 @@ class TransferenciaBemPatrimonialModelTestCase(TestCase):
         self.assertIn("status 'Aprovado'", str(ctx.exception))
         self.assertFalse(transferencia.numero_ntbpm)
 
-    def test_numero_processo_da_transferencia_deve_ser_unico(self):
+    def test_numero_processo_da_transferencia_pode_ser_repetido(self):
         self._criar_transferencia()
         transferencia = TransferenciaBemPatrimonial(
             unidade_orcamentaria_origem=self.uo_origem,
@@ -174,7 +174,53 @@ class TransferenciaBemPatrimonialModelTestCase(TestCase):
             criado_por=self.gestor,
         )
 
-        with self.assertRaises(ValidationError) as ctx:
-            transferencia.full_clean()
+        transferencia.full_clean()
+        transferencia.save()
 
-        self.assertIn("numero_processo", ctx.exception.message_dict)
+        self.assertEqual(
+            TransferenciaBemPatrimonial.objects.filter(
+                numero_processo="SEI-123456/2026"
+            ).count(),
+            2,
+        )
+
+    def test_model_permite_multiplas_transferencias_mesmo_processo(self):
+        t1 = self._criar_transferencia()
+        t2 = TransferenciaBemPatrimonial.objects.create(
+            unidade_orcamentaria_origem=self.uo_origem,
+            unidade_orcamentaria_destino=self.uo_destino,
+            unidade_administrativa_destino=self.ua_destino,
+            numero_processo="SEI-123456/2026",
+            observacao="Segunda transferência no mesmo processo",
+            criado_por=self.gestor,
+        )
+
+        self.assertEqual(t1.numero_processo, t2.numero_processo)
+        self.assertNotEqual(t1.pk, t2.pk)
+
+    def test_efetivar_transferencia_com_multiplos_processos_iguais(self):
+        bem1 = self._criar_bem("001.000000006-6", self.ua_origem_1)
+        bem2 = self._criar_bem("001.000000007-7", self.ua_origem_2)
+
+        t1 = self._criar_transferencia()
+        TransferenciaBensItem.objects.create(transferencia=t1, bem=bem1)
+        t1.efetivar_transferencia(self.gestor)
+
+        t2 = TransferenciaBemPatrimonial.objects.create(
+            unidade_orcamentaria_origem=self.uo_origem,
+            unidade_orcamentaria_destino=self.uo_destino,
+            unidade_administrativa_destino=self.ua_destino,
+            numero_processo="SEI-123456/2026",
+            observacao="Segunda transferência no mesmo processo",
+            criado_por=self.gestor,
+        )
+        TransferenciaBensItem.objects.create(transferencia=t2, bem=bem2)
+        t2.efetivar_transferencia(self.gestor)
+
+        bem2.refresh_from_db()
+        t2.refresh_from_db()
+        self.assertEqual(bem2.unidade_administrativa, self.ua_destino)
+        self.assertEqual(bem2.status, constants.TRANSFERIDO)
+        self.assertTrue(t2.numero_ntbpm)
+        self.assertEqual(t1.numero_processo, t2.numero_processo)
+        self.assertNotEqual(t1.numero_ntbpm, t2.numero_ntbpm)


### PR DESCRIPTION
## Objetivo

Permitir multiplas transferencias de Bens Patrimoniais por processo. Antes o campo `numero_processo` possuia `unique=True`, bloqueando mais de uma transferencia com o mesmo numero de processo.

## Alteracoes

**bem_patrimonial/models.py**
`numero_processo`: `unique=True` -> `unique=False`

**bem_patrimonial/models.py**
`numero_ntbpm`: `default=""` -> `null=True` (evita conflito de UNIQUE com string vazia em transferencias nao efetivadas)

**migrations/0041_***

- Remove a constraint UNIQUE do banco no campo `numero_processo`
- Permite NULL no campo `numero_ntbpm`

**tests/tests_transferencia_admin.py**
- Renomeado: `test_form_rejeita_numero_processo_duplicado` -> `test_form_aceita_numero_processo_duplicado`
- Novo: `test_admin_list_exibe_multiplas_transferencias_mesmo_processo`

**tests/tests_transferencia_bem_patrimonial.py**
- Renomeado: `test_numero_processo_da_transferencia_deve_ser_unico` -> `test_numero_processo_da_transferencia_pode_ser_repetido`
- Novo: `test_model_permite_multiplas_transferencias_mesmo_processo`
- Novo: `test_efetivar_transferencia_com_multiplos_processos_iguais`

---

## Testes Criados/Alterados

- `test_form_aceita_numero_processo_duplicado`: Form aceita `numero_processo` ja existente em outra transferencia.
- `test_admin_list_exibe_multiplas_transferencias_mesmo_processo`: Query por processo retorna multiplos registros (count = 2).
- `test_numero_processo_da_transferencia_pode_ser_repetido`: `full_clean()` nao rejeita mais duplicata; ambas persistem no banco.
- `test_model_permite_multiplas_transferencias_mesmo_processo`: Duas transferencias com mesmo processo persistem com PKs distintas.
- `test_efetivar_transferencia_com_multiplos_processos_iguais`: Efetivacao de duas transferencias com mesmo processo gera NTBPMs distintos e move os bens corretamente.

---

## Como testar

### Geral do projeto

Comando:

```
docker compose -f docker-compose-dev.yml run --rm web python manage.py test
```

Resultado: 982 tests OK

### Escopo das alterações

Comando:

```
docker compose -f docker-compose-dev.yml exec web python manage.py test \
  bem_patrimonial.tests.tests_transferencia_admin \
  bem_patrimonial.tests.tests_transferencia_bem_patrimonial -v2
```

Resultado: 29 tests OK
