### PR TITLE
Feature(143037): Endpoints de Conciliação de Inventário

### DIFF
--- a/bem_patrimonial/emails.py
+++ b/bem_patrimonial/emails.py
@@ -1,10 +1,7 @@
-import pytz
 from django.conf import settings
 from django.utils import timezone
 from config.utils import email_utils
 from usuario.models import Usuario
-
-local_timezone = pytz.timezone(settings.TIME_ZONE)
 
 EMAIL_TEMPLATE_SIMPLE_MESSAGE = "simple_message.html"
 URL_BAIXA_FISICA_CHANGE = "{}/bem_patrimonial/baixafisicabempatrimonial/{}/change/"

--- a/bem_patrimonial/pdf_utils.py
+++ b/bem_patrimonial/pdf_utils.py
@@ -11,7 +11,7 @@ from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
 from reportlab.lib.enums import TA_CENTER
 from reportlab.platypus import Image, Paragraph, Spacer
 
-import pytz
+from zoneinfo import ZoneInfo
 
 
 class PDFConfigBase:
@@ -116,7 +116,7 @@ def formatar_data(dt):
 
 
 def formatar_datahora_geracao(data_geracao=None, config_cls=PDFConfigBase):
-    tz = pytz.timezone(config_cls.TZ_PADRAO)
+    tz = ZoneInfo(config_cls.TZ_PADRAO)
     data_ref = data_geracao if data_geracao else timezone.now()
 
     if timezone.is_naive(data_ref):

--- a/inventario/api_serializers.py
+++ b/inventario/api_serializers.py
@@ -1,6 +1,16 @@
+from django.core.exceptions import ValidationError as DjangoValidationError
 from rest_framework import serializers
 
-from inventario.models import ParametroConciliacaoAnual
+from dados_comuns.escopo import filtrar_ua_origem_por_escopo
+from dados_comuns.models import UnidadeAdministrativa
+
+from inventario import constants
+from inventario.models import (
+    ConciliacaoUA,
+    ItemConciliacao,
+    OcorrenciaConciliacao,
+    ParametroConciliacaoAnual,
+)
 
 
 class ParametroConciliacaoAnualListSerializer(serializers.ModelSerializer):
@@ -40,3 +50,378 @@ class ParametroConciliacaoAnualDetailSerializer(
 ):
     class Meta(ParametroConciliacaoAnualListSerializer.Meta):
         read_only_fields = ["id", "esta_vigente"]
+
+
+def _resumo_situacoes(conciliacao):
+    situacoes = [
+        ("encontrados", constants.ENCONTRADO_SEM_DIVERGENCIA),
+        ("nao_encontrados", constants.NAO_ENCONTRADO),
+        ("divergentes", constants.DIVERGENTE),
+        ("em_processo_baixa", constants.EM_PROCESSO_BAIXA_FISICA),
+        ("baixa_fisica", constants.BAIXA_FISICA),
+        ("encontrados_com_divergencia", constants.ENCONTRADO),
+    ]
+    return {
+        chave: conciliacao.itens.filter(situacao=valor).count()
+        for chave, valor in situacoes
+    }
+
+
+class ConciliacaoUACreateSerializer(serializers.ModelSerializer):
+    """
+    Serializer de criação de Conciliação.
+
+    Replica as regras do ConciliacaoUAAdminForm:
+    - tipo é forçado para EVENTUAL (anuais são criadas automaticamente pelo sistema).
+    - unidade_administrativa é validada contra o escopo do usuário.
+    - Bloqueia criação quando já existe conciliação em aberto para a UA.
+    - periodo_final é obrigatório para EVENTUAL.
+    """
+
+    class Meta:
+        model = ConciliacaoUA
+        fields = ["unidade_administrativa", "tipo", "periodo_final"]
+        extra_kwargs = {
+            "unidade_administrativa": {"required": True, "allow_null": False},
+            "tipo": {"required": False},
+            "periodo_final": {"required": False, "allow_null": True},
+        }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        request = self.context.get("request")
+        user = getattr(request, "user", None)
+
+        if "unidade_administrativa" in self.fields and user is not None:
+            base_qs = UnidadeAdministrativa.objects.filter(
+                status=UnidadeAdministrativa.ATIVA
+            )
+            self.fields["unidade_administrativa"].queryset = (
+                filtrar_ua_origem_por_escopo(user, base_qs)
+            )
+
+    def validate_tipo(self, value):
+        if value is None:
+            return constants.CONCILIACAO_EVENTUAL
+        if value != constants.CONCILIACAO_EVENTUAL:
+            raise serializers.ValidationError(
+                "Conciliações anuais são criadas automaticamente pelo sistema. "
+                "Para criar uma conciliação manualmente, use o tipo 'eventual'."
+            )
+        return value
+
+    def validate(self, attrs):
+        attrs.setdefault("tipo", constants.CONCILIACAO_EVENTUAL)
+        attrs["tipo"] = self.validate_tipo(attrs.get("tipo"))
+
+        unidade_administrativa = attrs.get("unidade_administrativa")
+        if unidade_administrativa is None:
+            raise serializers.ValidationError(
+                {"unidade_administrativa": "Unidade Administrativa é obrigatória."}
+            )
+
+        request = self.context.get("request")
+        user = getattr(request, "user", None)
+        self._validar_ua_no_escopo(user, unidade_administrativa)
+        self._validar_sem_conciliacao_aberta(unidade_administrativa)
+
+        tipo = attrs["tipo"]
+        periodo_final = attrs.get("periodo_final")
+
+        if tipo == constants.CONCILIACAO_EVENTUAL and not periodo_final:
+            raise serializers.ValidationError(
+                {"periodo_final": "Este campo é obrigatório para conciliação eventual."}
+            )
+
+        return attrs
+
+    def _validar_ua_no_escopo(self, user, unidade_administrativa):
+        if user is None:
+            return
+        allowed_qs = filtrar_ua_origem_por_escopo(
+            user,
+            UnidadeAdministrativa.objects.filter(status=UnidadeAdministrativa.ATIVA),
+        )
+        if not allowed_qs.filter(pk=unidade_administrativa.pk).exists():
+            raise serializers.ValidationError(
+                {
+                    "unidade_administrativa": (
+                        "Você não tem permissão para usar esta Unidade Administrativa."
+                    )
+                }
+            )
+
+    def _validar_sem_conciliacao_aberta(self, unidade_administrativa):
+        if self.instance and self.instance.pk:
+            return
+        existe_aberto = ConciliacaoUA.objects.filter(
+            unidade_administrativa=unidade_administrativa,
+            status=constants.CONCILIACAO_EM_ABERTO,
+        ).exists()
+        if existe_aberto:
+            raise serializers.ValidationError(
+                {
+                    "unidade_administrativa": (
+                        "Já existe uma conciliação em aberto para esta Unidade "
+                        "Administrativa. Feche a conciliação anterior para abrir uma nova."
+                    )
+                }
+            )
+
+    def create(self, validated_data):
+        request = self.context.get("request")
+        user = getattr(request, "user", None)
+        conciliacao = ConciliacaoUA(**validated_data)
+        if user is not None:
+            conciliacao.criado_por = user
+        try:
+            conciliacao.save()
+        except DjangoValidationError as exc:
+            self._raise_drf_validation_error(exc)
+        return conciliacao
+
+    def _raise_drf_validation_error(self, exc):
+        if hasattr(exc, "message_dict"):
+            errors = dict(exc.message_dict)
+            if "__all__" in errors:
+                errors["non_field_errors"] = errors.pop("__all__")
+            raise serializers.ValidationError(errors)
+        if hasattr(exc, "messages"):
+            raise serializers.ValidationError({"non_field_errors": exc.messages})
+        raise serializers.ValidationError({"non_field_errors": [str(exc)]})
+
+
+class ConciliacaoUAListSerializer(serializers.ModelSerializer):
+    unidade_administrativa_codigo = serializers.CharField(
+        source="unidade_administrativa.codigo",
+        read_only=True,
+    )
+    unidade_administrativa_nome = serializers.CharField(
+        source="unidade_administrativa.nome",
+        read_only=True,
+    )
+    unidade_administrativa_sigla = serializers.CharField(
+        source="unidade_administrativa.sigla",
+        read_only=True,
+    )
+    unidade_orcamentaria_codigo = serializers.CharField(
+        source="unidade_administrativa.unidade_orcamentaria.codigo",
+        read_only=True,
+        default="",
+    )
+    unidade_orcamentaria_nome = serializers.CharField(
+        source="unidade_administrativa.unidade_orcamentaria.nome",
+        read_only=True,
+        default="",
+    )
+    status_display = serializers.CharField(
+        source="get_status_display", read_only=True
+    )
+    tipo_display = serializers.CharField(source="get_tipo_display", read_only=True)
+    total_itens = serializers.SerializerMethodField()
+    resumo_situacoes = serializers.SerializerMethodField()
+    ano_vigencia = serializers.SerializerMethodField()
+
+    class Meta:
+        model = ConciliacaoUA
+        fields = [
+            "id",
+            "numero_conciliacao",
+            "unidade_administrativa",
+            "unidade_administrativa_codigo",
+            "unidade_administrativa_nome",
+            "unidade_administrativa_sigla",
+            "unidade_orcamentaria_codigo",
+            "unidade_orcamentaria_nome",
+            "tipo",
+            "tipo_display",
+            "periodo_final",
+            "status",
+            "status_display",
+            "total_itens",
+            "resumo_situacoes",
+            "ano_vigencia",
+            "criado_em",
+            "fechado_em",
+        ]
+        read_only_fields = fields
+
+    def get_total_itens(self, obj):
+        return obj.itens.count()
+
+    def get_resumo_situacoes(self, obj):
+        return _resumo_situacoes(obj)
+
+    def get_ano_vigencia(self, obj):
+        if obj.periodo_final:
+            return obj.periodo_final.year
+        return None
+
+
+class ConciliacaoUADetailSerializer(ConciliacaoUAListSerializer):
+    criado_por_nome = serializers.CharField(
+        source="criado_por.nome", read_only=True, default=""
+    )
+    criado_por_rf = serializers.CharField(
+        source="criado_por.rf", read_only=True, default=""
+    )
+    fechado_por_nome = serializers.CharField(
+        source="fechado_por.nome", read_only=True, default=""
+    )
+    fechado_por_rf = serializers.CharField(
+        source="fechado_por.rf", read_only=True, default=""
+    )
+    esta_aberto = serializers.BooleanField(read_only=True)
+
+    class Meta(ConciliacaoUAListSerializer.Meta):
+        fields = ConciliacaoUAListSerializer.Meta.fields + [
+            "criado_por",
+            "criado_por_nome",
+            "criado_por_rf",
+            "criado_em",
+            "fechado_por",
+            "fechado_por_nome",
+            "fechado_por_rf",
+            "fechado_em",
+            "esta_aberto",
+        ]
+        read_only_fields = fields
+
+
+class BemPatrimonialSimplificadoSerializer(serializers.Serializer):
+    id = serializers.IntegerField(read_only=True)
+    numero_patrimonial = serializers.CharField(read_only=True)
+    nome = serializers.CharField(read_only=True)
+    descricao = serializers.CharField(read_only=True)
+    marca = serializers.CharField(read_only=True)
+    modelo = serializers.CharField(read_only=True)
+    valor_unitario = serializers.DecimalField(
+        max_digits=16, decimal_places=2, read_only=True
+    )
+    status = serializers.CharField(read_only=True)
+    localizacao = serializers.CharField(read_only=True)
+    bloqueado_conciliacao = serializers.BooleanField(read_only=True)
+
+
+class OcorrenciaConciliacaoSerializer(serializers.ModelSerializer):
+    situacao_display = serializers.CharField(
+        source="get_situacao_display", read_only=True
+    )
+    registrado_por_nome = serializers.CharField(
+        source="registrado_por.nome", read_only=True, default=""
+    )
+    registrado_por_rf = serializers.CharField(
+        source="registrado_por.rf", read_only=True, default=""
+    )
+
+    class Meta:
+        model = OcorrenciaConciliacao
+        fields = [
+            "id",
+            "situacao",
+            "situacao_display",
+            "observacao",
+            "divergencia",
+            "registrado_por",
+            "registrado_por_nome",
+            "registrado_por_rf",
+            "registrado_em",
+        ]
+        read_only_fields = fields
+
+
+class ItemConciliacaoListSerializer(serializers.ModelSerializer):
+    bem = BemPatrimonialSimplificadoSerializer(read_only=True)
+    situacao_display = serializers.CharField(
+        source="get_situacao_display", read_only=True
+    )
+    conciliacao_numero = serializers.CharField(
+        source="conciliacao.numero_conciliacao", read_only=True
+    )
+    conciliacao_status = serializers.CharField(
+        source="conciliacao.status", read_only=True
+    )
+    unidade_administrativa = serializers.IntegerField(
+        source="conciliacao.unidade_administrativa_id", read_only=True
+    )
+    unidade_administrativa_sigla = serializers.CharField(
+        source="conciliacao.unidade_administrativa.sigla", read_only=True
+    )
+    atualizado_por_nome = serializers.CharField(
+        source="atualizado_por.nome", read_only=True, default=""
+    )
+    tem_ocorrencia = serializers.BooleanField(read_only=True)
+    permite_registrar_ocorrencia = serializers.BooleanField(read_only=True)
+
+    class Meta:
+        model = ItemConciliacao
+        fields = [
+            "id",
+            "conciliacao",
+            "conciliacao_numero",
+            "conciliacao_status",
+            "unidade_administrativa",
+            "unidade_administrativa_sigla",
+            "bem",
+            "situacao",
+            "situacao_display",
+            "observacao",
+            "divergencia",
+            "tem_ocorrencia",
+            "permite_registrar_ocorrencia",
+            "atualizado_por",
+            "atualizado_por_nome",
+            "atualizado_em",
+        ]
+        read_only_fields = fields
+
+
+class ItemConciliacaoDetailSerializer(ItemConciliacaoListSerializer):
+    ocorrencias = OcorrenciaConciliacaoSerializer(many=True, read_only=True)
+    pode_marcar_como_encontrado = serializers.BooleanField(read_only=True)
+    pode_resolver_situacao = serializers.BooleanField(read_only=True)
+    conciliacao_esta_aberto = serializers.BooleanField(
+        source="conciliacao.esta_aberto", read_only=True
+    )
+
+    class Meta(ItemConciliacaoListSerializer.Meta):
+        fields = ItemConciliacaoListSerializer.Meta.fields + [
+            "pode_marcar_como_encontrado",
+            "pode_resolver_situacao",
+            "conciliacao_esta_aberto",
+            "ocorrencias",
+        ]
+        read_only_fields = fields
+
+
+class RegistrarOcorrenciaSerializer(serializers.Serializer):
+    situacao = serializers.ChoiceField(choices=constants.SITUACOES_ITEM_CONCILIACAO)
+    observacao = serializers.CharField(required=False, allow_blank=True, default="")
+    divergencia = serializers.CharField(required=False, allow_blank=True, default="")
+
+    def validate(self, attrs):
+        situacao = attrs.get("situacao")
+        divergencia = attrs.get("divergencia", "")
+        if situacao == constants.DIVERGENTE and not divergencia:
+            raise serializers.ValidationError(
+                {"divergencia": "Campo divergência é obrigatório quando situação é Divergente."}
+            )
+        return attrs
+
+
+class ConciliacaoHistoricoAcaoSerializer(serializers.Serializer):
+    campo = serializers.CharField()
+    valor_antigo = serializers.CharField(allow_null=True)
+    valor_novo = serializers.CharField(allow_null=True)
+    justificativa = serializers.CharField(allow_null=True, required=False)
+
+
+class ConciliacaoHistoricoGrupoSerializer(serializers.Serializer):
+    alterado_em = serializers.DateTimeField()
+    alterado_por = serializers.IntegerField(allow_null=True)
+    alterado_por_nome = serializers.CharField(allow_null=True)
+    acoes = ConciliacaoHistoricoAcaoSerializer(many=True)
+
+
+class ConciliacaoExportQuerySerializer(serializers.Serializer):
+    formato = serializers.ChoiceField(choices=["pdf"])

--- a/inventario/api_urls.py
+++ b/inventario/api_urls.py
@@ -1,6 +1,11 @@
+from django.urls import path
 from rest_framework.routers import DefaultRouter
 
