### PR TITLE
Refactor(151176): Corrige Code Smells Apontados pelo Sonar 26.5.0

### DIFF
--- a/bem_patrimonial/admins/baixa_fisica_bem_patrimonial.py
+++ b/bem_patrimonial/admins/baixa_fisica_bem_patrimonial.py
@@ -298,7 +298,10 @@ class BaixaFisicaBemPatrimonialAdmin(ExportMixin, admin.ModelAdmin):
     change_form_template = "admin/bem_patrimonial/baixa_fisica/change_form.html"
 
     class Media:
-        js = ("admin/baixa_fisica_autocomplete.js",)
+        js = (
+            "admin/admin_autocomplete_filter.js",
+            "admin/baixa_fisica_autocomplete.js",
+        )
         css = {
             "all": (
                 "css/hide_crud_icons.css",

--- a/bem_patrimonial/admins/baixa_fisica_bem_patrimonial.py
+++ b/bem_patrimonial/admins/baixa_fisica_bem_patrimonial.py
@@ -166,8 +166,8 @@ class BaixaFisicaBensItemInline(admin.TabularInline):
     def get_readonly_fields(self, request, obj=None):
 
         if obj and obj.status != constants.AGUARDANDO_ENVIO:
-            return ("bem",)
-        return ()
+            return ["bem"]
+        return []
 
 
 class BaixaFisicaResource(resources.ModelResource):
@@ -309,7 +309,7 @@ class BaixaFisicaBemPatrimonialAdmin(ExportMixin, admin.ModelAdmin):
 
     def get_readonly_fields(self, request, obj=None):
         if obj:
-            return (
+            return [
                 "unidade_administrativa_origem",
                 "numero_processo_baixa",
                 "status",
@@ -318,8 +318,8 @@ class BaixaFisicaBemPatrimonialAdmin(ExportMixin, admin.ModelAdmin):
                 "aprovado_por",
                 "data_aprovacao",
                 "data_baixa",
-            )
-        return ()
+            ]
+        return []
 
     def get_fieldsets(self, request, obj=None):
         campos_basicos = (

--- a/bem_patrimonial/admins/inlines/inlines.py
+++ b/bem_patrimonial/admins/inlines/inlines.py
@@ -230,8 +230,8 @@ class TransferenciaBensItemInline(admin.TabularInline):
 
     def get_readonly_fields(self, request, obj=None):
         if obj is None:
-            return ()
-        return ("bem_detalhado",)
+            return []
+        return ["bem_detalhado"]
 
     def get_extra(self, request, obj=None, **kwargs):
         if obj is None:

--- a/bem_patrimonial/admins/movimentacao_bem_patrimonial.py
+++ b/bem_patrimonial/admins/movimentacao_bem_patrimonial.py
@@ -463,6 +463,7 @@ class MovimentacaoBemPatrimonialAdmin(admin.ModelAdmin):
     class Media:
         js = (
             "js/bem_patrimonial/prevenir_duplo_submit.js",
+            "admin/admin_autocomplete_filter.js",
             "admin/movimentacao_filtra_bens_por_ua.js",
             "admin/movimentacao_uo_destino.js",
         )

--- a/bem_patrimonial/admins/transferencia_bem_patrimonial.py
+++ b/bem_patrimonial/admins/transferencia_bem_patrimonial.py
@@ -73,6 +73,7 @@ class TransferenciaBemPatrimonialAdmin(admin.ModelAdmin):
     class Media:
         js = (
             "js/bem_patrimonial/prevenir_duplo_submit.js",
+            "admin/admin_autocomplete_filter.js",
             "admin/transferencia_filtra_bens_por_uo.js",
         )
         css = {

--- a/bem_patrimonial/management/commands/bem_patrimonial_remove_npat_da_descricao.py
+++ b/bem_patrimonial/management/commands/bem_patrimonial_remove_npat_da_descricao.py
@@ -40,7 +40,7 @@ class Command(BaseCommand):
         )
         return True
 
-    def _processar_descricao_bem(self, bem, numero, descricao_original):
+    def _processar_descricao_bem(self, numero, descricao_original):
         descricao_trabalhada = descricao_original
         alterou = False
         if numero and numero in descricao_trabalhada:
@@ -81,7 +81,7 @@ class Command(BaseCommand):
                     continue
 
                 descricao_limpa, alterou = self._processar_descricao_bem(
-                    bem, numero, descricao_original
+                    numero, descricao_original
                 )
 
                 if not alterou:

--- a/inventario/admin.py
+++ b/inventario/admin.py
@@ -500,7 +500,7 @@ class ConciliacaoUAAdmin(admin.ModelAdmin):
 
     def get_fieldsets(self, request, obj=None):
         if obj is None:
-            return (
+            return [
                 (
                     "Criar Conciliação",
                     {
@@ -511,9 +511,9 @@ class ConciliacaoUAAdmin(admin.ModelAdmin):
                         )
                     },
                 ),
-            )
+            ]
 
-        return (
+        return [
             (
                 "Dados Básicos",
                 {
@@ -530,7 +530,7 @@ class ConciliacaoUAAdmin(admin.ModelAdmin):
                 "Auditoria",
                 {"fields": ("criado_por", "criado_em", "fechado_por", "fechado_em")},
             ),
-        )
+        ]
 
     def get_readonly_fields(self, request, obj=None):
         ro = list(super().get_readonly_fields(request, obj))

--- a/static/admin/admin_autocomplete_filter.js
+++ b/static/admin/admin_autocomplete_filter.js
@@ -1,0 +1,7 @@
+(function() {
+    function isAutocompleteUrl(url) {
+        return typeof url === 'string' && url.includes('/admin/autocomplete/');
+    }
+
+    globalThis.AdminAutocompleteFilter = { isAutocompleteUrl: isAutocompleteUrl };
+})();

--- a/static/admin/baixa_fisica_autocomplete.js
+++ b/static/admin/baixa_fisica_autocomplete.js
@@ -116,7 +116,7 @@
                 const opts = isStringUrl ? options : { ...options };
                 const url = isStringUrl ? opts : opts.url;
 
-                if (!url || !url.includes('/admin/autocomplete/')) {
+                if (!globalThis.AdminAutocompleteFilter.isAutocompleteUrl(url)) {
                     return oldAjax.apply(this, arguments);
                 }
 

--- a/static/admin/baixa_fisica_autocomplete.js
+++ b/static/admin/baixa_fisica_autocomplete.js
@@ -1,6 +1,6 @@
 (function() {
     function startWhenReady() {
-        if (!window.django || !django.jQuery) {
+        if (!globalThis.django || !django.jQuery) {
             return setTimeout(startWhenReady, 100);
         }
 
@@ -116,7 +116,7 @@
                 const opts = isStringUrl ? options : { ...options };
                 const url = isStringUrl ? opts : opts.url;
 
-                if (!url || url.indexOf('/admin/autocomplete/') === -1) {
+                if (!url || !url.includes('/admin/autocomplete/')) {
                     return oldAjax.apply(this, arguments);
                 }
 
@@ -135,7 +135,7 @@
                 }
 
                 if (params.length) {
-                    const sep = url.indexOf('?') === -1 ? '?' : '&';
+                    const sep = url.includes('?') ? '&' : '?';
                     const newUrl = url + sep + params.join('&');
                     return oldAjax.apply(this, [isStringUrl ? newUrl : { ...opts, url: newUrl }]);
                 }

--- a/static/admin/bem_patrimonial.js
+++ b/static/admin/bem_patrimonial.js
@@ -3,7 +3,7 @@
   function id(s){ return document.getElementById(s); }
   function qs(s, r){ return (r || document).querySelector(s); }
   function qsa(s, r){ return Array.prototype.slice.call((r || document).querySelectorAll(s)); }
-  function onlyDigits(s){ return (s||'').replace(/\D/g,''); }
+  function onlyDigits(s){ return (s||'').replaceAll(/\D/g,''); }
   function fmt(d){
     d = (d||'').slice(0,13);
     const p1=d.slice(0,3), p2=d.slice(3,12), p3=d.slice(12,13);
@@ -42,17 +42,17 @@
     (function init(){
       const raw = (el.value?.trim() || "");
       if (raw){
-        const digits = raw.replace(/[^\d]/g, "");
+        const digits = raw.replaceAll(/[^\d]/g, "");
         const formatted = formatBRMoneyFromDigits(digits);
         if (raw !== formatted) el.value = formatted;
       }
     })();
     el.addEventListener("input", function(){
-      const digits = (el.value || "").replace(/[^\d]/g, "");
+      const digits = (el.value || "").replaceAll(/[^\d]/g, "");
       el.value = formatBRMoneyFromDigits(digits);
     });
     el.addEventListener("blur", function(){
-      const digits = (el.value || "").replace(/[^\d]/g, "");
+      const digits = (el.value || "").replaceAll(/[^\d]/g, "");
       el.value = formatBRMoneyFromDigits(digits);
     });
     el.setAttribute("required", "required");
@@ -80,14 +80,14 @@
     }
 
     function applyPatternAndMask(){
-      
-      if (!ant?.checked){
-        np.setAttribute('pattern', '^\\d{3}\\.\\d{9}-\\d$');
-        np.placeholder = '000.000000000-0';
-        np.value = fmt(onlyDigits(np.value));
-      } else {
+
+      if (ant?.checked){
         np.removeAttribute('pattern');
         np.placeholder = 'Valor livre (formato antigo)';
+      } else {
+        np.setAttribute('pattern', String.raw`^\d{3}\.\d{9}-\d$`);
+        np.placeholder = '000.000000000-0';
+        np.value = fmt(onlyDigits(np.value));
       }
     }
 
@@ -153,7 +153,7 @@
       const semMarcado = !!sem?.checked;
       if (!ant?.checked && !semMarcado){
         np.value = fmt(onlyDigits(np.value));
-        np.setAttribute('pattern', '^\\d{3}\\.\\d{9}-\\d$');
+        np.setAttribute('pattern', String.raw`^\d{3}\.\d{9}-\d$`);
         np.placeholder = '000.000000000-0';
       } else if (ant?.checked){
         np.removeAttribute('pattern');
@@ -243,7 +243,7 @@
         input.removeAttribute('pattern');
         input.placeholder = 'Valor livre (formato antigo)';
       } else if (!sem.checked){
-        input.setAttribute('pattern', '^\\d{3}\\.\\d{9}-\\d$');
+        input.setAttribute('pattern', String.raw`^\d{3}\.\d{9}-\d$`);
         input.value = fmt(onlyDigits(input.value));
         input.placeholder = '000.000000000-0';
       }
@@ -292,16 +292,16 @@
       const sem = qs('.fld-sem', row);
       const loc = qs('.fld-loc', row);
 
-      if (typeof item.numero_patrimonial !== 'undefined' && np){
+      if (item.numero_patrimonial !== undefined && np){
         np.value = item.numero_patrimonial || '';
       }
-      if (typeof item.numero_formato_antigo !== 'undefined' && ant){
+      if (item.numero_formato_antigo !== undefined && ant){
         ant.checked = !!item.numero_formato_antigo;
       }
-      if (typeof item.sem_numeracao !== 'undefined' && sem){
+      if (item.sem_numeracao !== undefined && sem){
         sem.checked = !!item.sem_numeracao;
       }
-      if (typeof item.localizacao !== 'undefined' && loc){
+      if (item.localizacao !== undefined && loc){
         loc.value = item.localizacao || '';
       }
       ant?.dispatchEvent(new Event('change'));
@@ -335,19 +335,6 @@
         errors.push('Adicione ao menos uma linha no modo Múltiplos Bens.');
     }
 
-    function markErr(input){
-        input.classList.add('error');
-        input.style.setProperty('border-color', '#ba2121', 'important');
-        input.style.setProperty('outline', '2px solid rgba(186,33,33,.15)', 'important');
-        input.style.setProperty('outline-offset', '1px', 'important');
-    }
-    function clearErr(input){
-        input.classList.remove('error');
-        input.style.removeProperty('border-color');
-        input.style.removeProperty('outline');
-        input.style.removeProperty('outline-offset');
-    }
-
     rows.forEach(function(r, i){
         const idx = i + 1;
         const np  = qs('.fld-npat', r);
@@ -368,12 +355,12 @@
         clearErr(np);
         }
 
-        if (!locVal){
+        if (locVal){
+        clearErr(loc);
+        } else {
         errors.push('Linha '+idx+': Informe a Localização (obrigatória).');
         markErr(loc);
         r.classList.add('invalid');
-        } else {
-        clearErr(loc);
         }
     });
 
@@ -392,6 +379,20 @@
   function cleanBaseHighlights(form){
     qsa('.form-row .error', form).forEach(function(el){ el.classList.remove('error'); });
     qsa('.form-row input, .form-row select, .form-row textarea', form).forEach(function(el){ el.style.borderColor = ''; });
+  }
+
+  function markErr(input){
+    input.classList.add('error');
+    input.style.setProperty('border-color', '#ba2121', 'important');
+    input.style.setProperty('outline', '2px solid rgba(186,33,33,.15)', 'important');
+    input.style.setProperty('outline-offset', '1px', 'important');
+  }
+
+  function clearErr(input){
+    input.classList.remove('error');
+    input.style.removeProperty('border-color');
+    input.style.removeProperty('outline');
+    input.style.removeProperty('outline-offset');
   }
 
   function markErrorField(field){
@@ -433,7 +434,7 @@
   function collectRequiredFields(form){
     let req = qsa('input[required], select[required], textarea[required]', form);
     qsa('.form-row.required input, .form-row.required select, .form-row.required textarea', form).forEach(function(el){
-      if (req.indexOf(el) === -1) req.push(el);
+      if (!req.includes(el)) req.push(el);
     });
     req = req.filter(function(el){ return !el.closest('#multi-container'); });
     return req;
@@ -515,7 +516,7 @@
     })();
 
     hydrateFromPayload(initialPayload);
-    const forceMultiFlag = root.getAttribute('data-force-multi') === '1';
+    const forceMultiFlag = root.dataset.forceMulti === '1';
     setMode(forceMultiFlag ? 'multi' : null);
 
     function guardSubmit(ev){

--- a/static/admin/movimentacao_filtra_bens_por_ua.js
+++ b/static/admin/movimentacao_filtra_bens_por_ua.js
@@ -5,7 +5,7 @@
             const opts = isStringUrl ? options : { ...options };
             const url = isStringUrl ? opts : opts.url;
 
-            if (!url || url.indexOf('/admin/autocomplete/') === -1) {
+            if (!url || !url.includes('/admin/autocomplete/')) {
                 return oldAjax.apply(this, arguments);
             }
 
@@ -29,7 +29,7 @@
             }
 
             if (params.length) {
-                const sep = url.indexOf('?') === -1 ? '?' : '&';
+                const sep = url.includes('?') ? '&' : '?';
                 const newUrl = url + sep + params.join('&');
                 return oldAjax.apply(this, [isStringUrl ? newUrl : { ...opts, url: newUrl }]);
             }
@@ -38,7 +38,7 @@
     }
 
     function startWhenReady() {
-        if (!window.django || !django.jQuery) {
+        if (!globalThis.django || !django.jQuery) {
             return setTimeout(startWhenReady, 100);
         }
 

--- a/static/admin/movimentacao_filtra_bens_por_ua.js
+++ b/static/admin/movimentacao_filtra_bens_por_ua.js
@@ -5,7 +5,7 @@
             const opts = isStringUrl ? options : { ...options };
             const url = isStringUrl ? opts : opts.url;
 
-            if (!url || !url.includes('/admin/autocomplete/')) {
+            if (!globalThis.AdminAutocompleteFilter.isAutocompleteUrl(url)) {
                 return oldAjax.apply(this, arguments);
             }
 

--- a/static/admin/movimentacao_uo_destino.js
+++ b/static/admin/movimentacao_uo_destino.js
@@ -68,7 +68,7 @@
     }
 
     function init() {
-        if (!window.django || !django.jQuery) {
+        if (!globalThis.django || !django.jQuery) {
             return setTimeout(init, 100);
         }
 

--- a/static/admin/transferencia_filtra_bens_por_uo.js
+++ b/static/admin/transferencia_filtra_bens_por_uo.js
@@ -5,7 +5,7 @@
             const opts = isStringUrl ? options : { ...options };
             const url = isStringUrl ? opts : opts.url;
 
-            if (!url || url.indexOf('/admin/autocomplete/') === -1) {
+            if (!url || !url.includes('/admin/autocomplete/')) {
                 return oldAjax.apply(this, arguments);
             }
 
@@ -32,7 +32,7 @@
             }
 
             if (params.length) {
-                const sep = url.indexOf('?') === -1 ? '?' : '&';
+                const sep = url.includes('?') ? '&' : '?';
                 const newUrl = url + sep + params.join('&');
                 return oldAjax.apply(this, [isStringUrl ? newUrl : { ...opts, url: newUrl }]);
             }
@@ -41,7 +41,7 @@
     }
 
     function startWhenReady() {
-        if (!window.django || !django.jQuery) {
+        if (!globalThis.django || !django.jQuery) {
             return setTimeout(startWhenReady, 100);
         }
 

--- a/static/admin/transferencia_filtra_bens_por_uo.js
+++ b/static/admin/transferencia_filtra_bens_por_uo.js
@@ -5,7 +5,7 @@
             const opts = isStringUrl ? options : { ...options };
             const url = isStringUrl ? opts : opts.url;
 
-            if (!url || !url.includes('/admin/autocomplete/')) {
+            if (!globalThis.AdminAutocompleteFilter.isAutocompleteUrl(url)) {
                 return oldAjax.apply(this, arguments);
             }
 

--- a/static/admin/ua_codigo_prefixo.js
+++ b/static/admin/ua_codigo_prefixo.js
@@ -1,7 +1,7 @@
 (function () {
     function ready(fn) {
-        if (document.readyState !== 'loading') fn()
-        else document.addEventListener('DOMContentLoaded', fn)
+        if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', fn)
+        else fn()
     }
 
     function ensurePrefixEl(afterEl) {

--- a/static/admin/usuario_uo_ua.js
+++ b/static/admin/usuario_uo_ua.js
@@ -1,7 +1,7 @@
 (function () {
     function ready(fn) {
-        if (document.readyState !== 'loading') fn()
-        else document.addEventListener('DOMContentLoaded', fn)
+        if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', fn)
+        else fn()
     }
 
     function setSelected(selectEl, value) {
@@ -20,7 +20,7 @@
 
         if (!uo || !ua) return;
 
-        const url = new URL(window.location.href);
+        const url = new URL(globalThis.location.href);
         const uoParam = url.searchParams.get('unidade_orcamentaria');
         if (uoParam) {
             setSelected(uo, uoParam);
@@ -31,7 +31,7 @@
         uo.addEventListener('change', function () {
             const uoId = uo.value || '';
             ua.value = '';
-            const newUrl = new URL(window.location.href);
+            const newUrl = new URL(globalThis.location.href);
 
             if (uoId) {
                 newUrl.searchParams.set('unidade_orcamentaria', uoId);
@@ -39,7 +39,7 @@
                 newUrl.searchParams.delete('unidade_orcamentaria');
             }
 
-            window.location.href = newUrl.toString();
+            globalThis.location.href = newUrl.toString();
         });
     });
 })()


### PR DESCRIPTION
## Descrição
Resolve 37 code smells apontados pelo Sonar 26.5.0 (após atualização da versão), sem alterar regras de negócio ou comportamento funcional.

## Alterações
Python (5)
- bem_patrimonial/admins/baixa_fisica_bem_patrimonial.py — get_readonly_fields (linhas 166 e 310): tupla → lista para evitar retornos de tamanhos diferentes
- bem_patrimonial/admins/inlines/inlines.py — get_readonly_fields (linha 231): mesma correção
- inventario/admin.py — get_fieldsets (linha 501): tupla → lista
- bem_patrimonial/management/commands/bem_patrimonial_remove_npat_da_descricao.py — removido parâmetro bem não utilizado em _processar_descricao_bem

## JavaScript (32)
- baixa_fisica_autocomplete.js — window → globalThis; indexOf → includes
- bem_patrimonial.js — replace → replaceAll; String.raw em regex; typeof !== 'undefined' → comparação direta; getAttribute → dataset; condições negadas invertidas; funções markErr/clearErr movidas para escopo externo
- movimentacao_filtra_bens_por_ua.js — window → globalThis; indexOf → includes
- movimentacao_uo_destino.js — window → globalThis
- transferencia_filtra_bens_por_uo.js — window → globalThis; indexOf → includes
- ua_codigo_prefixo.js — condição negada invertida em ready()
- usuario_uo_ua.js — window.location → globalThis.location; condição negada invertida em ready()

## Falsos positivos
Os 20 code smells restantes foram classificados como falso positivo por estarem em arquivos .html (templates do admin do Django), onde:
- Tags inline não permitem reestruturação sem mudar a renderização
- As recomendações do Sonar nesses casos é sem impacto real de qualidade

## Checklist
- Nenhuma regra de negócio alterada
- Comportamento externo preservado
- Lógica de validação/manipulação inalterada
