### PR TITLE
Refactor(151176): Corrige Code Smells Apontados pelo Sonar 26.5.0

### DIFF
--- a/bem_patrimonial/admins/baixa_fisica_bem_patrimonial.py
+++ b/bem_patrimonial/admins/baixa_fisica_bem_patrimonial.py
@@ -166,8 +166,8 @@ class BaixaFisicaBensItemInline(admin.TabularInline):
     def get_readonly_fields(self, request, obj=None):
 
         if obj and obj.status != constants.AGUARDANDO_ENVIO:
-            return ("bem",)
-        return ()
+            return ["bem"]
+        return []
 
 
 class BaixaFisicaResource(resources.ModelResource):
@@ -309,7 +309,7 @@ class BaixaFisicaBemPatrimonialAdmin(ExportMixin, admin.ModelAdmin):
 
     def get_readonly_fields(self, request, obj=None):
         if obj:
-            return (
+            return [
                 "unidade_administrativa_origem",
                 "numero_processo_baixa",
                 "status",
@@ -318,8 +318,8 @@ class BaixaFisicaBemPatrimonialAdmin(ExportMixin, admin.ModelAdmin):
                 "aprovado_por",
                 "data_aprovacao",
                 "data_baixa",
-            )
-        return ()
+            ]
+        return []
 
     def get_fieldsets(self, request, obj=None):
         campos_basicos = (

--- a/bem_patrimonial/admins/inlines/inlines.py
+++ b/bem_patrimonial/admins/inlines/inlines.py
@@ -230,8 +230,8 @@ class TransferenciaBensItemInline(admin.TabularInline):
 
     def get_readonly_fields(self, request, obj=None):
         if obj is None:
-            return ()
-        return ("bem_detalhado",)
+            return []
+        return ["bem_detalhado"]
 
     def get_extra(self, request, obj=None, **kwargs):
         if obj is None:

--- a/bem_patrimonial/management/commands/bem_patrimonial_remove_npat_da_descricao.py
+++ b/bem_patrimonial/management/commands/bem_patrimonial_remove_npat_da_descricao.py
@@ -40,7 +40,7 @@ class Command(BaseCommand):
         )
         return True
 
-    def _processar_descricao_bem(self, bem, numero, descricao_original):
+    def _processar_descricao_bem(self, numero, descricao_original):
         descricao_trabalhada = descricao_original
         alterou = False
         if numero and numero in descricao_trabalhada:
@@ -81,7 +81,7 @@ class Command(BaseCommand):
                     continue
 
                 descricao_limpa, alterou = self._processar_descricao_bem(
-                    bem, numero, descricao_original
+                    numero, descricao_original
                 )
 
                 if not alterou:

--- a/inventario/admin.py
+++ b/inventario/admin.py
@@ -500,7 +500,7 @@ class ConciliacaoUAAdmin(admin.ModelAdmin):
 
     def get_fieldsets(self, request, obj=None):
         if obj is None:
-            return (
+            return [
                 (
                     "Criar Conciliação",
                     {
@@ -511,9 +511,9 @@ class ConciliacaoUAAdmin(admin.ModelAdmin):
                         )
                     },
                 ),
-            )
+            ]
 
-        return (
+        return [
             (
                 "Dados Básicos",
                 {
@@ -530,7 +530,7 @@ class ConciliacaoUAAdmin(admin.ModelAdmin):
                 "Auditoria",
                 {"fields": ("criado_por", "criado_em", "fechado_por", "fechado_em")},
             ),
-        )
+        ]
 
     def get_readonly_fields(self, request, obj=None):
         ro = list(super().get_readonly_fields(request, obj))


### PR DESCRIPTION
## Descrição
Resolve 5 code smells em código Python apontados pelo Sonar 26.5.0, sem alterar regras de negócio ou comportamento funcional.

## Alterações
- bem_patrimonial/admins/baixa_fisica_bem_patrimonial.py — get_readonly_fields (linhas 166 e 310): tupla → lista
- bem_patrimonial/admins/inlines/inlines.py — get_readonly_fields (linha 231): tupla → lista
- inventario/admin.py — get_fieldsets (linha 501): tupla → lista
- bem_patrimonial/management/commands/bem_patrimonial_remove_npat_da_descricao.py — removido parâmetro bem não utilizado de _processar_descricao_bem

Por que tupla → lista
O Sonar reporta "Refactor this function to always return tuples of the same length" quando a função retorna tuplas de tamanhos diferentes em branches distintos. Como get_readonly_fields e get_fieldsets do Django aceitam tanto tupla quanto lista, a conversão para lista elimina o aviso sem impacto funcional.
Falsos positivos

Os demais code smells apontados pelo Sonar foram classificados como falso positivo por estarem em:
- Templates HTML do Django Admin — a lógica inline nos .html é proposital para manter contexto visual; mover para .js separados fragmentaria o código sem ganho real de qualidade.
- JS de máscara/formulário — arquivos como bem_patrimonial.js lidam com máscaras de input, formatação monetária e validação client-side já consolidadas; as sugestões do Sonar (ex: replace → replaceAll, typeof → comparação direta) são estilísticas e não afetam o comportamento.

Esses casos foram revisados individualmente e mantidos como estão por questão de proporcionalidade custo/benefício.

## Checklist
- Nenhuma regra de negócio alterada
- Comportamento externo preservado
- Apenas arquivos Python modificados