-from inventario.api_views import ParametroConciliacaoAnualViewSet
+from inventario.api_views import (
+    ConciliacaoUAViewSet,
+    ItemConciliacaoViewSet,
+    ParametroConciliacaoAnualViewSet,
+)
 
 router = DefaultRouter()
 router.register(
@@ -8,5 +13,61 @@ router.register(
     ParametroConciliacaoAnualViewSet,
     basename="parametros-conciliacao-anual",
 )
+router.register(
+    r"inventario/conciliacoes",
+    ConciliacaoUAViewSet,
+    basename="conciliacoes",
+)
 
-urlpatterns = router.urls
+
+item_list = ItemConciliacaoViewSet.as_view({
+    "get": "list",
+})
+item_detail = ItemConciliacaoViewSet.as_view({
+    "get": "retrieve",
+})
+item_situacoes = ItemConciliacaoViewSet.as_view({
+    "get": "situacoes_disponiveis",
+})
+item_registrar_ocorrencia = ItemConciliacaoViewSet.as_view({
+    "post": "registrar_ocorrencia",
+})
+item_excluir_ocorrencia = ItemConciliacaoViewSet.as_view({
+    "post": "excluir_ocorrencia",
+})
+item_historico = ItemConciliacaoViewSet.as_view({
+    "get": "historico",
+})
+
+urlpatterns = router.urls + [
+    path(
+        "inventario/conciliacoes/<int:conciliacao_pk>/itens/",
+        item_list,
+        name="itens-conciliacao-list",
+    ),
+    path(
+        "inventario/conciliacoes/<int:conciliacao_pk>/itens/<int:item_id>/",
+        item_detail,
+        name="itens-conciliacao-detail",
+    ),
+    path(
+        "inventario/conciliacoes/<int:conciliacao_pk>/itens/<int:item_id>/situacoes-disponiveis/",
+        item_situacoes,
+        name="itens-conciliacao-situacoes-disponiveis",
+    ),
+    path(
+        "inventario/conciliacoes/<int:conciliacao_pk>/itens/<int:item_id>/ocorrencias/",
+        item_registrar_ocorrencia,
+        name="itens-conciliacao-registrar-ocorrencia",
+    ),
+    path(
+        "inventario/conciliacoes/<int:conciliacao_pk>/itens/<int:item_id>/ocorrencias/remover/",
+        item_excluir_ocorrencia,
+        name="itens-conciliacao-excluir-ocorrencia",
+    ),
+    path(
+        "inventario/conciliacoes/<int:conciliacao_pk>/itens/<int:item_id>/historico/",
+        item_historico,
+        name="itens-conciliacao-historico",
+    ),
+]

--- a/inventario/api_views.py
+++ b/inventario/api_views.py
@@ -1,17 +1,63 @@
+from collections import defaultdict
+
+from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError as DjangoValidationError
+from django.db import transaction
 from django.db.models.deletion import ProtectedError
+from django.http import HttpResponse
 
 from django_filters.rest_framework import DjangoFilterBackend
-from rest_framework import viewsets
-from rest_framework.exceptions import NotFound, ValidationError as DRFValidationError
+import django_filters
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import (
+    OpenApiParameter,
+    OpenApiResponse,
+    extend_schema,
+    extend_schema_view,
+)
+from rest_framework import mixins, status, viewsets
+from rest_framework.decorators import action
+from rest_framework.exceptions import (
+    NotFound,
+    ValidationError as DRFValidationError,
+)
 from rest_framework.filters import OrderingFilter, SearchFilter
 from rest_framework.permissions import BasePermission
+from rest_framework.response import Response
+
+from dados_comuns.context import audit_as
+from dados_comuns.escopo import filtrar_queryset_por_escopo
+from dados_comuns.models import HistoricoGeral
 
 from inventario.api_serializers import (
+    ConciliacaoExportQuerySerializer,
+    ConciliacaoHistoricoGrupoSerializer,
+    ConciliacaoUACreateSerializer,
+    ConciliacaoUADetailSerializer,
+    ConciliacaoUAListSerializer,
+    ItemConciliacaoDetailSerializer,
+    ItemConciliacaoListSerializer,
     ParametroConciliacaoAnualDetailSerializer,
     ParametroConciliacaoAnualListSerializer,
+    RegistrarOcorrenciaSerializer,
 )
-from inventario.models import ParametroConciliacaoAnual
+from inventario.conciliacao import excluir_ocorrencia, registrar_ocorrencia
+from inventario import constants
+from inventario.models import (
+    ConciliacaoUA,
+    ItemConciliacao,
+    ParametroConciliacaoAnual,
+)
+from inventario.permissions import ConciliacaoUAPermission, ItemConciliacaoPermission
+from inventario.relatorio_conciliacao_pdf import gerar_pdf_conciliacao
+from inventario.utils_conciliacao.conciliacao_automatica import (
+    processar_conciliacao_anual_automatica,
+)
+from inventario.utils_conciliacao.conciliacao_utils import (
+    criar_itens_conciliacao,
+    finalizar_conciliacao,
+    remover_itens_baixados_invalidos,
+)
 
 
 class ParametroConciliacaoAnualPermission(BasePermission):
@@ -52,6 +98,36 @@ class ParametroConciliacaoAnualPermission(BasePermission):
         return True
 
 
+@extend_schema_view(
+    list=extend_schema(
+        tags=["Inventário"],
+        summary="Listar parâmetros de conciliação anual",
+        description=(
+            "Lista paginada com busca, filtros e ordenação. "
+            "Acesso restrito a superusuário e gestor de patrimônio."
+        ),
+    ),
+    retrieve=extend_schema(
+        tags=["Inventário"],
+        summary="Detalhar parâmetro de conciliação anual",
+    ),
+    create=extend_schema(
+        tags=["Inventário"],
+        summary="Criar parâmetro de conciliação anual",
+    ),
+    update=extend_schema(
+        tags=["Inventário"],
+        summary="Atualizar parâmetro de conciliação anual",
+    ),
+    partial_update=extend_schema(
+        tags=["Inventário"],
+        summary="Atualizar parcialmente parâmetro de conciliação anual",
+    ),
+    destroy=extend_schema(
+        tags=["Inventário"],
+        summary="Excluir parâmetro de conciliação anual",
+    ),
+)
 class ParametroConciliacaoAnualViewSet(viewsets.ModelViewSet):
     permission_classes = [ParametroConciliacaoAnualPermission]
 
@@ -175,3 +251,864 @@ class ParametroConciliacaoAnualViewSet(viewsets.ModelViewSet):
                     )
                 }
             )
+
+
+CONCILIACAO_ID_PATH_PARAM = OpenApiParameter(
+    name="id",
+    required=True,
+    type=OpenApiTypes.INT,
+    location=OpenApiParameter.PATH,
+    description="Identificador numérico único da conciliação.",
+)
+
+CONCILIACAO_NESTED_ID_PATH_PARAM = OpenApiParameter(
+    name="conciliacao_pk",
+    required=True,
+    type=OpenApiTypes.INT,
+    location=OpenApiParameter.PATH,
+    description="Identificador numérico único da conciliação pai.",
+)
+
+ITEM_CONCILIACAO_ID_PATH_PARAM = OpenApiParameter(
+    name="item_id",
+    required=True,
+    type=OpenApiTypes.INT,
+    location=OpenApiParameter.PATH,
+    description="Identificador numérico único do item de conciliação.",
+)
+
+CONCILIACAO_LIST_QUERY_PARAMETERS = [
+    OpenApiParameter(
+        name="search",
+        type=OpenApiTypes.STR,
+        location=OpenApiParameter.QUERY,
+        description=(
+            "Busca em: número da conciliação, código/nome/sigla da Unidade "
+            "Administrativa."
+        ),
+    ),
+    OpenApiParameter(
+        name="ordering",
+        type=OpenApiTypes.STR,
+        location=OpenApiParameter.QUERY,
+        description=(
+            "Ordenação por: id, criado_em, periodo_final, status, tipo, "
+            "unidade_administrativa__codigo, unidade_administrativa__sigla, "
+            "unidade_administrativa__nome. Use '-' para descendente."
+        ),
+    ),
+    OpenApiParameter(
+        name="status",
+        type=OpenApiTypes.STR,
+        location=OpenApiParameter.QUERY,
+        enum=[c[0] for c in constants.STATUS_CONCILIACAO],
+        description=(
+            "Filtra por status da conciliação. Aceita um valor ou vários "
+            "separados por vírgula."
+        ),
+    ),
+    OpenApiParameter(
+        name="tipo",
+        type=OpenApiTypes.STR,
+        location=OpenApiParameter.QUERY,
+        enum=[c[0] for c in constants.TIPOS_CONCILIACAO],
+        description="Filtra por tipo da conciliação.",
+    ),
+    OpenApiParameter(
+        name="unidade_administrativa",
+        type=OpenApiTypes.INT,
+        location=OpenApiParameter.QUERY,
+        description="Filtra por Unidade Administrativa (ID).",
+    ),
+    OpenApiParameter(
+        name="ano_vigencia",
+        type=OpenApiTypes.INT,
+        location=OpenApiParameter.QUERY,
+        description="Filtra pelo ano de vigência (ano do período final).",
+    ),
+    OpenApiParameter(
+        name="periodo_final__gte",
+        type=OpenApiTypes.DATE,
+        location=OpenApiParameter.QUERY,
+        description="Filtra conciliações com período final a partir da data (YYYY-MM-DD).",
+    ),
+    OpenApiParameter(
+        name="periodo_final__lte",
+        type=OpenApiTypes.DATE,
+        location=OpenApiParameter.QUERY,
+        description="Filtra conciliações com período final até a data (YYYY-MM-DD).",
+    ),
+    OpenApiParameter(
+        name="criado_em__gte",
+        type=OpenApiTypes.DATETIME,
+        location=OpenApiParameter.QUERY,
+        description="Filtra conciliações criadas a partir da data/hora informada.",
+    ),
+    OpenApiParameter(
+        name="criado_em__lte",
+        type=OpenApiTypes.DATETIME,
+        location=OpenApiParameter.QUERY,
+        description="Filtra conciliações criadas até a data/hora informada.",
+    ),
+    OpenApiParameter(
+        name="page",
+        type=OpenApiTypes.INT,
+        location=OpenApiParameter.QUERY,
+        description="Número da página.",
+    ),
+    OpenApiParameter(
+        name="page_size",
+        type=OpenApiTypes.INT,
+        location=OpenApiParameter.QUERY,
+        description="Quantidade de itens por página (máximo 100).",
+    ),
+]
+
+ITEM_LIST_QUERY_PARAMETERS = [
+    OpenApiParameter(
+        name="search",
+        type=OpenApiTypes.STR,
+        location=OpenApiParameter.QUERY,
+        description=(
+            "Busca em: número patrimonial e nome do bem."
+        ),
+    ),
+    OpenApiParameter(
+        name="ordering",
+        type=OpenApiTypes.STR,
+        location=OpenApiParameter.QUERY,
+        description=(
+            "Ordenação por: id, atualizado_em, situacao, "
+            "bem__numero_patrimonial, bem__nome. Use '-' para descendente."
+        ),
+    ),
+    OpenApiParameter(
+        name="situacao",
+        type=OpenApiTypes.STR,
+        location=OpenApiParameter.QUERY,
+        enum=[c[0] for c in constants.SITUACOES_ITEM_CONCILIACAO],
+        description="Filtra por situação do item.",
+    ),
+    OpenApiParameter(
+        name="tem_ocorrencia",
+        type=OpenApiTypes.BOOL,
+        location=OpenApiParameter.QUERY,
+        description="Filtra itens com (true) ou sem (false) ocorrência registrada.",
+    ),
+    OpenApiParameter(
+        name="page",
+        type=OpenApiTypes.INT,
+        location=OpenApiParameter.QUERY,
+        description="Número da página.",
+    ),
+    OpenApiParameter(
+        name="page_size",
+        type=OpenApiTypes.INT,
+        location=OpenApiParameter.QUERY,
+        description="Quantidade de itens por página (máximo 100).",
+    ),
+]
+
+
+def _filtrar_ano_vigencia(queryset, value):
+    if not value:
+        return queryset
+    try:
+        ano = int(value)
+    except (TypeError, ValueError):
+        return queryset
+    return queryset.filter(periodo_final__year=ano)
+
+
+class ConciliacaoUAFilter(django_filters.FilterSet):
+    """
+    FilterSet customizado para ConciliacaoUA.
+
+    Suporta:
+    - status: filtro exato ou lista (via valores separados por vírgula)
+    - tipo: filtro exato
+    - unidade_administrativa: filtro por ID
+    - periodo_final__gte / periodo_final__lte: range de período final
+    - criado_em__gte / criado_em__lte: range de data de criação
+    """
+
+    status = django_filters.CharFilter(method="filter_status")
+    periodo_final__gte = django_filters.DateFilter(
+        field_name="periodo_final", lookup_expr="gte"
+    )
+    periodo_final__lte = django_filters.DateFilter(
+        field_name="periodo_final", lookup_expr="lte"
+    )
+    criado_em__gte = django_filters.DateTimeFilter(
+        field_name="criado_em", lookup_expr="gte"
+    )
+    criado_em__lte = django_filters.DateTimeFilter(
+        field_name="criado_em", lookup_expr="lte"
+    )
+
+    class Meta:
+        model = ConciliacaoUA
+        fields = ["tipo", "unidade_administrativa"]
+
+    def filter_status(self, queryset, name, value):
+        if not value:
+            return queryset
+        valores = [v.strip() for v in value.split(",") if v.strip()]
+        if len(valores) == 1:
+            return queryset.filter(status=valores[0])
+        return queryset.filter(status__in=valores)
+
+
+class AuditHistoryConciliacaoMixin:
+    audit_model = None
+    historico_grupo_serializer_class = None
+
+    def _get_audit_content_type(self):
+        return ContentType.objects.get_for_model(self.audit_model)
+
+    def _registrar_historico(
+        self, obj, campo, valor_antigo, valor_novo, usuario, justificativa=""
+    ):
+        ct = self._get_audit_content_type()
+        HistoricoGeral.objects.create(
+            content_type=ct,
+            object_id=str(obj.pk),
+            campo=campo,
+            valor_antigo=str(valor_antigo) if valor_antigo is not None else "",
+            valor_novo=str(valor_novo) if valor_novo is not None else "",
+            alterado_por=usuario,
+            justificativa=justificativa,
+        )
+
+    def _build_historico_response(self, instance):
+        historicos = (
+            HistoricoGeral.objects.filter(
+                content_type=self._get_audit_content_type(),
+                object_id=str(instance.pk),
+            )
+            .select_related("alterado_por")
+            .order_by("-alterado_em")
+        )
+
+        agrupado = defaultdict(list)
+        for item in historicos:
+            chave = (item.alterado_em.replace(microsecond=0), item.alterado_por_id)
+            agrupado[chave].append(item)
+
+        resposta = []
+        for (alterado_em, alterado_por_id), itens in agrupado.items():
+            resposta.append(
+                {
+                    "alterado_em": alterado_em,
+                    "alterado_por": alterado_por_id,
+                    "alterado_por_nome": (
+                        itens[0].alterado_por.nome if itens[0].alterado_por else None
+                    ),
+                    "acoes": [
+                        {
+                            "campo": i.campo,
+                            "valor_antigo": i.valor_antigo,
+                            "valor_novo": i.valor_novo,
+                            "justificativa": i.justificativa,
+                        }
+                        for i in itens
+                    ],
+                }
+            )
+
+        resposta_ordenada = sorted(
+            resposta,
+            key=lambda row: row["alterado_em"],
+            reverse=True,
+        )
+
+        serializer = self.historico_grupo_serializer_class(
+            resposta_ordenada,
+            many=True,
+        )
+        return Response(serializer.data)
+
+
+@extend_schema_view(
+    list=extend_schema(
+        tags=["Inventário"],
+        summary="Listar conciliações",
+        description=(
+            "Lista paginada com busca, filtros e ordenação. O escopo é "
+            "automaticamente restrito à Unidade Administrativa do usuário "
+            "(operador/gestor com UA) ou à Unidade Orçamentária do gestor."
+        ),
+        parameters=CONCILIACAO_LIST_QUERY_PARAMETERS,
+        responses={
+            200: OpenApiResponse(description="Lista retornada com sucesso."),
+            401: OpenApiResponse(description="Usuário não autenticado."),
+            403: OpenApiResponse(
+                description="Usuário sem permissão para acessar o recurso."
+            ),
+        },
+    ),
+    retrieve=extend_schema(
+        tags=["Inventário"],
+        summary="Detalhar conciliação",
+        parameters=[CONCILIACAO_ID_PATH_PARAM],
+        responses={
+            200: OpenApiResponse(description="Detalhe retornado com sucesso."),
+            401: OpenApiResponse(description="Usuário não autenticado."),
+            403: OpenApiResponse(description="Usuário sem permissão."),
+            404: OpenApiResponse(description="Conciliação não encontrada."),
+        },
+    ),
+    create=extend_schema(
+        tags=["Inventário"],
+        summary="Criar conciliação",
+        description=(
+            "Cria uma conciliação eventual para a Unidade Administrativa informada. "
+            "Os itens são gerados automaticamente a partir dos bens da UA. "
+            "Conciliações anuais são criadas automaticamente pelo sistema dentro "
+            "do período de vigência definido nos parâmetros anuais."
+        ),
+        responses={
+            201: OpenApiResponse(description="Conciliação criada com sucesso."),
+            400: OpenApiResponse(description="Dados inválidos."),
+            401: OpenApiResponse(description="Usuário não autenticado."),
+            403: OpenApiResponse(description="Usuário sem permissão."),
+        },
+    ),
+)
+class ConciliacaoUAViewSet(
+    AuditHistoryConciliacaoMixin,
+    mixins.CreateModelMixin,
+    mixins.RetrieveModelMixin,
+    mixins.ListModelMixin,
+    viewsets.GenericViewSet,
+):
+    permission_classes = [ConciliacaoUAPermission]
+    audit_model = ConciliacaoUA
+    historico_grupo_serializer_class = ConciliacaoHistoricoGrupoSerializer
+
+    filter_backends = [DjangoFilterBackend, SearchFilter, OrderingFilter]
+    filterset_class = ConciliacaoUAFilter
+    search_fields = [
+        "numero_conciliacao",
+        "unidade_administrativa__nome",
+        "unidade_administrativa__codigo",
+        "unidade_administrativa__sigla",
+    ]
+    ordering_fields = [
+        "id",
+        "criado_em",
+        "periodo_final",
+        "status",
+        "tipo",
+        "unidade_administrativa__codigo",
+        "unidade_administrativa__sigla",
+        "unidade_administrativa__nome",
+    ]
+    ordering = ["-criado_em", "unidade_administrativa__sigla"]
+
+    def get_serializer_class(self):
+        if self.action == "create":
+            return ConciliacaoUACreateSerializer
+        if self.action == "retrieve":
+            return ConciliacaoUADetailSerializer
+        return ConciliacaoUAListSerializer
+
+    def get_queryset(self):
+        qs = ConciliacaoUA.objects.select_related(
+            "unidade_administrativa",
+            "unidade_administrativa__unidade_orcamentaria",
+            "criado_por",
+            "fechado_por",
+        )
+        return filtrar_queryset_por_escopo(
+            usuario=self.request.user,
+            queryset=qs,
+            campo_ua="unidade_administrativa",
+        )
+
+    def filter_queryset(self, queryset):
+        queryset = super().filter_queryset(queryset)
+        ano = self.request.query_params.get("ano_vigencia")
+        if ano:
+            queryset = _filtrar_ano_vigencia(queryset, ano)
+        return queryset
+
+    def list(self, request, *args, **kwargs):
+        try:
+            processar_conciliacao_anual_automatica(request.user)
+        except Exception:
+            pass
+        return super().list(request, *args, **kwargs)
+
+    def create(self, request, *args, **kwargs):
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        with transaction.atomic():
+            with audit_as(request.user):
+                conciliacao = serializer.save()
+            self._registrar_historico(
+                conciliacao,
+                campo="acao",
+                valor_antigo="",
+                valor_novo="criado",
+                usuario=request.user,
+                justificativa="Conciliação criada via API",
+            )
+            criar_itens_conciliacao(conciliacao)
+
+        detail_serializer = ConciliacaoUADetailSerializer(
+            conciliacao, context={"request": request}
+        )
+        return Response(detail_serializer.data, status=status.HTTP_201_CREATED)
+
+    def retrieve(self, request, *args, **kwargs):
+        conciliacao = self.get_object()
+        if conciliacao.esta_aberto:
+            remover_itens_baixados_invalidos(conciliacao)
+        serializer = self.get_serializer(conciliacao)
+        return Response(serializer.data)
+
+    @extend_schema(
+        tags=["Inventário"],
+        summary="Histórico da conciliação",
+        description="Retorna o histórico de alterações da conciliação informada.",
+        parameters=[CONCILIACAO_ID_PATH_PARAM],
+        responses={
+            200: OpenApiResponse(
+                response=ConciliacaoHistoricoGrupoSerializer(many=True),
+                description="Histórico retornado com sucesso.",
+            ),
+            401: OpenApiResponse(description="Usuário não autenticado."),
+            403: OpenApiResponse(description="Usuário sem permissão."),
+            404: OpenApiResponse(description="Conciliação não encontrada."),
+        },
+    )
+    @action(
+        detail=True,
+        methods=["get"],
+        url_path="historico",
+        filter_backends=[],
+        pagination_class=None,
+    )
+    def historico(self, request, pk=None):
+        return self._build_historico_response(self.get_object())
+
+    @extend_schema(
+        tags=["Inventário"],
+        summary="Exportar conciliação",
+        description="Exporta a conciliação em PDF no padrão do relatório de campo.",
+        parameters=[
+            CONCILIACAO_ID_PATH_PARAM,
+            OpenApiParameter(
+                name="formato",
+                required=False,
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.QUERY,
+                enum=["pdf"],
+                description="Formato de exportação (padrão: pdf).",
+            ),
+        ],
+        responses={
+            200: OpenApiResponse(description="Arquivo PDF gerado com sucesso."),
+            401: OpenApiResponse(description="Usuário não autenticado."),
+            403: OpenApiResponse(description="Usuário sem permissão."),
+            404: OpenApiResponse(description="Conciliação não encontrada."),
+        },
+    )
+    @action(detail=True, methods=["get"], url_path="exportar")
+    def exportar(self, request, pk=None):
+        serializer = ConciliacaoExportQuerySerializer(
+            data=request.query_params or {"formato": "pdf"}
+        )
+        serializer.is_valid(raise_exception=True)
+
+        conciliacao = self.get_object()
+        pdf_buffer = gerar_pdf_conciliacao(
+            conciliacao, usuario_gerador=request.user
+        )
+
+        numero = conciliacao.numero_conciliacao or str(conciliacao.pk)
+        ua_codigo = (
+            conciliacao.unidade_administrativa.codigo
+            if conciliacao.unidade_administrativa
+            else ""
+        )
+        ano = (
+            conciliacao.periodo_final.year if conciliacao.periodo_final else ""
+        )
+        partes = ["CONCILIACAO", numero]
+        if ano:
+            partes.append(str(ano))
+        if ua_codigo:
+            partes.append(f"UA{ua_codigo}")
+        filename = "_".join(partes) + ".pdf"
+
+        try:
+            pdf_buffer.seek(0)
+        except Exception:
+            pass
+
+        response = HttpResponse(pdf_buffer, content_type="application/pdf")
+        response["Content-Disposition"] = f'attachment; filename="{filename}"'
+        return response
+
+    @extend_schema(
+        tags=["Inventário"],
+        summary="Finalizar conciliação",
+        description=(
+            "Finaliza a conciliação em aberto. Aplica as mesmas regras do admin: "
+            "bloqueia se já está fechada e dispara a confirmação automática de "
+            "baixas físicas pendentes."
+        ),
+        parameters=[CONCILIACAO_ID_PATH_PARAM],
+        responses={
+            200: OpenApiResponse(description="Conciliação finalizada com sucesso."),
+            400: OpenApiResponse(description="Conciliação já finalizada ou inválida."),
+            401: OpenApiResponse(description="Usuário não autenticado."),
+            403: OpenApiResponse(description="Usuário sem permissão."),
+            404: OpenApiResponse(description="Conciliação não encontrada."),
+        },
+    )
+    @action(detail=True, methods=["post"], url_path="finalizar")
+    def finalizar(self, request, pk=None):
+        conciliacao = self.get_object()
+
+        if not conciliacao.esta_aberto:
+            raise DRFValidationError(
+                {"detail": "Conciliação já está finalizada."}
+            )
+
+        with transaction.atomic():
+            with audit_as(request.user):
+                finalizar_conciliacao(conciliacao, request.user)
+            self._registrar_historico(
+                conciliacao,
+                campo="status",
+                valor_antigo=constants.CONCILIACAO_EM_ABERTO,
+                valor_novo=conciliacao.get_status_display(),
+                usuario=request.user,
+                justificativa="Conciliação finalizada via API",
+            )
+            self._registrar_historico(
+                conciliacao,
+                campo="fechado_por",
+                valor_antigo="",
+                valor_novo=str(request.user),
+                usuario=request.user,
+                justificativa="Conciliação finalizada via API",
+            )
+
+        conciliacao.refresh_from_db()
+        detail_serializer = ConciliacaoUADetailSerializer(
+            conciliacao, context={"request": request}
+        )
+        return Response(detail_serializer.data, status=status.HTTP_200_OK)
+
+
+@extend_schema_view(
+    list=extend_schema(
+        tags=["Inventário"],
+        summary="Listar itens de conciliação",
+        description=(
+            "Lista paginada dos itens de uma conciliação específica, com busca, "
+            "filtros e ordenação. O escopo é automaticamente restrito à "
+            "Unidade Administrativa do usuário ou à Unidade Orçamentária do gestor."
+        ),
+        parameters=[CONCILIACAO_NESTED_ID_PATH_PARAM, *ITEM_LIST_QUERY_PARAMETERS],
+        responses={
+            200: OpenApiResponse(description="Lista retornada com sucesso."),
+            401: OpenApiResponse(description="Usuário não autenticado."),
+            403: OpenApiResponse(description="Usuário sem permissão."),
+            404: OpenApiResponse(description="Conciliação não encontrada."),
+        },
+    ),
+    retrieve=extend_schema(
+        tags=["Inventário"],
+        summary="Detalhar item de conciliação",
+        parameters=[CONCILIACAO_NESTED_ID_PATH_PARAM, ITEM_CONCILIACAO_ID_PATH_PARAM],
+        responses={
+            200: OpenApiResponse(description="Detalhe retornado com sucesso."),
+            401: OpenApiResponse(description="Usuário não autenticado."),
+            403: OpenApiResponse(description="Usuário sem permissão."),
+            404: OpenApiResponse(description="Item não encontrado."),
+        },
+    ),
+)
+class ItemConciliacaoViewSet(
+    AuditHistoryConciliacaoMixin,
+    mixins.RetrieveModelMixin,
+    mixins.ListModelMixin,
+    viewsets.GenericViewSet,
+):
+    permission_classes = [ItemConciliacaoPermission]
+    audit_model = ItemConciliacao
+    historico_grupo_serializer_class = ConciliacaoHistoricoGrupoSerializer
+    lookup_url_kwarg = "item_id"
+
+    filter_backends = [DjangoFilterBackend, SearchFilter, OrderingFilter]
+    filterset_fields = ["situacao"]
+    search_fields = [
+        "bem__numero_patrimonial",
+        "bem__nome",
+    ]
+    ordering_fields = [
+        "id",
+        "atualizado_em",
+        "situacao",
+        "bem__numero_patrimonial",
+        "bem__nome",
+    ]
+    ordering = ["bem__numero_patrimonial"]
+
+    def get_serializer_class(self):
+        if self.action == "retrieve":
+            return ItemConciliacaoDetailSerializer
+        return ItemConciliacaoListSerializer
+
+    def get_queryset(self):
+        qs = ItemConciliacao.objects.select_related(
+            "bem",
+            "bem__unidade_administrativa",
+            "conciliacao",
+            "conciliacao__unidade_administrativa",
+            "conciliacao__unidade_administrativa__unidade_orcamentaria",
+            "atualizado_por",
+        ).prefetch_related("ocorrencias__registrado_por")
+        qs = filtrar_queryset_por_escopo(
+            usuario=self.request.user,
+            queryset=qs,
+            campo_ua="conciliacao__unidade_administrativa",
+        )
+
+        conciliacao_pk = self.kwargs.get("conciliacao_pk")
+        if conciliacao_pk:
+            qs = qs.filter(conciliacao_id=conciliacao_pk)
+        return qs
+
+    def _get_conciliacao(self):
+        conciliacao_pk = self.kwargs.get("conciliacao_pk")
+        if not conciliacao_pk:
+            return None
+        qs = filtrar_queryset_por_escopo(
+            usuario=self.request.user,
+            queryset=ConciliacaoUA.objects.all(),
+            campo_ua="unidade_administrativa",
+        )
+        conciliacao = qs.filter(pk=conciliacao_pk).first()
+        if not conciliacao:
+            raise NotFound("Conciliação não encontrada.")
+        return conciliacao
+
+    def list(self, request, *args, **kwargs):
+        self._get_conciliacao()
+        return super().list(request, *args, **kwargs)
+
+    def retrieve(self, request, *args, **kwargs):
+        self._get_conciliacao()
+        return super().retrieve(request, *args, **kwargs)
+
+    def get_object(self):
+        item = super().get_object()
+        conciliacao_pk = self.kwargs.get("conciliacao_pk")
+        if conciliacao_pk and item.conciliacao_id != int(conciliacao_pk):
+            raise NotFound("Item não pertence à conciliação informada.")
+        return item
+
+    def filter_queryset(self, queryset):
+        queryset = super().filter_queryset(queryset)
+        tem_ocorrencia = self.request.query_params.get("tem_ocorrencia")
+        if tem_ocorrencia in ("true", "True", "1"):
+            queryset = queryset.filter(ocorrencias__isnull=False).distinct()
+        elif tem_ocorrencia in ("false", "False", "0"):
+            queryset = queryset.filter(ocorrencias__isnull=True)
+        return queryset
+
+    @extend_schema(
+        tags=["Inventário"],
+        summary="Situações disponíveis para ocorrência",
+        description=(
+            "Retorna as situações que podem ser usadas ao registrar/editar a "
+            "ocorrência do item, respeitando as regras do admin (ex.: bloqueia "
+            "Baixa Física e limites de resolução)."
+        ),
+        parameters=[CONCILIACAO_NESTED_ID_PATH_PARAM, ITEM_CONCILIACAO_ID_PATH_PARAM],
+        responses={
+            200: OpenApiResponse(description="Lista de situações disponíveis."),
+            401: OpenApiResponse(description="Usuário não autenticado."),
+            403: OpenApiResponse(description="Usuário sem permissão."),
+            404: OpenApiResponse(description="Item não encontrado."),
+        },
+    )
+    def situacoes_disponiveis(self, request, conciliacao_pk=None, item_id=None):
+        self._get_conciliacao()
+        item = self.get_object()
+        situacoes = self._get_situacoes_disponiveis_para_item(item)
+        return Response(
+            [{"value": v, "label": l} for v, l in situacoes]
+        )
+
+    def _get_situacoes_disponiveis_para_item(self, item):
+        situacoes = list(constants.SITUACOES_ITEM_CONCILIACAO)
+        situacoes = [s for s in situacoes if s[0] != constants.BAIXA_FISICA]
+
+        if not item.pode_resolver_situacao:
+            situacoes = [
+                s for s in situacoes if s[0] != constants.ENCONTRADO_SEM_DIVERGENCIA
+            ]
+
+        if not item.pode_marcar_como_encontrado:
+            situacoes = [s for s in situacoes if s[0] != constants.ENCONTRADO]
+
+        return situacoes
+
+    @extend_schema(
+        tags=["Inventário"],
+        summary="Registrar ocorrência do item",
+        description=(
+            "Registra ou atualiza a ocorrência do item de conciliação. "
+            "Replica as regras do admin: bloqueia se a conciliação está fechada, "
+            "se o item está em Baixa Física e exige divergência quando a "
+            "situação for 'Divergente'."
+        ),
+        parameters=[CONCILIACAO_NESTED_ID_PATH_PARAM, ITEM_CONCILIACAO_ID_PATH_PARAM],
+        request=RegistrarOcorrenciaSerializer,
+        responses={
+            200: OpenApiResponse(description="Ocorrência registrada com sucesso."),
+            400: OpenApiResponse(description="Dados inválidos."),
+            401: OpenApiResponse(description="Usuário não autenticado."),
+            403: OpenApiResponse(description="Usuário sem permissão."),
+            404: OpenApiResponse(description="Item não encontrado."),
+        },
+    )
+    def registrar_ocorrencia(self, request, conciliacao_pk=None, item_id=None):
+        self._get_conciliacao()
+        item = self.get_object()
+        self._validar_item_para_ocorrencia(item)
+
+        serializer = RegistrarOcorrenciaSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        situacao_anterior = item.get_situacao_display()
+
+        try:
+            registrar_ocorrencia(
+                item=item,
+                situacao=serializer.validated_data["situacao"],
+                observacao=serializer.validated_data.get("observacao", ""),
+                divergencia=serializer.validated_data.get("divergencia", ""),
+                usuario=request.user,
+            )
+        except DjangoValidationError as exc:
+            self._raise_drf_validation_error(exc)
+
+        self._registrar_historico(
+            item,
+            campo="situacao",
+            valor_antigo=situacao_anterior,
+            valor_novo=dict(constants.SITUACOES_ITEM_CONCILIACAO).get(
+                serializer.validated_data["situacao"],
+                serializer.validated_data["situacao"],
+            ),
+            usuario=request.user,
+            justificativa="Ocorrência registrada via API",
+        )
+
+        item.refresh_from_db()
+        detail_serializer = ItemConciliacaoDetailSerializer(
+            item, context={"request": request}
+        )
+        return Response(detail_serializer.data, status=status.HTTP_200_OK)
+
+    @extend_schema(
+        tags=["Inventário"],
+        summary="Excluir ocorrência do item",
+        description=(
+            "Exclui a última ocorrência do item e restaura a situação anterior "
+            "conforme regras do admin. Bloqueia se a conciliação está fechada "
+            "ou se o item não tem ocorrência."
+        ),
+        parameters=[CONCILIACAO_NESTED_ID_PATH_PARAM, ITEM_CONCILIACAO_ID_PATH_PARAM],
+        request=None,
+        responses={
+            200: OpenApiResponse(description="Ocorrência excluída com sucesso."),
+            400: OpenApiResponse(description="Item sem ocorrência ou conciliação fechada."),
+            401: OpenApiResponse(description="Usuário não autenticado."),
+            403: OpenApiResponse(description="Usuário sem permissão."),
+            404: OpenApiResponse(description="Item não encontrado."),
+        },
+    )
+    def excluir_ocorrencia(self, request, conciliacao_pk=None, item_id=None):
+        self._get_conciliacao()
+        item = self.get_object()
+
+        if not item.conciliacao.esta_aberto:
+            raise DRFValidationError(
+                {"detail": "Conciliação fechada não permite edições."}
+            )
+
+        situacao_anterior = item.get_situacao_display()
+
+        try:
+            excluir_ocorrencia(item=item, usuario=request.user)
+        except DjangoValidationError as exc:
+            self._raise_drf_validation_error(exc)
+
+        self._registrar_historico(
+            item,
+            campo="situacao",
+            valor_antigo=situacao_anterior,
+            valor_novo=item.get_situacao_display(),
+            usuario=request.user,
+            justificativa="Ocorrência excluída via API",
+        )
+
+        item.refresh_from_db()
+        detail_serializer = ItemConciliacaoDetailSerializer(
+            item, context={"request": request}
+        )
+        return Response(detail_serializer.data, status=status.HTTP_200_OK)
+
+    @extend_schema(
+        tags=["Inventário"],
+        summary="Histórico do item de conciliação",
+        description="Retorna o histórico de alterações do item de conciliação.",
+        parameters=[CONCILIACAO_NESTED_ID_PATH_PARAM, ITEM_CONCILIACAO_ID_PATH_PARAM],
+        responses={
+            200: OpenApiResponse(
+                response=ConciliacaoHistoricoGrupoSerializer(many=True),
+                description="Histórico retornado com sucesso.",
+            ),
+            401: OpenApiResponse(description="Usuário não autenticado."),
+            403: OpenApiResponse(description="Usuário sem permissão."),
+            404: OpenApiResponse(description="Item não encontrado."),
+        },
+    )
+    def historico(self, request, conciliacao_pk=None, item_id=None):
+        self._get_conciliacao()
+        return self._build_historico_response(self.get_object())
+
+    def _validar_item_para_ocorrencia(self, item):
+        if not item.conciliacao.esta_aberto:
+            raise DRFValidationError(
+                {"detail": "Conciliação fechada não permite edições."}
+            )
+        if not item.permite_registrar_ocorrencia:
+            raise DRFValidationError(
+                {
+                    "detail": (
+                        "Bem com status 'Baixa Física' não pode ter ocorrência "
+                        "registrada. Este status é definitivo."
+                    )
+                }
+            )
+
+    def _raise_drf_validation_error(self, exc):
+        if hasattr(exc, "message_dict"):
+            errors = dict(exc.message_dict)
+            if "__all__" in errors:
+                errors["non_field_errors"] = errors.pop("__all__")
+            raise DRFValidationError(errors)
+        if hasattr(exc, "messages"):
+            raise DRFValidationError({"non_field_errors": exc.messages})
+        raise DRFValidationError({"non_field_errors": [str(exc)]})

--- a/inventario/permissions.py
+++ b/inventario/permissions.py
@@ -1,0 +1,89 @@
+from rest_framework.permissions import BasePermission
+
+
+def _pode_acessar_modulo_inventario(user):
+    if not user or not user.is_authenticated:
+        return False
+    if getattr(user, "is_superuser", False):
+        return True
+    return bool(
+        getattr(user, "is_gestor_patrimonio", False)
+        or getattr(user, "is_operador_inventario", False)
+    )
+
+
+class ConciliacaoUAPermission(BasePermission):
+    """
+    Regras de acesso para API de Conciliação (ConciliacaoUA):
+
+    - Acesso ao módulo: gestor de patrimônio, operador de inventário ou superuser.
+    - Listagem, detalhe, histórico, exportação, criação e finalização:
+      qualquer perfil do módulo (espelha o admin, onde o operador possui as
+      permissões add_conciliacaoua e change_conciliacaoua). O escopo de UA/UO
+      é validado no queryset e no serializer.
+    - Atualização/exclusão: bloqueadas (espelha o admin, que não permite
+      editar/excluir conciliações).
+    """
+
+    def has_permission(self, request, view):
+        if not _pode_acessar_modulo_inventario(request.user):
+            return False
+
+        action = getattr(view, "action", None)
+
+        if action in ("list", "retrieve", "historico", "exportar",
+                      "create", "finalizar"):
+            return True
+
+        if action in ("update", "partial_update", "destroy"):
+            return False
+
+        return True
+
+    def has_object_permission(self, request, view, obj):
+        action = getattr(view, "action", None)
+
+        if action in ("update", "partial_update", "destroy"):
+            return False
+
+        return True
+
+
+class ItemConciliacaoPermission(BasePermission):
+    """
+    Regras de acesso para API de Itens de Conciliação (ItemConciliacao):
+
+    - Acesso ao módulo: gestor de patrimônio, operador de inventário ou superuser.
+    - Listagem, detalhe e histórico: qualquer perfil do módulo.
+    - Registrar/excluir ocorrência: qualquer perfil do módulo (escopo validado no queryset).
+    - Criação/edição/exclusão direta de itens: bloqueadas (espelha o admin).
+    """
+
+    def has_permission(self, request, view):
+        if not _pode_acessar_modulo_inventario(request.user):
+            return False
+
+        action = getattr(view, "action", None)
+
+        if action in (
+            "list",
+            "retrieve",
+            "historico",
+            "registrar_ocorrencia",
+            "excluir_ocorrencia",
+            "situacoes_disponiveis",
+        ):
+            return True
+
+        if action in ("create", "update", "partial_update", "destroy"):
+            return False
+
+        return True
+
+    def has_object_permission(self, request, view, obj):
+        action = getattr(view, "action", None)
+
+        if action in ("create", "update", "partial_update", "destroy"):
+            return False
+
+        return True

--- a/inventario/relatorio_conciliacao_pdf.py
+++ b/inventario/relatorio_conciliacao_pdf.py
@@ -22,7 +22,7 @@ from reportlab.platypus import (
     PageTemplate,
     KeepTogether,
 )
-import pytz
+from zoneinfo import ZoneInfo
 
 from inventario import constants as inv_constants
 from bem_patrimonial.pdf_utils import obter_rf_usuario
@@ -136,7 +136,7 @@ def _criar_info_geracao(usuario_gerador=None, data_geracao=None):
         "InfoGeracao", styles, alignment=TA_LEFT, textColor=colors.grey
     )
 
-    tz_sp = pytz.timezone("America/Sao_Paulo")
+    tz_sp = ZoneInfo("America/Sao_Paulo")
 
     data_ref = data_geracao or timezone.now()
     if timezone.is_naive(data_ref):

--- a/inventario/tests/conciliacao_base.py
+++ b/inventario/tests/conciliacao_base.py
@@ -1,0 +1,171 @@
+from datetime import date
+from decimal import Decimal
+
+from django.contrib.auth.models import Group
+from rest_framework.test import APITestCase
+
+from bem_patrimonial import constants as bem_constants
+from bem_patrimonial.models import BemPatrimonial
+from dados_comuns.tests.auth_test_utils import auth_kwargs, codigo_ua, codigo_uo
+from dados_comuns.tests.factories import criar_ua, criar_uo
+from inventario import constants
+from inventario.models import ConciliacaoUA
+from usuario.constants import (
+    GRUPO_GESTOR_PATRIMONIO,
+    GRUPO_OPERADOR_INVENTARIO,
+)
+from usuario.models import Usuario
+
+
+class ConciliacaoAPIBaseTestCase(APITestCase):
+    """
+    Base compartilhada para os testes de API de Conciliação e Itens.
+
+    Cria a estrutura organizacional (UO/UA), os grupos e os usuários padrão
+    (gestor_com_ua, gestor_sem_ua, operador, operador_fora, superuser) uma
+    única vez por classe de teste.
+
+    Subclasses podem sobrescrever `username_prefix` para evitar conflito de
+    unique constraints quando a classe base for reutilizada em outros
+    arquivos de teste.
+    """
+
+    username_prefix = ""
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls._criar_estrutura_organizacional()
+        cls._criar_grupos()
+        cls._criar_usuarios()
+
+    @classmethod
+    def _criar_estrutura_organizacional(cls):
+        cls.uo1 = criar_uo(
+            codigo=codigo_uo(10, 10, 10), nome="UO 1", sigla="UO1"
+        )
+        cls.uo2 = criar_uo(
+            codigo=codigo_uo(20, 20, 20), nome="UO 2", sigla="UO2"
+        )
+        cls.ua1 = criar_ua(
+            uo=cls.uo1,
+            codigo=codigo_ua(10, 10, 10, 1),
+            sigla="UA1",
+            nome="Unidade 1",
+        )
+        cls.ua2 = criar_ua(
+            uo=cls.uo1,
+            codigo=codigo_ua(10, 10, 10, 2),
+            sigla="UA2",
+            nome="Unidade 2",
+        )
+        cls.ua_fora = criar_ua(
+            uo=cls.uo2,
+            codigo=codigo_ua(20, 20, 20, 1),
+            sigla="UAF",
+            nome="Unidade Fora",
+        )
+
+    @classmethod
+    def _criar_grupos(cls):
+        cls.grupo_gestor = Group.objects.get_or_create(
+            name=GRUPO_GESTOR_PATRIMONIO
+        )[0]
+        cls.grupo_operador = Group.objects.get_or_create(
+            name=GRUPO_OPERADOR_INVENTARIO
+        )[0]
+
+    @classmethod
+    def _criar_usuario(cls, *, username, email, nome, grupo, **kwargs):
+        user = Usuario.objects.create_user(
+            username=username,
+            email=email,
+            **auth_kwargs("test123"),
+            nome=nome,
+            is_staff=True,
+            **kwargs,
+        )
+        user.groups.add(grupo)
+        return user
+
+    @classmethod
+    def _criar_usuarios(cls):
+        prefix = cls.username_prefix
+        cls.gestor_com_ua = cls._criar_usuario(
+            username=f"{prefix}gestor_com_ua",
+            email=f"{prefix}gestor.com.ua@test.com",
+            nome="Gestor Com UA",
+            grupo=cls.grupo_gestor,
+            unidade_administrativa=cls.ua1,
+            unidade_orcamentaria=cls.uo1,
+        )
+        cls.gestor_sem_ua = cls._criar_usuario(
+            username=f"{prefix}gestor_sem_ua",
+            email=f"{prefix}gestor.sem.ua@test.com",
+            nome="Gestor Sem UA",
+            grupo=cls.grupo_gestor,
+            unidade_orcamentaria=cls.uo1,
+        )
+        cls.operador = cls._criar_usuario(
+            username=f"{prefix}operador",
+            email=f"{prefix}operador@test.com",
+            nome="Operador",
+            grupo=cls.grupo_operador,
+            unidade_administrativa=cls.ua1,
+            unidade_orcamentaria=cls.uo1,
+        )
+        cls.operador_fora = cls._criar_usuario(
+            username=f"{prefix}operador_fora",
+            email=f"{prefix}operador.fora@test.com",
+            nome="Operador Fora",
+            grupo=cls.grupo_operador,
+            unidade_administrativa=cls.ua_fora,
+            unidade_orcamentaria=cls.uo2,
+        )
+        cls.superuser = cls._criar_usuario(
+            username=f"{prefix}superuser",
+            email=f"{prefix}superuser@test.com",
+            nome="Superuser",
+            grupo=cls.grupo_gestor,
+            is_superuser=True,
+            unidade_orcamentaria=cls.uo1,
+        )
+
+    def setUp(self):
+        super().setUp()
+        self.conciliacao_ua1 = self._criar_conciliacao(
+            self.ua1, periodo=date(2025, 8, 23)
+        )
+        self.conciliacao_ua2 = self._criar_conciliacao(
+            self.ua2, periodo=date(2025, 9, 1)
+        )
+        self.conciliacao_fora = self._criar_conciliacao(
+            self.ua_fora,
+            criado_por=self.operador_fora,
+            periodo=date(2025, 9, 1),
+        )
+
+    def _criar_conciliacao(self, ua, criado_por=None, periodo=None):
+        return ConciliacaoUA.objects.create(
+            tipo=constants.CONCILIACAO_EVENTUAL,
+            periodo_final=periodo,
+            unidade_administrativa=ua,
+            criado_por=criado_por or self.gestor_com_ua,
+        )
+
+    def _criar_bem(self, ua, **kwargs):
+        defaults = {
+            "nome": "Bem Teste",
+            "descricao": "Descrição",
+            "valor_unitario": Decimal("100.00"),
+            "marca": "Marca",
+            "modelo": "Modelo",
+            "status": bem_constants.APROVADO,
+            "unidade_administrativa": ua,
+            "criado_por": self.gestor_com_ua,
+        }
+        defaults.update(kwargs)
+        return BemPatrimonial.objects.create(**defaults)
+
+    def _auth(self, user):
+        self.client.force_authenticate(user)

--- a/inventario/tests/test_conciliacao_api.py
+++ b/inventario/tests/test_conciliacao_api.py
@@ -1,28 +1,17 @@
 from datetime import date
-from decimal import Decimal
-from io import BytesIO
 from unittest.mock import patch
+from io import BytesIO
 
-from django.contrib.auth.models import Group
 from django.urls import reverse
 from django.utils import timezone
 from rest_framework import status
-from rest_framework.test import APITestCase
 
-from bem_patrimonial import constants as bem_constants
-from bem_patrimonial.models import BemPatrimonial
-from dados_comuns.tests.auth_test_utils import auth_kwargs, codigo_ua, codigo_uo
-from dados_comuns.tests.factories import criar_ua, criar_uo
 from inventario import constants
 from inventario.models import ConciliacaoUA
-from usuario.constants import (
-    GRUPO_GESTOR_PATRIMONIO,
-    GRUPO_OPERADOR_INVENTARIO,
-)
-from usuario.models import Usuario
+from inventario.tests.conciliacao_base import ConciliacaoAPIBaseTestCase
 
 
-class ConciliacaoUAAPITestCase(APITestCase):
+class ConciliacaoUAAPITestCase(ConciliacaoAPIBaseTestCase):
     LIST_FIELDS = {
         "id",
         "numero_conciliacao",
@@ -54,128 +43,10 @@ class ConciliacaoUAAPITestCase(APITestCase):
         "esta_aberto",
     }
 
-    @classmethod
-    def setUpTestData(cls):
-        cls.uo1 = criar_uo(codigo=codigo_uo(10, 10, 10), nome="UO 1", sigla="UO1")
-        cls.uo2 = criar_uo(codigo=codigo_uo(20, 20, 20), nome="UO 2", sigla="UO2")
-
-        cls.ua1 = criar_ua(
-            uo=cls.uo1,
-            codigo=codigo_ua(10, 10, 10, 1),
-            sigla="UA1",
-            nome="Unidade 1",
-        )
-        cls.ua2 = criar_ua(
-            uo=cls.uo1,
-            codigo=codigo_ua(10, 10, 10, 2),
-            sigla="UA2",
-            nome="Unidade 2",
-        )
-        cls.ua_fora = criar_ua(
-            uo=cls.uo2,
-            codigo=codigo_ua(20, 20, 20, 1),
-            sigla="UAF",
-            nome="Unidade Fora",
-        )
-
-        grupo_gestor = Group.objects.get_or_create(name=GRUPO_GESTOR_PATRIMONIO)[0]
-        grupo_operador = Group.objects.get_or_create(
-            name=GRUPO_OPERADOR_INVENTARIO
-        )[0]
-
-        cls.gestor_com_ua = Usuario.objects.create_user(
-            username="gestor_com_ua",
-            email="gestor.com.ua@test.com",
-            **auth_kwargs("test123"),
-            nome="Gestor Com UA",
-            is_staff=True,
-            unidade_administrativa=cls.ua1,
-            unidade_orcamentaria=cls.uo1,
-        )
-        cls.gestor_com_ua.groups.add(grupo_gestor)
-
-        cls.gestor_sem_ua = Usuario.objects.create_user(
-            username="gestor_sem_ua",
-            email="gestor.sem.ua@test.com",
-            **auth_kwargs("test123"),
-            nome="Gestor Sem UA",
-            is_staff=True,
-            unidade_orcamentaria=cls.uo1,
-        )
-        cls.gestor_sem_ua.groups.add(grupo_gestor)
-
-        cls.operador = Usuario.objects.create_user(
-            username="operador",
-            email="operador@test.com",
-            **auth_kwargs("test123"),
-            nome="Operador",
-            is_staff=True,
-            unidade_administrativa=cls.ua1,
-            unidade_orcamentaria=cls.uo1,
-        )
-        cls.operador.groups.add(grupo_operador)
-
-        cls.operador_fora = Usuario.objects.create_user(
-            username="operador_fora",
-            email="operador.fora@test.com",
-            **auth_kwargs("test123"),
-            nome="Operador Fora",
-            is_staff=True,
-            unidade_administrativa=cls.ua_fora,
-            unidade_orcamentaria=cls.uo2,
-        )
-        cls.operador_fora.groups.add(grupo_operador)
-
-        cls.superuser = Usuario.objects.create_user(
-            username="superuser",
-            email="superuser@test.com",
-            **auth_kwargs("test123"),
-            nome="Superuser",
-            is_staff=True,
-            is_superuser=True,
-            unidade_orcamentaria=cls.uo1,
-        )
-        cls.superuser.groups.add(grupo_gestor)
-
     def setUp(self):
+        super().setUp()
         self._criar_bem(self.ua1)
-        self.conciliacao_ua1 = ConciliacaoUA.objects.create(
-            tipo=constants.CONCILIACAO_EVENTUAL,
-            periodo_final=date(2025, 8, 23),
-            unidade_administrativa=self.ua1,
-            criado_por=self.gestor_com_ua,
-        )
-        self.conciliacao_ua2 = ConciliacaoUA.objects.create(
-            tipo=constants.CONCILIACAO_EVENTUAL,
-            periodo_final=date(2025, 9, 1),
-            unidade_administrativa=self.ua2,
-            criado_por=self.gestor_com_ua,
-        )
-        self.conciliacao_fora = ConciliacaoUA.objects.create(
-            tipo=constants.CONCILIACAO_EVENTUAL,
-            periodo_final=date(2025, 9, 1),
-            unidade_administrativa=self.ua_fora,
-            criado_por=self.operador_fora,
-        )
         self.list_url = reverse("conciliacoes-list")
-
-    def _criar_bem(self, ua, **kwargs):
-        defaults = {
-            "numero_patrimonial": f"001.{str(BemPatrimonial.objects.count() + 1).zfill(9)}-0",
-            "nome": "Bem Teste",
-            "descricao": "Descrição",
-            "valor_unitario": Decimal("100.00"),
-            "marca": "Marca",
-            "modelo": "Modelo",
-            "status": bem_constants.APROVADO,
-            "unidade_administrativa": ua,
-            "criado_por": self.gestor_com_ua,
-        }
-        defaults.update(kwargs)
-        return BemPatrimonial.objects.create(**defaults)
-
-    def _auth(self, user):
-        self.client.force_authenticate(user)
 
     def _detail_url(self, conciliacao_id):
         return reverse("conciliacoes-detail", args=[conciliacao_id])
@@ -325,8 +196,6 @@ class ConciliacaoUAAPITestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_retrieve_remove_itens_baixados_invalidos(self):
-        from unittest.mock import patch
-
         self._auth(self.gestor_com_ua)
         with patch(
             "inventario.api_views.remover_itens_baixados_invalidos"
@@ -337,8 +206,6 @@ class ConciliacaoUAAPITestCase(APITestCase):
             mock_remover.assert_called_once()
 
     def test_retrieve_conciliacao_fechada_nao_remove_itens(self):
-        from unittest.mock import patch
-
         ConciliacaoUA.objects.filter(pk=self.conciliacao_ua1.pk).update(
             status=constants.CONCILIACAO_FECHADO
         )

--- a/inventario/tests/test_conciliacao_api.py
+++ b/inventario/tests/test_conciliacao_api.py
@@ -1,0 +1,551 @@
+from datetime import date
+from decimal import Decimal
+from io import BytesIO
+from unittest.mock import patch
+
+from django.contrib.auth.models import Group
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from bem_patrimonial import constants as bem_constants
+from bem_patrimonial.models import BemPatrimonial
+from dados_comuns.tests.auth_test_utils import auth_kwargs, codigo_ua, codigo_uo
+from dados_comuns.tests.factories import criar_ua, criar_uo
+from inventario import constants
+from inventario.models import ConciliacaoUA
+from usuario.constants import (
+    GRUPO_GESTOR_PATRIMONIO,
+    GRUPO_OPERADOR_INVENTARIO,
+)
+from usuario.models import Usuario
+
+
+class ConciliacaoUAAPITestCase(APITestCase):
+    LIST_FIELDS = {
+        "id",
+        "numero_conciliacao",
+        "unidade_administrativa",
+        "unidade_administrativa_codigo",
+        "unidade_administrativa_nome",
+        "unidade_administrativa_sigla",
+        "unidade_orcamentaria_codigo",
+        "unidade_orcamentaria_nome",
+        "tipo",
+        "tipo_display",
+        "periodo_final",
+        "status",
+        "status_display",
+        "total_itens",
+        "resumo_situacoes",
+        "ano_vigencia",
+        "criado_em",
+        "fechado_em",
+    }
+
+    DETAIL_EXTRA_FIELDS = {
+        "criado_por",
+        "criado_por_nome",
+        "criado_por_rf",
+        "fechado_por",
+        "fechado_por_nome",
+        "fechado_por_rf",
+        "esta_aberto",
+    }
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.uo1 = criar_uo(codigo=codigo_uo(10, 10, 10), nome="UO 1", sigla="UO1")
+        cls.uo2 = criar_uo(codigo=codigo_uo(20, 20, 20), nome="UO 2", sigla="UO2")
+
+        cls.ua1 = criar_ua(
+            uo=cls.uo1,
+            codigo=codigo_ua(10, 10, 10, 1),
+            sigla="UA1",
+            nome="Unidade 1",
+        )
+        cls.ua2 = criar_ua(
+            uo=cls.uo1,
+            codigo=codigo_ua(10, 10, 10, 2),
+            sigla="UA2",
+            nome="Unidade 2",
+        )
+        cls.ua_fora = criar_ua(
+            uo=cls.uo2,
+            codigo=codigo_ua(20, 20, 20, 1),
+            sigla="UAF",
+            nome="Unidade Fora",
+        )
+
+        grupo_gestor = Group.objects.get_or_create(name=GRUPO_GESTOR_PATRIMONIO)[0]
+        grupo_operador = Group.objects.get_or_create(
+            name=GRUPO_OPERADOR_INVENTARIO
+        )[0]
+
+        cls.gestor_com_ua = Usuario.objects.create_user(
+            username="gestor_com_ua",
+            email="gestor.com.ua@test.com",
+            **auth_kwargs("test123"),
+            nome="Gestor Com UA",
+            is_staff=True,
+            unidade_administrativa=cls.ua1,
+            unidade_orcamentaria=cls.uo1,
+        )
+        cls.gestor_com_ua.groups.add(grupo_gestor)
+
+        cls.gestor_sem_ua = Usuario.objects.create_user(
+            username="gestor_sem_ua",
+            email="gestor.sem.ua@test.com",
+            **auth_kwargs("test123"),
+            nome="Gestor Sem UA",
+            is_staff=True,
+            unidade_orcamentaria=cls.uo1,
+        )
+        cls.gestor_sem_ua.groups.add(grupo_gestor)
+
+        cls.operador = Usuario.objects.create_user(
+            username="operador",
+            email="operador@test.com",
+            **auth_kwargs("test123"),
+            nome="Operador",
+            is_staff=True,
+            unidade_administrativa=cls.ua1,
+            unidade_orcamentaria=cls.uo1,
+        )
+        cls.operador.groups.add(grupo_operador)
+
+        cls.operador_fora = Usuario.objects.create_user(
+            username="operador_fora",
+            email="operador.fora@test.com",
+            **auth_kwargs("test123"),
+            nome="Operador Fora",
+            is_staff=True,
+            unidade_administrativa=cls.ua_fora,
+            unidade_orcamentaria=cls.uo2,
+        )
+        cls.operador_fora.groups.add(grupo_operador)
+
+        cls.superuser = Usuario.objects.create_user(
+            username="superuser",
+            email="superuser@test.com",
+            **auth_kwargs("test123"),
+            nome="Superuser",
+            is_staff=True,
+            is_superuser=True,
+            unidade_orcamentaria=cls.uo1,
+        )
+        cls.superuser.groups.add(grupo_gestor)
+
+    def setUp(self):
+        self._criar_bem(self.ua1)
+        self.conciliacao_ua1 = ConciliacaoUA.objects.create(
+            tipo=constants.CONCILIACAO_EVENTUAL,
+            periodo_final=date(2025, 8, 23),
+            unidade_administrativa=self.ua1,
+            criado_por=self.gestor_com_ua,
+        )
+        self.conciliacao_ua2 = ConciliacaoUA.objects.create(
+            tipo=constants.CONCILIACAO_EVENTUAL,
+            periodo_final=date(2025, 9, 1),
+            unidade_administrativa=self.ua2,
+            criado_por=self.gestor_com_ua,
+        )
+        self.conciliacao_fora = ConciliacaoUA.objects.create(
+            tipo=constants.CONCILIACAO_EVENTUAL,
+            periodo_final=date(2025, 9, 1),
+            unidade_administrativa=self.ua_fora,
+            criado_por=self.operador_fora,
+        )
+        self.list_url = reverse("conciliacoes-list")
+
+    def _criar_bem(self, ua, **kwargs):
+        defaults = {
+            "numero_patrimonial": f"001.{str(BemPatrimonial.objects.count() + 1).zfill(9)}-0",
+            "nome": "Bem Teste",
+            "descricao": "Descrição",
+            "valor_unitario": Decimal("100.00"),
+            "marca": "Marca",
+            "modelo": "Modelo",
+            "status": bem_constants.APROVADO,
+            "unidade_administrativa": ua,
+            "criado_por": self.gestor_com_ua,
+        }
+        defaults.update(kwargs)
+        return BemPatrimonial.objects.create(**defaults)
+
+    def _auth(self, user):
+        self.client.force_authenticate(user)
+
+    def _detail_url(self, conciliacao_id):
+        return reverse("conciliacoes-detail", args=[conciliacao_id])
+
+    def _payload_create(self, **overrides):
+        payload = {
+            "unidade_administrativa": self.ua1.id,
+            "tipo": constants.CONCILIACAO_EVENTUAL,
+            "periodo_final": str(date.today()),
+        }
+        payload.update(overrides)
+        return payload
+
+    def test_nao_autenticado_retorna_401(self):
+        response = self.client.get(self.list_url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_operador_pode_listar(self):
+        self._auth(self.operador)
+        response = self.client.get(self.list_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = {row["id"] for row in response.data["results"]}
+        self.assertIn(self.conciliacao_ua1.id, ids)
+        self.assertNotIn(self.conciliacao_ua2.id, ids)
+        self.assertNotIn(self.conciliacao_fora.id, ids)
+
+    def test_gestor_com_ua_ve_apenas_sua_ua(self):
+        self._auth(self.gestor_com_ua)
+        response = self.client.get(self.list_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = {row["id"] for row in response.data["results"]}
+        self.assertIn(self.conciliacao_ua1.id, ids)
+        self.assertNotIn(self.conciliacao_ua2.id, ids)
+        self.assertNotIn(self.conciliacao_fora.id, ids)
+
+    def test_gestor_sem_ua_ve_uo_inteira(self):
+        self._auth(self.gestor_sem_ua)
+        response = self.client.get(self.list_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = {row["id"] for row in response.data["results"]}
+        self.assertIn(self.conciliacao_ua1.id, ids)
+        self.assertIn(self.conciliacao_ua2.id, ids)
+        self.assertNotIn(self.conciliacao_fora.id, ids)
+
+    def test_superuser_com_uo_ve_apenas_sua_uo(self):
+        self._auth(self.superuser)
+        response = self.client.get(self.list_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = {row["id"] for row in response.data["results"]}
+        self.assertIn(self.conciliacao_ua1.id, ids)
+        self.assertIn(self.conciliacao_ua2.id, ids)
+        self.assertNotIn(self.conciliacao_fora.id, ids)
+
+    def test_listagem_campos_retorna_esperados(self):
+        self._auth(self.gestor_com_ua)
+        response = self.client.get(self.list_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            set(response.data["results"][0].keys()), self.LIST_FIELDS
+        )
+
+    def test_listagem_filtros_status_tipo_e_ano(self):
+        ConciliacaoUA.objects.filter(pk=self.conciliacao_ua2.pk).update(
+            status=constants.CONCILIACAO_FECHADO
+        )
+        self._auth(self.gestor_sem_ua)
+
+        response = self.client.get(
+            self.list_url,
+            {"status": constants.CONCILIACAO_FECHADO},
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = {row["id"] for row in response.data["results"]}
+        self.assertEqual(ids, {self.conciliacao_ua2.id})
+
+        response = self.client.get(
+            self.list_url,
+            {"tipo": constants.CONCILIACAO_EVENTUAL, "ano_vigencia": 2025},
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = {row["id"] for row in response.data["results"]}
+        self.assertEqual(
+            ids, {self.conciliacao_ua1.id, self.conciliacao_ua2.id}
+        )
+
+    def test_listagem_filtro_multi_status(self):
+        ConciliacaoUA.objects.filter(pk=self.conciliacao_ua2.pk).update(
+            status=constants.CONCILIACAO_FECHADO
+        )
+        self._auth(self.gestor_sem_ua)
+        response = self.client.get(
+            self.list_url,
+            {
+                "status": f"{constants.CONCILIACAO_EM_ABERTO},{constants.CONCILIACAO_FECHADO}"
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = {row["id"] for row in response.data["results"]}
+        self.assertEqual(
+            ids, {self.conciliacao_ua1.id, self.conciliacao_ua2.id}
+        )
+
+    def test_listagem_filtro_periodo_final_range(self):
+        self._auth(self.gestor_sem_ua)
+        response = self.client.get(
+            self.list_url,
+            {
+                "periodo_final__gte": "2025-08-01",
+                "periodo_final__lte": "2025-08-31",
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = {row["id"] for row in response.data["results"]}
+        self.assertEqual(ids, {self.conciliacao_ua1.id})
+
+    def test_listagem_busca_por_numero(self):
+        self._auth(self.gestor_sem_ua)
+        response = self.client.get(
+            self.list_url,
+            {"search": self.conciliacao_ua1.numero_conciliacao},
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = {row["id"] for row in response.data["results"]}
+        self.assertEqual(ids, {self.conciliacao_ua1.id})
+
+    def test_listagem_ordenacao_criado_em_desc(self):
+        self._auth(self.gestor_sem_ua)
+        response = self.client.get(self.list_url, {"ordering": "-criado_em"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = [row["id"] for row in response.data["results"]]
+        self.assertEqual(ids, sorted(ids, key=lambda x: -x))
+
+    def test_retrieve_retorna_detalhe_completo(self):
+        self._auth(self.gestor_com_ua)
+        response = self.client.get(self._detail_url(self.conciliacao_ua1.id))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["id"], self.conciliacao_ua1.id)
+        self.assertTrue(
+            self.DETAIL_EXTRA_FIELDS.issubset(set(response.data.keys()))
+        )
+        self.assertIn("encontrados", response.data["resumo_situacoes"])
+        self.assertTrue(response.data["esta_aberto"])
+
+    def test_retrieve_fora_do_escopo_retorna_404(self):
+        self._auth(self.operador)
+        response = self.client.get(self._detail_url(self.conciliacao_ua2.id))
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_retrieve_remove_itens_baixados_invalidos(self):
+        from unittest.mock import patch
+
+        self._auth(self.gestor_com_ua)
+        with patch(
+            "inventario.api_views.remover_itens_baixados_invalidos"
+        ) as mock_remover:
+            mock_remover.return_value = 0
+            response = self.client.get(self._detail_url(self.conciliacao_ua1.id))
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            mock_remover.assert_called_once()
+
+    def test_retrieve_conciliacao_fechada_nao_remove_itens(self):
+        from unittest.mock import patch
+
+        ConciliacaoUA.objects.filter(pk=self.conciliacao_ua1.pk).update(
+            status=constants.CONCILIACAO_FECHADO
+        )
+        self._auth(self.gestor_com_ua)
+        with patch(
+            "inventario.api_views.remover_itens_baixados_invalidos"
+        ) as mock_remover:
+            response = self.client.get(self._detail_url(self.conciliacao_ua1.id))
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            mock_remover.assert_not_called()
+
+    def test_create_eventual_por_gestor_com_ua(self):
+        ConciliacaoUA.objects.filter(pk=self.conciliacao_ua1.pk).update(
+            status=constants.CONCILIACAO_FECHADO
+        )
+        self._auth(self.gestor_com_ua)
+
+        payload = self._payload_create(
+            unidade_administrativa=self.ua1.id,
+            periodo_final=str(date.today() + timezone.timedelta(days=10)),
+        )
+        response = self.client.post(self.list_url, payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data["tipo"], constants.CONCILIACAO_EVENTUAL)
+        self.assertEqual(response.data["unidade_administrativa"], self.ua1.id)
+        nova = ConciliacaoUA.objects.get(pk=response.data["id"])
+        self.assertEqual(nova.criado_por, self.gestor_com_ua)
+        self.assertTrue(nova.itens.exists())
+
+    def test_create_por_operador_no_escopo(self):
+        ConciliacaoUA.objects.filter(pk=self.conciliacao_ua1.pk).update(
+            status=constants.CONCILIACAO_FECHADO
+        )
+        self._auth(self.operador)
+        payload = self._payload_create(
+            periodo_final=str(date.today() + timezone.timedelta(days=10)),
+        )
+        response = self.client.post(self.list_url, payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data["unidade_administrativa"], self.ua1.id)
+        nova = ConciliacaoUA.objects.get(pk=response.data["id"])
+        self.assertEqual(nova.criado_por, self.operador)
+        self.assertTrue(nova.itens.exists())
+
+    def test_create_sem_ua_fora_do_escopo_retorna_400(self):
+        self._auth(self.gestor_com_ua)
+        payload = self._payload_create(
+            unidade_administrativa=self.ua_fora.id,
+            periodo_final=str(date.today()),
+        )
+        response = self.client.post(self.list_url, payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("unidade_administrativa", response.data)
+
+    def test_create_tipo_anual_rejeitado(self):
+        self._auth(self.gestor_com_ua)
+        payload = self._payload_create(
+            tipo=constants.CONCILIACAO_ANUAL,
+            periodo_final="",
+        )
+        response = self.client.post(self.list_url, payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("tipo", response.data)
+
+    def test_create_eventual_sem_periodo_final_retorna_400(self):
+        self._auth(self.gestor_sem_ua)
+        payload = self._payload_create(
+            unidade_administrativa=self.ua1.id,
+            periodo_final="",
+        )
+        response = self.client.post(self.list_url, payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("periodo_final", response.data)
+
+    def test_create_com_conciliacao_aberta_existente_retorna_400(self):
+        self._auth(self.gestor_com_ua)
+        payload = self._payload_create(
+            periodo_final=str(date.today() + timezone.timedelta(days=10)),
+        )
+        response = self.client.post(self.list_url, payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("unidade_administrativa", response.data)
+
+    def test_create_por_operador_fora_do_escopo_retorna_400(self):
+        self._auth(self.operador)
+        payload = self._payload_create(
+            unidade_administrativa=self.ua2.id,
+            periodo_final=str(date.today()),
+        )
+        response = self.client.post(self.list_url, payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("unidade_administrativa", response.data)
+
+    def test_put_patch_delete_nao_permitidos(self):
+        self._auth(self.gestor_com_ua)
+        url = self._detail_url(self.conciliacao_ua1.id)
+
+        put = self.client.put(
+            url, self._payload_create(), format="json"
+        )
+        self.assertEqual(put.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+
+        patch = self.client.patch(url, {"status": "fechado"}, format="json")
+        self.assertEqual(patch.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+
+        delete = self.client.delete(url)
+        self.assertEqual(delete.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+
+    def test_finalizar_por_gestor(self):
+        self._auth(self.gestor_com_ua)
+        url = reverse("conciliacoes-finalizar", args=[self.conciliacao_ua1.id])
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.conciliacao_ua1.refresh_from_db()
+        self.assertEqual(
+            self.conciliacao_ua1.status, constants.CONCILIACAO_FECHADO
+        )
+        self.assertEqual(self.conciliacao_ua1.fechado_por, self.gestor_com_ua)
+
+    def test_finalizar_ja_fechada_retorna_400(self):
+        ConciliacaoUA.objects.filter(pk=self.conciliacao_ua1.pk).update(
+            status=constants.CONCILIACAO_FECHADO
+        )
+        self._auth(self.gestor_com_ua)
+        url = reverse("conciliacoes-finalizar", args=[self.conciliacao_ua1.id])
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_finalizar_por_operador_no_escopo(self):
+        self._auth(self.operador)
+        url = reverse("conciliacoes-finalizar", args=[self.conciliacao_ua1.id])
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.conciliacao_ua1.refresh_from_db()
+        self.assertEqual(
+            self.conciliacao_ua1.status, constants.CONCILIACAO_FECHADO
+        )
+        self.assertEqual(self.conciliacao_ua1.fechado_por, self.operador)
+
+    def test_finalizar_fora_do_escopo_retorna_404(self):
+        self._auth(self.gestor_com_ua)
+        url = reverse("conciliacoes-finalizar", args=[self.conciliacao_fora.id])
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_historico_retorna_grupos(self):
+        self._auth(self.gestor_com_ua)
+        url = reverse("conciliacoes-historico", args=[self.conciliacao_ua1.id])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIsInstance(response.data, list)
+
+    def test_historico_registra_finalizar(self):
+        self._auth(self.gestor_com_ua)
+        url_finalizar = reverse(
+            "conciliacoes-finalizar", args=[self.conciliacao_ua1.id]
+        )
+        self.client.post(url_finalizar)
+
+        url_historico = reverse(
+            "conciliacoes-historico", args=[self.conciliacao_ua1.id]
+        )
+        response = self.client.get(url_historico)
+        campos = {
+            acao["campo"]
+            for grupo in response.data
+            for acao in grupo["acoes"]
+        }
+        self.assertIn("status", campos)
+        self.assertIn("fechado_por", campos)
+
+    def test_exportar_pdf_retorna_pdf(self):
+        self._auth(self.gestor_com_ua)
+        url = reverse("conciliacoes-exportar", args=[self.conciliacao_ua1.id])
+
+        with patch(
+            "inventario.api_views.gerar_pdf_conciliacao",
+            return_value=BytesIO(b"%PDF-1.4\nconteudo\n%%EOF"),
+        ):
+            response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response["Content-Type"], "application/pdf")
+        self.assertIn("attachment", response["Content-Disposition"])
+        self.assertIn(".pdf", response["Content-Disposition"])
+
+    def test_exportar_fora_do_escopo_retorna_404(self):
+        self._auth(self.operador)
+        url = reverse("conciliacoes-exportar", args=[self.conciliacao_ua2.id])
+
+        with patch(
+            "inventario.api_views.gerar_pdf_conciliacao",
+            return_value=BytesIO(b"%PDF-1.4"),
+        ):
+            response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_exportar_conciliacao_inexistente_retorna_404(self):
+        self._auth(self.gestor_com_ua)
+        url = reverse("conciliacoes-exportar", args=[999999])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_operador_fora_da_uo_nao_ve_nada(self):
+        self._auth(self.operador_fora)
+        response = self.client.get(self.list_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = {row["id"] for row in response.data["results"]}
+        self.assertEqual(ids, {self.conciliacao_fora.id})

--- a/inventario/tests/test_item_conciliacao_api.py
+++ b/inventario/tests/test_item_conciliacao_api.py
@@ -1,0 +1,561 @@
+from datetime import date
+from decimal import Decimal
+
+from django.contrib.auth.models import Group
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from bem_patrimonial import constants as bem_constants
+from bem_patrimonial.models import BemPatrimonial
+from dados_comuns.tests.auth_test_utils import auth_kwargs, codigo_ua, codigo_uo
+from dados_comuns.tests.factories import criar_ua, criar_uo
+from inventario import constants
+from inventario.models import (
+    ConciliacaoUA,
+    ItemConciliacao,
+    OcorrenciaConciliacao,
+)
+from usuario.constants import (
+    GRUPO_GESTOR_PATRIMONIO,
+    GRUPO_OPERADOR_INVENTARIO,
+)
+from usuario.models import Usuario
+
+
+class ItemConciliacaoAPITestCase(APITestCase):
+    LIST_FIELDS = {
+        "id",
+        "conciliacao",
+        "conciliacao_numero",
+        "conciliacao_status",
+        "unidade_administrativa",
+        "unidade_administrativa_sigla",
+        "bem",
+        "situacao",
+        "situacao_display",
+        "observacao",
+        "divergencia",
+        "tem_ocorrencia",
+        "permite_registrar_ocorrencia",
+        "atualizado_por",
+        "atualizado_por_nome",
+        "atualizado_em",
+    }
+
+    DETAIL_EXTRA_FIELDS = {
+        "pode_marcar_como_encontrado",
+        "pode_resolver_situacao",
+        "conciliacao_esta_aberto",
+        "ocorrencias",
+    }
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.uo1 = criar_uo(codigo=codigo_uo(10, 10, 10), nome="UO 1", sigla="UO1")
+        cls.uo2 = criar_uo(codigo=codigo_uo(20, 20, 20), nome="UO 2", sigla="UO2")
+
+        cls.ua1 = criar_ua(
+            uo=cls.uo1,
+            codigo=codigo_ua(10, 10, 10, 1),
+            sigla="UA1",
+            nome="Unidade 1",
+        )
+        cls.ua2 = criar_ua(
+            uo=cls.uo1,
+            codigo=codigo_ua(10, 10, 10, 2),
+            sigla="UA2",
+            nome="Unidade 2",
+        )
+        cls.ua_fora = criar_ua(
+            uo=cls.uo2,
+            codigo=codigo_ua(20, 20, 20, 1),
+            sigla="UAF",
+            nome="Unidade Fora",
+        )
+
+        grupo_gestor = Group.objects.get_or_create(name=GRUPO_GESTOR_PATRIMONIO)[0]
+        grupo_operador = Group.objects.get_or_create(
+            name=GRUPO_OPERADOR_INVENTARIO
+        )[0]
+
+        cls.gestor_com_ua = Usuario.objects.create_user(
+            username="gestor_items_com_ua",
+            email="gestor.items.com.ua@test.com",
+            **auth_kwargs("test123"),
+            nome="Gestor Com UA",
+            is_staff=True,
+            unidade_administrativa=cls.ua1,
+            unidade_orcamentaria=cls.uo1,
+        )
+        cls.gestor_com_ua.groups.add(grupo_gestor)
+
+        cls.gestor_sem_ua = Usuario.objects.create_user(
+            username="gestor_items_sem_ua",
+            email="gestor.items.sem.ua@test.com",
+            **auth_kwargs("test123"),
+            nome="Gestor Sem UA",
+            is_staff=True,
+            unidade_orcamentaria=cls.uo1,
+        )
+        cls.gestor_sem_ua.groups.add(grupo_gestor)
+
+        cls.operador = Usuario.objects.create_user(
+            username="operador_items",
+            email="operador.items@test.com",
+            **auth_kwargs("test123"),
+            nome="Operador Items",
+            is_staff=True,
+            unidade_administrativa=cls.ua1,
+            unidade_orcamentaria=cls.uo1,
+        )
+        cls.operador.groups.add(grupo_operador)
+
+        cls.operador_fora = Usuario.objects.create_user(
+            username="operador_items_fora",
+            email="operador.items.fora@test.com",
+            **auth_kwargs("test123"),
+            nome="Operador Fora",
+            is_staff=True,
+            unidade_administrativa=cls.ua_fora,
+            unidade_orcamentaria=cls.uo2,
+        )
+        cls.operador_fora.groups.add(grupo_operador)
+
+    def setUp(self):
+        self.conciliacao_ua1 = ConciliacaoUA.objects.create(
+            tipo=constants.CONCILIACAO_EVENTUAL,
+            periodo_final=date(2025, 8, 23),
+            unidade_administrativa=self.ua1,
+            criado_por=self.gestor_com_ua,
+        )
+        self.conciliacao_ua2 = ConciliacaoUA.objects.create(
+            tipo=constants.CONCILIACAO_EVENTUAL,
+            periodo_final=date(2025, 9, 1),
+            unidade_administrativa=self.ua2,
+            criado_por=self.gestor_com_ua,
+        )
+        self.conciliacao_fora = ConciliacaoUA.objects.create(
+            tipo=constants.CONCILIACAO_EVENTUAL,
+            periodo_final=date(2025, 9, 1),
+            unidade_administrativa=self.ua_fora,
+            criado_por=self.operador_fora,
+        )
+
+        self.bem_ua1_a = self._criar_bem(self.ua1, numero_patrimonial="001.000000001-1")
+        self.bem_ua1_b = self._criar_bem(self.ua1, numero_patrimonial="001.000000002-2")
+        self.bem_ua2 = self._criar_bem(self.ua2, numero_patrimonial="001.000000003-3")
+        self.bem_fora = self._criar_bem(
+            self.ua_fora, numero_patrimonial="001.000000004-4"
+        )
+
+        self.item_a = ItemConciliacao.objects.create(
+            conciliacao=self.conciliacao_ua1,
+            bem=self.bem_ua1_a,
+            situacao=constants.ENCONTRADO_SEM_DIVERGENCIA,
+        )
+        self.item_b = ItemConciliacao.objects.create(
+            conciliacao=self.conciliacao_ua1,
+            bem=self.bem_ua1_b,
+            situacao=constants.DIVERGENTE,
+            divergencia="Etiqueta danificada",
+            observacao="Divergência",
+        )
+        OcorrenciaConciliacao.objects.create(
+            item=self.item_b,
+            situacao=constants.DIVERGENTE,
+            divergencia="Etiqueta danificada",
+            observacao="Divergência",
+            registrado_por=self.gestor_com_ua,
+        )
+
+        self.item_ua2 = ItemConciliacao.objects.create(
+            conciliacao=self.conciliacao_ua2,
+            bem=self.bem_ua2,
+            situacao=constants.ENCONTRADO_SEM_DIVERGENCIA,
+        )
+
+        self.item_fora = ItemConciliacao.objects.create(
+            conciliacao=self.conciliacao_fora,
+            bem=self.bem_fora,
+            situacao=constants.ENCONTRADO_SEM_DIVERGENCIA,
+        )
+
+        self.list_url = reverse(
+            "itens-conciliacao-list", args=[self.conciliacao_ua1.id]
+        )
+
+    def _criar_bem(self, ua, **kwargs):
+        defaults = {
+            "nome": "Bem Teste",
+            "descricao": "Descrição",
+            "valor_unitario": Decimal("100.00"),
+            "marca": "Marca",
+            "modelo": "Modelo",
+            "status": bem_constants.APROVADO,
+            "unidade_administrativa": ua,
+            "criado_por": self.gestor_com_ua,
+        }
+        defaults.update(kwargs)
+        return BemPatrimonial.objects.create(**defaults)
+
+    def _auth(self, user):
+        self.client.force_authenticate(user)
+
+    def _list_url(self, conciliacao_id):
+        return reverse("itens-conciliacao-list", args=[conciliacao_id])
+
+    def _detail_url(self, conciliacao_id, item_id):
+        return reverse(
+            "itens-conciliacao-detail", args=[conciliacao_id, item_id]
+        )
+
+    def _registrar_url(self, conciliacao_id, item_id):
+        return reverse(
+            "itens-conciliacao-registrar-ocorrencia",
+            args=[conciliacao_id, item_id],
+        )
+
+    def _excluir_url(self, conciliacao_id, item_id):
+        return reverse(
+            "itens-conciliacao-excluir-ocorrencia",
+            args=[conciliacao_id, item_id],
+        )
+
+    def _situacoes_url(self, conciliacao_id, item_id):
+        return reverse(
+            "itens-conciliacao-situacoes-disponiveis",
+            args=[conciliacao_id, item_id],
+        )
+
+    def _historico_url(self, conciliacao_id, item_id):
+        return reverse(
+            "itens-conciliacao-historico",
+            args=[conciliacao_id, item_id],
+        )
+
+    def test_nao_autenticado_retorna_401(self):
+        response = self.client.get(self.list_url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_operador_ve_apenas_itens_da_sua_ua(self):
+        self._auth(self.operador)
+        response = self.client.get(self.list_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = {row["id"] for row in response.data["results"]}
+        self.assertEqual(ids, {self.item_a.id, self.item_b.id})
+
+    def test_gestor_sem_ua_ve_itens_da_sua_uo(self):
+        self._auth(self.gestor_sem_ua)
+        response = self.client.get(self.list_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = {row["id"] for row in response.data["results"]}
+        self.assertEqual(ids, {self.item_a.id, self.item_b.id})
+
+    def test_listagem_outra_conciliacao_mesma_uo(self):
+        self._auth(self.gestor_sem_ua)
+        response = self.client.get(self._list_url(self.conciliacao_ua2.id))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = {row["id"] for row in response.data["results"]}
+        self.assertEqual(ids, {self.item_ua2.id})
+
+    def test_listagem_conciliacao_fora_do_escopo_retorna_404(self):
+        self._auth(self.operador)
+        response = self.client.get(self._list_url(self.conciliacao_ua2.id))
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_listagem_conciliacao_inexistente_retorna_404(self):
+        self._auth(self.gestor_com_ua)
+        response = self.client.get(self._list_url(999999))
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_filtro_por_situacao(self):
+        self._auth(self.operador)
+        response = self.client.get(
+            self.list_url, {"situacao": constants.DIVERGENTE}
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = {row["id"] for row in response.data["results"]}
+        self.assertEqual(ids, {self.item_b.id})
+
+    def test_filtro_por_tem_ocorrencia_true(self):
+        self._auth(self.operador)
+        response = self.client.get(self.list_url, {"tem_ocorrencia": "true"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = {row["id"] for row in response.data["results"]}
+        self.assertEqual(ids, {self.item_b.id})
+
+    def test_filtro_por_tem_ocorrencia_false(self):
+        self._auth(self.operador)
+        response = self.client.get(self.list_url, {"tem_ocorrencia": "false"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = {row["id"] for row in response.data["results"]}
+        self.assertEqual(ids, {self.item_a.id})
+
+    def test_busca_por_numero_patrimonial(self):
+        self._auth(self.operador)
+        response = self.client.get(
+            self.list_url, {"search": "000000001-1"}
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = {row["id"] for row in response.data["results"]}
+        self.assertEqual(ids, {self.item_a.id})
+
+    def test_listagem_campos_retorna_esperados(self):
+        self._auth(self.operador)
+        response = self.client.get(self.list_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            set(response.data["results"][0].keys()), self.LIST_FIELDS
+        )
+
+    def test_listagem_inclui_bem_com_bloqueado_e_localizacao(self):
+        self._auth(self.operador)
+        response = self.client.get(self.list_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        bem = response.data["results"][0]["bem"]
+        self.assertIn("bloqueado_conciliacao", bem)
+        self.assertIn("localizacao", bem)
+        self.assertFalse(bem["bloqueado_conciliacao"])
+
+    def test_retrieve_retorna_detalhe_completo(self):
+        self._auth(self.operador)
+        response = self.client.get(
+            self._detail_url(self.conciliacao_ua1.id, self.item_b.id)
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["id"], self.item_b.id)
+        self.assertTrue(
+            self.DETAIL_EXTRA_FIELDS.issubset(set(response.data.keys()))
+        )
+        self.assertEqual(len(response.data["ocorrencias"]), 1)
+        self.assertTrue(response.data["tem_ocorrencia"])
+        self.assertTrue(response.data["conciliacao_esta_aberto"])
+
+    def test_retrieve_fora_do_escopo_retorna_404(self):
+        self._auth(self.operador)
+        response = self.client.get(
+            self._detail_url(self.conciliacao_ua2.id, self.item_ua2.id)
+        )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_retrieve_item_nao_pertence_a_conciliacao_retorna_404(self):
+        self._auth(self.operador)
+        response = self.client.get(
+            self._detail_url(self.conciliacao_ua1.id, self.item_ua2.id)
+        )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_post_put_delete_nao_permitidos(self):
+        self._auth(self.operador)
+
+        post = self.client.post(self.list_url, {}, format="json")
+        self.assertEqual(post.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+
+        url = self._detail_url(self.conciliacao_ua1.id, self.item_a.id)
+        put = self.client.put(url, {}, format="json")
+        self.assertEqual(put.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+
+        delete = self.client.delete(url)
+        self.assertEqual(delete.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+
+    def test_registrar_ocorrencia_nao_encontrado(self):
+        self._auth(self.operador)
+        url = self._registrar_url(
+            self.conciliacao_ua1.id, self.item_a.id
+        )
+        response = self.client.post(
+            url,
+            {
+                "situacao": constants.NAO_ENCONTRADO,
+                "observacao": "Não localizado",
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.item_a.refresh_from_db()
+        self.assertEqual(self.item_a.situacao, constants.NAO_ENCONTRADO)
+        self.assertTrue(self.item_a.tem_ocorrencia)
+
+    def test_registrar_ocorrencia_divergente_sem_divergencia_retorna_400(self):
+        self._auth(self.operador)
+        url = self._registrar_url(
+            self.conciliacao_ua1.id, self.item_a.id
+        )
+        response = self.client.post(
+            url,
+            {"situacao": constants.DIVERGENTE, "divergencia": ""},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("divergencia", response.data)
+
+    def test_registrar_ocorrencia_em_baixa_fisica_retorna_400(self):
+        ItemConciliacao.objects.filter(pk=self.item_a.pk).update(
+            situacao=constants.BAIXA_FISICA
+        )
+        self.item_a.refresh_from_db()
+        self._auth(self.operador)
+        url = self._registrar_url(
+            self.conciliacao_ua1.id, self.item_a.id
+        )
+        response = self.client.post(
+            url, {"situacao": constants.NAO_ENCONTRADO}, format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_registrar_ocorrencia_baixa_fisica_rejeitado(self):
+        self._auth(self.operador)
+        url = self._registrar_url(
+            self.conciliacao_ua1.id, self.item_a.id
+        )
+        response = self.client.post(
+            url, {"situacao": constants.BAIXA_FISICA}, format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_registrar_ocorrencia_conciliacao_fechada_retorna_400(self):
+        ConciliacaoUA.objects.filter(pk=self.conciliacao_ua1.pk).update(
+            status=constants.CONCILIACAO_FECHADO
+        )
+        self._auth(self.operador)
+        url = self._registrar_url(
+            self.conciliacao_ua1.id, self.item_a.id
+        )
+        response = self.client.post(
+            url, {"situacao": constants.NAO_ENCONTRADO}, format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_registrar_ocorrencia_edita_ocorrencia_existente(self):
+        self._auth(self.operador)
+        url = self._registrar_url(
+            self.conciliacao_ua1.id, self.item_b.id
+        )
+        response = self.client.post(
+            url,
+            {
+                "situacao": constants.NAO_ENCONTRADO,
+                "observacao": "Agora não foi encontrado",
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.item_b.refresh_from_db()
+        self.assertEqual(self.item_b.situacao, constants.NAO_ENCONTRADO)
+        self.assertEqual(self.item_b.ocorrencias.count(), 1)
+
+    def test_registrar_ocorrencia_fora_do_escopo_retorna_404(self):
+        self._auth(self.operador)
+        url = self._registrar_url(
+            self.conciliacao_ua2.id, self.item_ua2.id
+        )
+        response = self.client.post(
+            url, {"situacao": constants.NAO_ENCONTRADO}, format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_excluir_ocorrencia(self):
+        self._auth(self.operador)
+        url = self._excluir_url(
+            self.conciliacao_ua1.id, self.item_b.id
+        )
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.item_b.refresh_from_db()
+        self.assertEqual(self.item_b.ocorrencias.count(), 0)
+        self.assertFalse(self.item_b.tem_ocorrencia)
+
+    def test_excluir_ocorrencia_sem_ocorrencia_retorna_400(self):
+        self._auth(self.operador)
+        url = self._excluir_url(
+            self.conciliacao_ua1.id, self.item_a.id
+        )
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_excluir_ocorrencia_conciliacao_fechada_retorna_400(self):
+        ConciliacaoUA.objects.filter(pk=self.conciliacao_ua1.pk).update(
+            status=constants.CONCILIACAO_FECHADO
+        )
+        self._auth(self.operador)
+        url = self._excluir_url(
+            self.conciliacao_ua1.id, self.item_b.id
+        )
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_excluir_ocorrencia_fora_do_escopo_retorna_404(self):
+        self._auth(self.operador)
+        url = self._excluir_url(
+            self.conciliacao_ua2.id, self.item_ua2.id
+        )
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_situacoes_disponiveis_item_sem_ocorrencia(self):
+        self._auth(self.operador)
+        url = self._situacoes_url(
+            self.conciliacao_ua1.id, self.item_a.id
+        )
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        values = {s["value"] for s in response.data}
+        self.assertNotIn(constants.BAIXA_FISICA, values)
+        self.assertNotIn(constants.ENCONTRADO_SEM_DIVERGENCIA, values)
+        self.assertIn(constants.DIVERGENTE, values)
+        self.assertIn(constants.NAO_ENCONTRADO, values)
+
+    def test_situacoes_disponiveis_item_nao_encontrado(self):
+        ItemConciliacao.objects.filter(pk=self.item_a.pk).update(
+            situacao=constants.NAO_ENCONTRADO
+        )
+        self.item_a.refresh_from_db()
+        self._auth(self.operador)
+        url = self._situacoes_url(
+            self.conciliacao_ua1.id, self.item_a.id
+        )
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        values = {s["value"] for s in response.data}
+        self.assertIn(constants.ENCONTRADO, values)
+
+    def test_historico_do_item_apos_registrar_ocorrencia(self):
+        self._auth(self.operador)
+        url_registrar = self._registrar_url(
+            self.conciliacao_ua1.id, self.item_a.id
+        )
+        self.client.post(
+            url_registrar,
+            {"situacao": constants.NAO_ENCONTRADO, "observacao": "Perdido"},
+            format="json",
+        )
+
+        url_historico = self._historico_url(
+            self.conciliacao_ua1.id, self.item_a.id
+        )
+        response = self.client.get(url_historico)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIsInstance(response.data, list)
+        campos = {
+            acao["campo"]
+            for grupo in response.data
+            for acao in grupo["acoes"]
+        }
+        self.assertIn("situacao", campos)
+
+    def test_historico_item_vazio(self):
+        self._auth(self.operador)
+        url = self._historico_url(
+            self.conciliacao_ua1.id, self.item_a.id
+        )
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, [])
+
+    def test_operador_fora_da_uo_lista_propria_conciliacao(self):
+        self._auth(self.operador_fora)
+        response = self.client.get(self._list_url(self.conciliacao_fora.id))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = {row["id"] for row in response.data["results"]}
+        self.assertEqual(ids, {self.item_fora.id})

--- a/inventario/tests/test_item_conciliacao_api.py
+++ b/inventario/tests/test_item_conciliacao_api.py
@@ -1,29 +1,14 @@
-from datetime import date
-from decimal import Decimal
-
-from django.contrib.auth.models import Group
 from django.urls import reverse
 from rest_framework import status
-from rest_framework.test import APITestCase
 
-from bem_patrimonial import constants as bem_constants
-from bem_patrimonial.models import BemPatrimonial
-from dados_comuns.tests.auth_test_utils import auth_kwargs, codigo_ua, codigo_uo
-from dados_comuns.tests.factories import criar_ua, criar_uo
 from inventario import constants
-from inventario.models import (
-    ConciliacaoUA,
-    ItemConciliacao,
-    OcorrenciaConciliacao,
-)
-from usuario.constants import (
-    GRUPO_GESTOR_PATRIMONIO,
-    GRUPO_OPERADOR_INVENTARIO,
-)
-from usuario.models import Usuario
+from inventario.models import ItemConciliacao, OcorrenciaConciliacao
+from inventario.tests.conciliacao_base import ConciliacaoAPIBaseTestCase
 
 
-class ItemConciliacaoAPITestCase(APITestCase):
+class ItemConciliacaoAPITestCase(ConciliacaoAPIBaseTestCase):
+    username_prefix = "items_"
+
     LIST_FIELDS = {
         "id",
         "conciliacao",
@@ -50,101 +35,17 @@ class ItemConciliacaoAPITestCase(APITestCase):
         "ocorrencias",
     }
 
-    @classmethod
-    def setUpTestData(cls):
-        cls.uo1 = criar_uo(codigo=codigo_uo(10, 10, 10), nome="UO 1", sigla="UO1")
-        cls.uo2 = criar_uo(codigo=codigo_uo(20, 20, 20), nome="UO 2", sigla="UO2")
-
-        cls.ua1 = criar_ua(
-            uo=cls.uo1,
-            codigo=codigo_ua(10, 10, 10, 1),
-            sigla="UA1",
-            nome="Unidade 1",
-        )
-        cls.ua2 = criar_ua(
-            uo=cls.uo1,
-            codigo=codigo_ua(10, 10, 10, 2),
-            sigla="UA2",
-            nome="Unidade 2",
-        )
-        cls.ua_fora = criar_ua(
-            uo=cls.uo2,
-            codigo=codigo_ua(20, 20, 20, 1),
-            sigla="UAF",
-            nome="Unidade Fora",
-        )
-
-        grupo_gestor = Group.objects.get_or_create(name=GRUPO_GESTOR_PATRIMONIO)[0]
-        grupo_operador = Group.objects.get_or_create(
-            name=GRUPO_OPERADOR_INVENTARIO
-        )[0]
-
-        cls.gestor_com_ua = Usuario.objects.create_user(
-            username="gestor_items_com_ua",
-            email="gestor.items.com.ua@test.com",
-            **auth_kwargs("test123"),
-            nome="Gestor Com UA",
-            is_staff=True,
-            unidade_administrativa=cls.ua1,
-            unidade_orcamentaria=cls.uo1,
-        )
-        cls.gestor_com_ua.groups.add(grupo_gestor)
-
-        cls.gestor_sem_ua = Usuario.objects.create_user(
-            username="gestor_items_sem_ua",
-            email="gestor.items.sem.ua@test.com",
-            **auth_kwargs("test123"),
-            nome="Gestor Sem UA",
-            is_staff=True,
-            unidade_orcamentaria=cls.uo1,
-        )
-        cls.gestor_sem_ua.groups.add(grupo_gestor)
-
-        cls.operador = Usuario.objects.create_user(
-            username="operador_items",
-            email="operador.items@test.com",
-            **auth_kwargs("test123"),
-            nome="Operador Items",
-            is_staff=True,
-            unidade_administrativa=cls.ua1,
-            unidade_orcamentaria=cls.uo1,
-        )
-        cls.operador.groups.add(grupo_operador)
-
-        cls.operador_fora = Usuario.objects.create_user(
-            username="operador_items_fora",
-            email="operador.items.fora@test.com",
-            **auth_kwargs("test123"),
-            nome="Operador Fora",
-            is_staff=True,
-            unidade_administrativa=cls.ua_fora,
-            unidade_orcamentaria=cls.uo2,
-        )
-        cls.operador_fora.groups.add(grupo_operador)
-
     def setUp(self):
-        self.conciliacao_ua1 = ConciliacaoUA.objects.create(
-            tipo=constants.CONCILIACAO_EVENTUAL,
-            periodo_final=date(2025, 8, 23),
-            unidade_administrativa=self.ua1,
-            criado_por=self.gestor_com_ua,
+        super().setUp()
+        self.bem_ua1_a = self._criar_bem(
+            self.ua1, numero_patrimonial="001.000000001-1"
         )
-        self.conciliacao_ua2 = ConciliacaoUA.objects.create(
-            tipo=constants.CONCILIACAO_EVENTUAL,
-            periodo_final=date(2025, 9, 1),
-            unidade_administrativa=self.ua2,
-            criado_por=self.gestor_com_ua,
+        self.bem_ua1_b = self._criar_bem(
+            self.ua1, numero_patrimonial="001.000000002-2"
         )
-        self.conciliacao_fora = ConciliacaoUA.objects.create(
-            tipo=constants.CONCILIACAO_EVENTUAL,
-            periodo_final=date(2025, 9, 1),
-            unidade_administrativa=self.ua_fora,
-            criado_por=self.operador_fora,
+        self.bem_ua2 = self._criar_bem(
+            self.ua2, numero_patrimonial="001.000000003-3"
         )
-
-        self.bem_ua1_a = self._criar_bem(self.ua1, numero_patrimonial="001.000000001-1")
-        self.bem_ua1_b = self._criar_bem(self.ua1, numero_patrimonial="001.000000002-2")
-        self.bem_ua2 = self._criar_bem(self.ua2, numero_patrimonial="001.000000003-3")
         self.bem_fora = self._criar_bem(
             self.ua_fora, numero_patrimonial="001.000000004-4"
         )
@@ -168,13 +69,11 @@ class ItemConciliacaoAPITestCase(APITestCase):
             observacao="Divergência",
             registrado_por=self.gestor_com_ua,
         )
-
         self.item_ua2 = ItemConciliacao.objects.create(
             conciliacao=self.conciliacao_ua2,
             bem=self.bem_ua2,
             situacao=constants.ENCONTRADO_SEM_DIVERGENCIA,
         )
-
         self.item_fora = ItemConciliacao.objects.create(
             conciliacao=self.conciliacao_fora,
             bem=self.bem_fora,
@@ -184,23 +83,6 @@ class ItemConciliacaoAPITestCase(APITestCase):
         self.list_url = reverse(
             "itens-conciliacao-list", args=[self.conciliacao_ua1.id]
         )
-
-    def _criar_bem(self, ua, **kwargs):
-        defaults = {
-            "nome": "Bem Teste",
-            "descricao": "Descrição",
-            "valor_unitario": Decimal("100.00"),
-            "marca": "Marca",
-            "modelo": "Modelo",
-            "status": bem_constants.APROVADO,
-            "unidade_administrativa": ua,
-            "criado_por": self.gestor_com_ua,
-        }
-        defaults.update(kwargs)
-        return BemPatrimonial.objects.create(**defaults)
-
-    def _auth(self, user):
-        self.client.force_authenticate(user)
 
     def _list_url(self, conciliacao_id):
         return reverse("itens-conciliacao-list", args=[conciliacao_id])
@@ -415,6 +297,7 @@ class ItemConciliacaoAPITestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_registrar_ocorrencia_conciliacao_fechada_retorna_400(self):
+        from inventario.models import ConciliacaoUA
         ConciliacaoUA.objects.filter(pk=self.conciliacao_ua1.pk).update(
             status=constants.CONCILIACAO_FECHADO
         )
@@ -475,6 +358,7 @@ class ItemConciliacaoAPITestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_excluir_ocorrencia_conciliacao_fechada_retorna_400(self):
+        from inventario.models import ConciliacaoUA
         ConciliacaoUA.objects.filter(pk=self.conciliacao_ua1.pk).update(
             status=constants.CONCILIACAO_FECHADO
         )

--- a/inventario/tests/test_permissions_api.py
+++ b/inventario/tests/test_permissions_api.py
@@ -1,0 +1,188 @@
+from types import SimpleNamespace
+
+from django.test import SimpleTestCase
+
+from inventario.permissions import (
+    ConciliacaoUAPermission,
+    ItemConciliacaoPermission,
+)
+
+
+class PermissionsInventarioAPITestCase(SimpleTestCase):
+    def _request(self, user):
+        return SimpleNamespace(user=user)
+
+    def _view(self, action):
+        return SimpleNamespace(action=action)
+
+    def _user(
+        self,
+        *,
+        authenticated=True,
+        superuser=False,
+        gestor=False,
+        operador=False,
+    ):
+        return SimpleNamespace(
+            is_authenticated=authenticated,
+            is_superuser=superuser,
+            is_gestor_patrimonio=gestor,
+            is_operador_inventario=operador,
+        )
+
+    def test_conciliacao_has_permission_cobre_ramos_principais(self):
+        perm = ConciliacaoUAPermission()
+
+        user_sem_auth = self._user(authenticated=False)
+        self.assertFalse(
+            perm.has_permission(self._request(user_sem_auth), self._view("list"))
+        )
+
+        user_super = self._user(superuser=True)
+        for action in ("list", "retrieve", "create", "historico", "exportar", "finalizar"):
+            with self.subTest(action=action):
+                self.assertTrue(
+                    perm.has_permission(self._request(user_super), self._view(action))
+                )
+
+        user_gestor = self._user(gestor=True)
+        for action in ("list", "retrieve", "create", "historico", "exportar", "finalizar"):
+            with self.subTest(action=action):
+                self.assertTrue(
+                    perm.has_permission(self._request(user_gestor), self._view(action))
+                )
+
+        user_operador = self._user(operador=True)
+        for action in ("list", "retrieve", "create", "historico",
+                       "exportar", "finalizar"):
+            with self.subTest(action=action):
+                self.assertTrue(
+                    perm.has_permission(self._request(user_operador), self._view(action))
+                )
+
+    def test_conciliacao_bloqueia_update_e_delete(self):
+        perm = ConciliacaoUAPermission()
+        user_gestor = self._user(gestor=True)
+
+        for action in ("update", "partial_update", "destroy"):
+            with self.subTest(action=action):
+                self.assertFalse(
+                    perm.has_permission(self._request(user_gestor), self._view(action))
+                )
+
+    def test_conciliacao_has_object_permission_bloqueia_update_e_delete(self):
+        perm = ConciliacaoUAPermission()
+        user_gestor = self._user(gestor=True)
+        user_operador = self._user(operador=True)
+        obj = SimpleNamespace()
+
+        for action in ("update", "partial_update", "destroy"):
+            with self.subTest(action=action):
+                self.assertFalse(
+                    perm.has_object_permission(
+                        self._request(user_gestor), self._view(action), obj
+                    )
+                )
+
+        for action in ("retrieve", "historico", "exportar", "finalizar"):
+            with self.subTest(action=action):
+                self.assertTrue(
+                    perm.has_object_permission(
+                        self._request(user_gestor), self._view(action), obj
+                    )
+                )
+
+        for action in ("retrieve", "historico", "exportar", "finalizar"):
+            with self.subTest(action=action):
+                self.assertTrue(
+                    perm.has_object_permission(
+                        self._request(user_operador), self._view(action), obj
+                    )
+                )
+
+    def test_item_has_permission_cobre_ramos_principais(self):
+        perm = ItemConciliacaoPermission()
+
+        user_sem_auth = self._user(authenticated=False)
+        self.assertFalse(
+            perm.has_permission(self._request(user_sem_auth), self._view("list"))
+        )
+
+        user_super = self._user(superuser=True)
+        for action in (
+            "list",
+            "retrieve",
+            "historico",
+            "registrar_ocorrencia",
+            "excluir_ocorrencia",
+            "situacoes_disponiveis",
+        ):
+            with self.subTest(action=action):
+                self.assertTrue(
+                    perm.has_permission(self._request(user_super), self._view(action))
+                )
+
+        user_gestor = self._user(gestor=True)
+        for action in (
+            "list",
+            "retrieve",
+            "historico",
+            "registrar_ocorrencia",
+            "excluir_ocorrencia",
+            "situacoes_disponiveis",
+        ):
+            with self.subTest(action=action):
+                self.assertTrue(
+                    perm.has_permission(self._request(user_gestor), self._view(action))
+                )
+
+        user_operador = self._user(operador=True)
+        for action in (
+            "list",
+            "retrieve",
+            "historico",
+            "registrar_ocorrencia",
+            "excluir_ocorrencia",
+            "situacoes_disponiveis",
+        ):
+            with self.subTest(action=action):
+                self.assertTrue(
+                    perm.has_permission(self._request(user_operador), self._view(action))
+                )
+
+    def test_item_bloqueia_create_update_delete(self):
+        perm = ItemConciliacaoPermission()
+        user_gestor = self._user(gestor=True)
+
+        for action in ("create", "update", "partial_update", "destroy"):
+            with self.subTest(action=action):
+                self.assertFalse(
+                    perm.has_permission(self._request(user_gestor), self._view(action))
+                )
+
+    def test_item_has_object_permission_bloqueia_create_update_delete(self):
+        perm = ItemConciliacaoPermission()
+        user_gestor = self._user(gestor=True)
+        obj = SimpleNamespace()
+
+        for action in ("create", "update", "partial_update", "destroy"):
+            with self.subTest(action=action):
+                self.assertFalse(
+                    perm.has_object_permission(
+                        self._request(user_gestor), self._view(action), obj
+                    )
+                )
+
+        for action in (
+            "retrieve",
+            "historico",
+            "registrar_ocorrencia",
+            "excluir_ocorrencia",
+            "situacoes_disponiveis",
+        ):
+            with self.subTest(action=action):
+                self.assertTrue(
+                    perm.has_object_permission(
+                        self._request(user_gestor), self._view(action), obj
+                    )
+                )


### PR DESCRIPTION
## 🎯 Objetivo

Expor a Conciliação de Inventário (que hoje só está disponível via Django Admin) através de uma API REST completa, permitindo que o frontend liste, detalhe, crie, finalize e exporte conciliações, bem como gerencie os itens (bens) vinculados e registre ocorrências de campo.

A entrega também espelha o "resumo por situação" (Encontrados / Não encontrados / Divergentes / Baixa Física etc.) que o admin exibe na listagem, evitando que o frontend precise chamar o endpoint de detalhe de cada conciliação para conhecer esses números.

---

## Os 12 Endpoints Criados

Base: `/api/inventario/`

### Conciliação (`/conciliacoes/`) - 6 endpoints

| #  | Método | Rota                          | Descrição                                    |
|----|--------|-------------------------------|----------------------------------------------|
| 1  | `GET`  | `/conciliacoes/`              | Listar conciliações (paginado, com filtros)  |
| 2  | `POST` | `/conciliacoes/`              | Criar conciliação eventual                   |
| 3  | `GET`  | `/conciliacoes/{id}/`         | Detalhar conciliação                         |
| 4  | `GET`  | `/conciliacoes/{id}/historico/` | Histórico de alterações                     |
| 5  | `GET`  | `/conciliacoes/{id}/exportar/` | Exportar PDF (relatório de campo)           |
| 6  | `POST` | `/conciliacoes/{id}/finalizar/` | Finalizar conciliação                       |

### Itens da conciliação (`/conciliacoes/{pk}/itens/`) - 6 endpoints

| #  | Método | Rota                                                              | Descrição                                  |
|----|--------|-------------------------------------------------------------------|--------------------------------------------|
| 7  | `GET`  | `/conciliacoes/{pk}/itens/`                                       | Listar itens (paginado, com filtros)       |
| 8  | `GET`  | `/conciliacoes/{pk}/itens/{item_id}/`                             | Detalhar item                              |
| 9  | `GET`  | `/conciliacoes/{pk}/itens/{item_id}/situacoes-disponiveis/`       | Situações permitidas para o item           |
| 10 | `POST` | `/conciliacoes/{pk}/itens/{item_id}/ocorrencias/`                 | Registrar/editar ocorrência do item        |
| 11 | `POST` | `/conciliacoes/{pk}/itens/{item_id}/ocorrencias/remover/`         | Excluir (desfazer) ocorrência              |
| 12 | `GET`  | `/conciliacoes/{pk}/itens/{item_id}/historico/`                   | Histórico de alterações do item            |

> A documentação OpenAPI/Swagger é gerada via `drf-spectacular` e fica disponível em `/api/docs/`.

---

## ⚙️ Decisões de Implementação

### 🔐 Permissões e escopo
- 3 perfis: **superuser**, **gestor de patrimônio**, **operador de inventário**.
- `PUT`/`PATCH`/`DELETE` em conciliação e itens estão **bloqueados** (espelha o admin, que não permite editar/excluir conciliações). O retorno é `405 Method Not Allowed`.
- O escopo (UA do operador / UO do gestor) é aplicado automaticamente no `get_queryset` via `filtrar_queryset_por_escopo` 
- O frontend **não** precisa enviar filtros de UA/UO.
- Conciliação inexistente ou fora do escopo → `404` (não vaza existência do recurso).

### 🆕 Criação de conciliação
- Só é permitido criar **eventual** (anuais são criadas automaticamente pelo sistema).
- Bloqueia criação quando já existe conciliação **em aberto** para a mesma UA.
- `periodo_final` é obrigatório para conciliação eventual.
- Os itens são gerados **automaticamente** a partir dos bens ativos da UA (via `criar_itens_conciliacao`).

### 🔄 Concíliação anual automática
- O endpoint de listagem (`GET /conciliacoes/`) chama `processar_conciliacao_anual_automatica` antes de retornar - se houver um `ParametroConciliacaoAnual` vigente e nenhuma conciliação anual criada no ano, ela é criada on-the-fly.

### 🧹 Remoção automática de itens baixados
- O endpoint de detalhe (`GET /conciliacoes/{id}/`) chama `remover_itens_baixados_invalidos` quando a conciliação está em aberto - remove itens cujo bem foi baixado há mais de 1 período, replicando a lógica do admin.

### 📊 Resumo de situações na listagem
- O serializer de listagem retorna um objeto `resumo_situacoes` com a contagem por situação (`encontrados`, `nao_encontrados`, `divergentes`, `em_processo_baixa`, `baixa_fisica`, `encontrados_com_divergencia`), replicando a informação do admin e eliminando a necessidade de chamada extra ao detalhe.

### 📝 Ocorrências (upsert)
- O endpoint `POST .../ocorrencias/` é **idempotente** no sentido prático: se o item já tem ocorrência, a **última** é atualizada (em vez de criar uma nova), preservando o histórico de auditoria. O array `ocorrencias` na resposta do item traz o(s) registro(s) atual(is).
- O endpoint `POST .../ocorrencias/remover/` apaga a última e restaura a situação do item (ocorrência anterior → herdada de conciliação fechada anterior → `encontrado_sem_divergencia`).
- `baixa_fisica` é definitiva e **não** pode ser registrada manualmente - só é aplicada na finalização da conciliação.

### 📜 Histórico
- Usa a tabela genérica `HistoricoGeral` (Django ContentTypes) - não há tabela própria.
- A resposta vem agrupada por `(alterado_em, alterado_por)` para fácil renderização em timeline.

### 📄 Exportação PDF
- Reaproveita a função `gerar_pdf_conciliacao` já existente (mesma usada pelo admin).
- Content-Type: `application/pdf`, com `Content-Disposition: attachment; filename="CONCILIACAO_<numero>_<ano>_UA<codigo>.pdf"`.

---

## 🔄 Fluxo Principal

1. Usuário lista as conciliações disponíveis.
2. Usuário consulta o detalhe da conciliação e o resumo das situações.
3. Usuário registra ou remove ocorrências nos itens conciliados.
4. Usuário consulta históricos quando necessário.
5. Usuário finaliza a conciliação.
6. Usuário exporta o relatório PDF consolidado.

---

## 🧪 Testes

Cobertura: **71 testes automatizados** distribuídos em 3 arquivos.

### 📄 `inventario/tests/test_conciliacao_api.py` (33 testes)

Valida todos os endpoints de Conciliação, incluindo:

- Autenticação e autorização.
- Escopo de acesso por perfil (**superuser**, **gestor de patrimônio** e **operador de inventário**).
- Listagem com filtros, busca, ordenação e paginação.
- Detalhamento da conciliação.
- Criação de conciliações eventuais.
- Restrições de edição e exclusão (`405 Method Not Allowed`).
- Finalização de conciliações.
- Consulta de histórico.
- Exportação de PDF.
- Regras de negócio e side effects herdados do Admin:
  - criação automática de itens;
  - bloqueio de múltiplas conciliações abertas para a mesma UA;
  - remoção automática de itens baixados inválidos em conciliações abertas.

### 📄 `inventario/tests/test_item_conciliacao_api.py` (32 testes)

Valida todos os endpoints relacionados aos itens da conciliação, incluindo:

- Controle de acesso e escopo.
- Listagem com filtros e busca.
- Detalhamento de itens.
- Restrições de CRUD direto nos itens.
- Registro e remoção de ocorrências.
- Fluxo de atualização (upsert) de ocorrências.
- Consulta de situações disponíveis.
- Consulta de histórico.
- Regras de negócio específicas:
  - impossibilidade de registrar `baixa_fisica` manualmente;
  - bloqueio de alterações em conciliações fechadas;
  - restauração automática da situação do item ao remover ocorrência;
  - validação das transições permitidas de situação.

### 📄 `inventario/tests/test_permissions_api.py` (6 testes)

Testes unitários das classes de permissão:

- Permissões por perfil.
- Restrições de criação, edição e exclusão.
- Permissões em nível de objeto.
- Cobertura dos principais fluxos dos ViewSets de Conciliação e Itens.

### ▶️ Execução

```bash
docker compose -f docker-compose-dev.yml exec web \
  python manage.py test \
    inventario.tests.test_conciliacao_api \
    inventario.tests.test_item_conciliacao_api \
    inventario.tests.test_permissions_api
```

**Resultado atual:** 71 testes executados com sucesso.

---

## 🔄 Compatibilidade / Migrações

- **Sem migrações novas** - todos os modelos necessários (`ConciliacaoUA`, `ItemConciliacao`, `OcorrenciaConciliacao`, `ParametroConciliacaoAnual`, `HistoricoGeral`, `UnidadeAdministrativa`, `UnidadeOrcamentaria`) já existem.
- O endpoint de Conciliação expõe um recurso que **já era gerado automaticamente** pelo sistema dentro do período de vigência do `ParametroConciliacaoAnual`. A API apenas externaliza a operação, sem mudança de comportamento de negócio.

---

## 📋 Checklist de Revisão

- [x] Testes automatizados - 71 testes passando.
- [x] Sem migrations novas.
- [x] Sem alteração em modelos (`models.py`).
- [x] Compatibilidade com a lógica do admin (escopo, regras de negócio, side effects).
- [x] Documentação OpenAPI/Swagger atualizada automaticamente via `drf-spectacular`.
- [x] Refactor de `pytz` → `zoneinfo` (issue Sonar) já integrado na branch.

---

## 📚 Documentação Adicional

- **`/api/docs/`** - Swagger UI interativo com todos os endpoints.
